### PR TITLE
Msvc warn fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     # Be moderately paranoid with flags
     if(MSVC)
         add_definitions("/W4")
-        add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     else()
         add_definitions("-Wall -Wextra -pedantic")
     endif()

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -828,7 +828,8 @@ class App {
                 #else
                 // This also works on Windows, but gives a warning
                 buffer = std::getenv(opt->envname_.c_str());
-                ename_string = std::string(buffer);
+                if(buffer != nullptr)
+                    ename_string = std::string(buffer);
                 #endif
 
                 if(!ename_string.empty()) {

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -815,9 +815,24 @@ class App {
         // Get envname options if not yet passed
         for(const Option_p &opt : options_) {
             if(opt->count() == 0 && opt->envname_ != "") {
-                char *ename = std::getenv(opt->envname_.c_str());
-                if(ename != nullptr) {
-                    opt->add_result(std::string(ename));
+                char *buffer = nullptr;
+                std::string ename_string;
+
+                #ifdef _MSC_VER
+                // Windows version
+                size_t sz = 0;
+                if(_dupenv_s(&buf, &sz, opt->envname_.c_str()) == 0 && buf != nullptr) {
+                    ename_string = std::string(buffer);
+                    free(buffer);
+                }
+                #else
+                // This also works on Windows, but gives a warning
+                buffer = std::getenv(opt->envname_.c_str());
+                ename_string = std::string(buffer);
+                #endif
+
+                if(!ename_string.empty()) {
+                    opt->add_result(ename_string));
                 }
             }
         }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -832,7 +832,7 @@ class App {
                 #endif
 
                 if(!ename_string.empty()) {
-                    opt->add_result(ename_string));
+                    opt->add_result(ename_string);
                 }
             }
         }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -821,7 +821,7 @@ class App {
                 #ifdef _MSC_VER
                 // Windows version
                 size_t sz = 0;
-                if(_dupenv_s(&buf, &sz, opt->envname_.c_str()) == 0 && buf != nullptr) {
+                if(_dupenv_s(&buffer, &sz, opt->envname_.c_str()) == 0 && buf != nullptr) {
                     ename_string = std::string(buffer);
                     free(buffer);
                 }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -821,7 +821,7 @@ class App {
                 #ifdef _MSC_VER
                 // Windows version
                 size_t sz = 0;
-                if(_dupenv_s(&buffer, &sz, opt->envname_.c_str()) == 0 && buf != nullptr) {
+                if(_dupenv_s(&buffer, &sz, opt->envname_.c_str()) == 0 && buffer != nullptr) {
                     ename_string = std::string(buffer);
                     free(buffer);
                 }


### PR DESCRIPTION
This provides specialized windows code for getenv, fixing the warning given with `W4`. Fixes #10.