### PR TITLE
Fix #23: Respect fallthrough_ in _valid_subcommand

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -857,7 +857,7 @@ class App {
         for(const App_p &com : subcommands_)
             if(com->check_name(current))
                 return true;
-        if(parent_ != nullptr)
+        if(parent_ != nullptr && fallthrough_)
             return parent_->_valid_subcommand(current);
         else
             return false;


### PR DESCRIPTION
_valid_subcommand checks whether its argument appears to be a valid subcommand name or not; however, if it doesn't recognize the name, it always checks if its parent does. As described in in issue #23, this can cause incorrect behavior. To avoid this, check if fallthrough is disabled first, and do not consult the parent's known subcommands if fallthrough is disabled.