### PR TITLE
Fix config file on command line

### DIFF
--- a/.ci/check_style.sh
+++ b/.ci/check_style.sh
@@ -7,8 +7,8 @@ git ls-files -- '*.cpp' '*.hpp' | xargs clang-format -i -style=file
 
 git diff --exit-code --color
 
-mkdir build || true
-cd build
+mkdir build-tidy || true
+cd build-tidy
 CXX_FLAGS="-Werror -Wall -Wextra -pedantic -std=c++11" cmake .. -DCLANG_TIDY_FIX=ON
 cmake --build .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Version 1.2 (in progress)
 
-
+* Fixed Config file search if passed on command line [#30](https://github.com/CLIUtils/CLI11/issues/30)
 * Added `CLI11_PARSE(app, argc, argv)` macro for simple parse commands (does not support returning arg)
 * The name string can now contain spaces around commas [#29](https://github.com/CLIUtils/CLI11/pull/29)
 * `set_default_str` now only sets string, and `set_default_val` will evaluate the default string given [#26](https://github.com/CLIUtils/CLI11/issues/26)

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -899,17 +899,23 @@ class App {
         }
 
         // Process an INI file
-        if(config_ptr_ != nullptr && config_name_ != "") {
-            try {
-                std::vector<detail::ini_ret_t> values = detail::parse_ini(config_name_);
-                while(!values.empty()) {
-                    if(!_parse_ini(values)) {
-                        throw ExtrasINIError(values.back().fullname);
+        if(config_ptr_ != nullptr) {
+            if(*config_ptr_) {
+                config_ptr_->run_callback();
+                config_required_ = true;
+            }
+            if(config_name_ != "") {
+                try {
+                    std::vector<detail::ini_ret_t> values = detail::parse_ini(config_name_);
+                    while(!values.empty()) {
+                        if(!_parse_ini(values)) {
+                            throw ExtrasINIError(values.back().fullname);
+                        }
                     }
+                } catch(const FileError &) {
+                    if(config_required_)
+                        throw;
                 }
-            } catch(const FileError &) {
-                if(config_required_)
-                    throw;
             }
         }
 

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -195,11 +195,59 @@ TEST_F(TApp, IniNotRequired) {
     EXPECT_EQ(3, three);
 }
 
+TEST_F(TApp, IniNotRequiredNotDefault) {
+
+    TempFile tmpini{"TestIniTmp.ini"};
+    TempFile tmpini2{"TestIniTmp2.ini"};
+
+    app.add_config("--config", tmpini);
+
+    {
+        std::ofstream out{tmpini};
+        out << "[default]" << std::endl;
+        out << "two=99" << std::endl;
+        out << "three=3" << std::endl;
+    }
+
+    {
+        std::ofstream out{tmpini2};
+        out << "[default]" << std::endl;
+        out << "two=98" << std::endl;
+        out << "three=4" << std::endl;
+    }
+
+    int one = 0, two = 0, three = 0;
+    app.add_option("--one", one);
+    app.add_option("--two", two);
+    app.add_option("--three", three);
+
+    run();
+
+    EXPECT_EQ(99, two);
+    EXPECT_EQ(3, three);
+
+    app.reset();
+    args = {"--config", tmpini2};
+    run();
+
+    EXPECT_EQ(98, two);
+    EXPECT_EQ(4, three);
+}
+
 TEST_F(TApp, IniRequiredNotFound) {
 
     std::string noini = "TestIniNotExist.ini";
     app.add_config("--config", noini, "", true);
 
+    EXPECT_THROW(run(), CLI::FileError);
+}
+
+TEST_F(TApp, IniNotRequiredPassedNotFound) {
+
+    std::string noini = "TestIniNotExist.ini";
+    app.add_config("--config", "", "", false);
+
+    args = {"--config", noini};
     EXPECT_THROW(run(), CLI::FileError);
 }
 


### PR DESCRIPTION
This fixes two issues with loading a config file from the command line. First, if passed, this will override the default. Second, if this is passed and the file does not exist, an error will be reported even if the file is not required.

Closes #30.