### PR TITLE
Extras handling refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 1.3 (in progress)
+* `parse` no longer returns (so `CLI11_PARSE` is always usable) [#37](https://github.com/CLIUtils/CLI11/pull/37)
+* Added `remaining()` and `remaining_size()` [#37](https://github.com/CLIUtils/CLI11/pull/37)
+* `allow_extras` and `prefix_command` are now valid on subcommands [#37](https://github.com/CLIUtils/CLI11/pull/37)
+
 ## Version 1.2
 
 * Added functional form of flag [#33](https://github.com/CLIUtils/CLI11/pull/33), automatic on C++14

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ try {
 }
 ```
 
-> Note: The final five lines are so common, they have a dedicated macro: `CLI11_PARSE(app, argc, argv)`. You can use that as long as you don't need the return value of `.parse`.
+> Note: The final five lines are so common, they have a dedicated macro: `CLI11_PARSE(app, argc, argv)`.
 
 
 The initialization is just one line, adding options is just two each. The try/catch block ensures that `-h,--help` or a parse error will exit with the correct return code (selected from `CLI::ExitCodes`). (The return here should be inside `main`). After the app runs, the filename will be set to the correct value if it was passed, otherwise it will be set to the default. You can check to see if this was passed on the command line with `app.count("--file")`.
@@ -175,9 +175,12 @@ On the command line, options can be given as:
 * `--file=filename` (equals)
 
 Extra positional arguments will cause the program to exit, so at least one positional option with a vector is recommended if you want to allow extraneous arguments.
-If you set `.allow_extras()` on the main `App`, the parse function will return the left over arguments instead of throwing an error. You can access a vector of pointers to the parsed options in the original order using `parse_order()`.
+If you set `.allow_extras()` on the main `App`, you will not get an error. You can access the missing options using `remaining` (if you have subcommands, `app.remaining(true)` will get all remaining options, subcommands included).
+
+You can access a vector of pointers to the parsed options in the original order using `parse_order()`.
 If `--` is present in the command line,
 everything after that is positional only.
+
 
 
 ## Subcommands
@@ -204,8 +207,8 @@ There are several options that are supported on the main app and subcommands. Th
 * `.get_subcommands()`: The list of subcommands given on the command line
 * `.parsed()`: True if this subcommand was given on the command line
 * `.set_callback(void() function)`: Set the callback that runs at the end of parsing. The options have already run at this point.
-* `.allow_extras()`: Do not throw an error if extra arguments are left over (Only useful on the main `App`, as that's the one that throws errors).
-* `.prefix_command()`: Like `allow_extras`, but stop immediately on the first unrecognised item. It is ideal for allowing your app to be a "prefix" to calling another app.
+* `.allow_extras()`: Do not throw an error if extra arguments are left over
+* `.prefix_command()`: Like `allow_extras`, but stop immediately on the first unrecognised item. It is ideal for allowing your app or subcommand to be a "prefix" to calling another app.
 
 > Note: if you have a fixed number of required positional options, that will match before subcommand names.
 

--- a/examples/prefix_command.cpp
+++ b/examples/prefix_command.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     }
 
     std::vector<std::string> more_comms = app.remaining();
-    
+
     std::cout << "Prefix:";
     for(int v : vals)
         std::cout << v << ":";

--- a/examples/prefix_command.cpp
+++ b/examples/prefix_command.cpp
@@ -8,13 +8,14 @@ int main(int argc, char **argv) {
     std::vector<int> vals;
     app.add_option("--vals,-v", vals)->expected(1);
 
-    std::vector<std::string> more_comms;
     try {
-        more_comms = app.parse(argc, argv);
+        app.parse(argc, argv);
     } catch(const CLI::ParseError &e) {
         return app.exit(e);
     }
 
+    std::vector<std::string> more_comms = app.remaining();
+    
     std::cout << "Prefix:";
     for(int v : vals)
         std::cout << v << ":";

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -575,7 +575,8 @@ class App {
     App *add_subcommand(std::string name, std::string description = "", bool help = true) {
         subcommands_.emplace_back(new App(description, help, detail::dummy));
         subcommands_.back()->name_ = name;
-        subcommands_.back()->allow_extras();
+        subcommands_.back()->allow_extras_ = allow_extras_;
+        subcommands_.back()->prefix_command_ = prefix_command_;
         subcommands_.back()->parent_ = this;
         subcommands_.back()->ignore_case_ = ignore_case_;
         subcommands_.back()->fallthrough_ = fallthrough_;
@@ -854,23 +855,34 @@ class App {
     const std::vector<Option *> &parse_order() const { return parse_order_; }
 
     /// This retuns the missing options from the current subcommand
-    std::vector<std::string> remaining() const {
+    std::vector<std::string> remaining(bool recurse = false) const {
         std::vector<std::string> miss_list;
-        for(const std::pair<detail::Classifer, std::string>& miss : missing_) {
+        for(const std::pair<detail::Classifer, std::string> &miss : missing_) {
             miss_list.push_back(std::get<1>(miss));
+        }
+        if(recurse) {
+            for(const App_p &sub : subcommands_) {
+                std::vector<std::string> output = sub->remaining(recurse);
+                miss_list.assign(std::begin(output), std::end(output));
+            }
         }
         return miss_list;
     }
-    
+
     /// This returns the number of remaining options, minus the -- seperator
-    size_t remaining_size() const {
-        return std::count_if(
-                             std::begin(missing_), std::end(missing_),
-                             [](const std::pair<detail::Classifer, std::string> &val) {
-                                             return val.first != detail::Classifer::POSITIONAL_MARK;
-                            });
+    size_t remaining_size(bool recurse = false) const {
+        size_t count = std::count_if(
+            std::begin(missing_), std::end(missing_), [](const std::pair<detail::Classifer, std::string> &val) {
+                return val.first != detail::Classifer::POSITIONAL_MARK;
+            });
+        if(recurse) {
+            for(const App_p &sub : subcommands_) {
+                count += sub->remaining_size(recurse);
+            }
+        }
+        return count;
     }
-    
+
     ///@}
 
   protected:
@@ -885,13 +897,6 @@ class App {
             throw InvalidError(name_ + ": Too many positional arguments with unlimited expected args");
         for(const App_p &app : subcommands_)
             app->_validate();
-    }
-
-    /// Return missing from the master
-    missing_t *missing() {
-        if(parent_ != nullptr)
-            return parent_->missing();
-        return &missing_;
     }
 
     /// Internal function to run (App) callback, top down
@@ -1019,14 +1024,14 @@ class App {
 
         // Convert missing (pairs) to extras (string only)
         if(parent_ == nullptr) {
-            args = remaining();
+            args = remaining(true);
             std::reverse(std::begin(args), std::end(args));
-
-            size_t num_left_over = remaining_size();
-
-            if(num_left_over > 0 && !(allow_extras_ || prefix_command_))
-                throw ExtrasError("[" + detail::rjoin(args, " ") + "]");
         }
+
+        size_t num_left_over = remaining_size();
+
+        if(num_left_over > 0 && !(allow_extras_ || prefix_command_))
+            throw ExtrasError("[" + detail::rjoin(args, " ") + "]");
     }
 
     /// Parse one ini param, return false if not found in any subcommand, remove if it is
@@ -1093,7 +1098,7 @@ class App {
         detail::Classifer classifer = positional_only ? detail::Classifer::NONE : _recognize(args.back());
         switch(classifer) {
         case detail::Classifer::POSITIONAL_MARK:
-            missing()->emplace_back(classifer, args.back());
+            missing_.emplace_back(classifer, args.back());
             args.pop_back();
             positional_only = true;
             break;
@@ -1145,11 +1150,11 @@ class App {
             return parent_->_parse_positional(args);
         else {
             args.pop_back();
-            missing()->emplace_back(detail::Classifer::NONE, positional);
+            missing_.emplace_back(detail::Classifer::NONE, positional);
 
             if(prefix_command_) {
                 while(!args.empty()) {
-                    missing()->emplace_back(detail::Classifer::NONE, args.back());
+                    missing_.emplace_back(detail::Classifer::NONE, args.back());
                     args.pop_back();
                 }
             }
@@ -1195,7 +1200,7 @@ class App {
             // Otherwise, add to missing
             else {
                 args.pop_back();
-                missing()->emplace_back(detail::Classifer::SHORT, current);
+                missing_.emplace_back(detail::Classifer::SHORT, current);
                 return;
             }
         }
@@ -1259,7 +1264,7 @@ class App {
             // Otherwise, add to missing
             else {
                 args.pop_back();
-                missing()->emplace_back(detail::Classifer::LONG, current);
+                missing_.emplace_back(detail::Classifer::LONG, current);
                 return;
             }
         }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -854,6 +854,15 @@ class App {
     /// This gets a vector of pointers with the original parse order
     const std::vector<Option *> &parse_order() const { return parse_order_; }
 
+    /// This retuns the missing options from the current subcommand
+    std::vector<std::string> remaining() const {
+        std::vector<std::string> miss_list;
+        for(const std::pair<detail::Classifer, std::string>& miss : missing_) {
+            miss_list.push_back(std::get<1>(miss));
+        }
+        return miss_list;
+    }
+    
     ///@}
 
   protected:

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -617,21 +617,20 @@ class App {
 
     /// Parses the command line - throws errors
     /// This must be called after the options are in but before the rest of the program.
-    std::vector<std::string> parse(int argc, char **argv) {
+    void parse(int argc, char **argv) {
         name_ = argv[0];
         std::vector<std::string> args;
         for(int i = argc - 1; i > 0; i--)
             args.emplace_back(argv[i]);
-        return parse(args);
+        parse(args);
     }
 
     /// The real work is done here. Expects a reversed vector.
     /// Changes the vector to the remaining options.
-    std::vector<std::string> &parse(std::vector<std::string> &args) {
+    void parse(std::vector<std::string> &args) {
         _validate();
         _parse(args);
         run_callback();
-        return args;
     }
 
     /// Print a nice error message and return the exit code
@@ -863,6 +862,15 @@ class App {
         return miss_list;
     }
     
+    /// This returns the number of remaining options, minus the -- seperator
+    size_t remaining_size() const {
+        return std::count_if(
+                             std::begin(missing_), std::end(missing_),
+                             [](const std::pair<detail::Classifer, std::string> &val) {
+                                             return val.first != detail::Classifer::POSITIONAL_MARK;
+                            });
+    }
+    
     ///@}
 
   protected:
@@ -1011,17 +1019,10 @@ class App {
 
         // Convert missing (pairs) to extras (string only)
         if(parent_ == nullptr) {
-            args.resize(missing()->size());
-            std::transform(std::begin(*missing()),
-                           std::end(*missing()),
-                           std::begin(args),
-                           [](const std::pair<detail::Classifer, std::string> &val) { return val.second; });
+            args = remaining();
             std::reverse(std::begin(args), std::end(args));
 
-            size_t num_left_over = std::count_if(
-                std::begin(*missing()), std::end(*missing()), [](std::pair<detail::Classifer, std::string> &val) {
-                    return val.first != detail::Classifer::POSITIONAL_MARK;
-                });
+            size_t num_left_over = remaining_size();
 
             if(num_left_over > 0 && !(allow_extras_ || prefix_command_))
                 throw ExtrasError("[" + detail::rjoin(args, " ") + "]");

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -66,7 +66,7 @@ class App {
     /// If true, allow extra arguments (ie, don't throw an error).
     bool allow_extras_{false};
 
-    ///  If true, return immediatly on an unrecognised option (implies allow_extras)
+    ///  If true, return immediately on an unrecognised option (implies allow_extras)
     bool prefix_command_{false};
 
     /// This is a function that runs when complete. Great for subcommands. Can throw.
@@ -93,7 +93,7 @@ class App {
     /// This is faster and cleaner than storing just a list of strings and reparsing. This may contain the -- separator.
     missing_t missing_;
 
-    /// This is a list of pointers to options with the orignal parse order
+    /// This is a list of pointers to options with the original parse order
     std::vector<Option *> parse_order_;
 
     ///@}
@@ -164,7 +164,7 @@ class App {
         return this;
     }
 
-    /// Do not parse anything after the first unrecongnised option and return
+    /// Do not parse anything after the first unrecognised option and return
     App *prefix_command(bool allow = true) {
         prefix_command_ = allow;
         return this;
@@ -335,7 +335,7 @@ class App {
     template <typename T,
               enable_if_t<std::is_integral<T>::value && !is_bool<T>::value, detail::enabler> = detail::dummy>
     Option *add_flag(std::string name,
-                     T &count, ///< A varaible holding the count
+                     T &count, ///< A variable holding the count
                      std::string description = "") {
 
         count = 0;
@@ -354,7 +354,7 @@ class App {
     /// Bool version only allows the flag once
     template <typename T, enable_if_t<is_bool<T>::value, detail::enabler> = detail::dummy>
     Option *add_flag(std::string name,
-                     T &count, ///< A varaible holding true if passed
+                     T &count, ///< A variable holding true if passed
                      std::string description = "") {
 
         count = false;
@@ -401,7 +401,7 @@ class App {
     template <typename T>
     Option *add_set(std::string name,
                     T &member,           ///< The selected member of the set
-                    std::set<T> options, ///< The set of posibilities
+                    std::set<T> options, ///< The set of possibilities
                     std::string description = "") {
 
         CLI::callback_t fun = [&member, options](CLI::results_t res) {
@@ -454,7 +454,7 @@ class App {
     /// Add set of options, string only, ignore case (no default)
     Option *add_set_ignore_case(std::string name,
                                 std::string &member,           ///< The selected member of the set
-                                std::set<std::string> options, ///< The set of posibilities
+                                std::set<std::string> options, ///< The set of possibilities
                                 std::string description = "") {
 
         CLI::callback_t fun = [&member, options](CLI::results_t res) {
@@ -857,9 +857,9 @@ class App {
     ///@}
 
   protected:
-    /// Check the options to make sure there are no conficts.
+    /// Check the options to make sure there are no conflicts.
     ///
-    /// Currenly checks to see if mutiple positionals exist with -1 args
+    /// Currently checks to see if multiple positionals exist with -1 args
     void _validate() const {
         auto count = std::count_if(std::begin(options_), std::end(options_), [](const Option_p &opt) {
             return opt->get_expected() == -1 && opt->get_positional();
@@ -897,7 +897,7 @@ class App {
             return false;
     }
 
-    /// Selects a Classifer enum based on the type of the current argument
+    /// Selects a Classifier enum based on the type of the current argument
     detail::Classifer _recognize(const std::string &current) const {
         std::string dummy1, dummy2;
 
@@ -1022,10 +1022,10 @@ class App {
     /// Parse one ini param, return false if not found in any subcommand, remove if it is
     ///
     /// If this has more than one dot.separated.name, go into the subcommand matching it
-    /// Returns true if it managed to find the option, if false you'll need to remove the arg manully.
+    /// Returns true if it managed to find the option, if false you'll need to remove the arg manually.
     bool _parse_ini(std::vector<detail::ini_ret_t> &args) {
         detail::ini_ret_t &current = args.back();
-        std::string parent = current.parent(); // respects curent.level
+        std::string parent = current.parent(); // respects current.level
         std::string name = current.name();
 
         // If a parent is listed, go to a subcommand

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -144,7 +144,7 @@ class Option {
         return this;
     }
 
-    /// Support Plubmum term
+    /// Support Plumbum term
     Option *mandatory(bool value = true) { return required(value); }
 
     /// Set the number of expected arguments (Flags bypass this)

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -890,7 +890,7 @@ TEST_F(TApp, AllowExtras) {
     EXPECT_FALSE(val);
 
     args = {"-x", "-f"};
-    
+
     EXPECT_NO_THROW(run());
     EXPECT_TRUE(val);
     EXPECT_EQ(app.remaining(), std::vector<std::string>({"-x"}));

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -890,10 +890,10 @@ TEST_F(TApp, AllowExtras) {
     EXPECT_FALSE(val);
 
     args = {"-x", "-f"};
-    std::vector<std::string> left_over;
-    EXPECT_NO_THROW({ left_over = run(); });
+    
+    EXPECT_NO_THROW(run());
     EXPECT_TRUE(val);
-    EXPECT_EQ(std::vector<std::string>({"-x"}), left_over);
+    EXPECT_EQ(app.remaining(), std::vector<std::string>({"-x"}));
 }
 
 TEST_F(TApp, AllowExtrasOrder) {
@@ -901,14 +901,13 @@ TEST_F(TApp, AllowExtrasOrder) {
     app.allow_extras();
 
     args = {"-x", "-f"};
-    std::vector<std::string> left_over;
-    EXPECT_NO_THROW({ left_over = run(); });
-    EXPECT_EQ(std::vector<std::string>({"-f", "-x"}), left_over);
+    EXPECT_NO_THROW(run());
+    EXPECT_EQ(app.remaining(), std::vector<std::string>({"-x", "-f"}));
     app.reset();
 
-    std::vector<std::string> left_over_2;
-    left_over_2 = app.parse(left_over);
-    EXPECT_EQ(left_over, left_over_2);
+    std::vector<std::string> left_over = app.remaining();
+    app.parse(left_over);
+    EXPECT_EQ(app.remaining(), left_over);
 }
 
 // Test horrible error

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -345,14 +345,14 @@ TEST_F(TApp, PrefixProgram) {
 TEST_F(TApp, PrefixSubcom) {
     auto subc = app.add_subcommand("subc");
     subc->prefix_command();
-    
+
     app.add_flag("--simple");
-    
+
     args = {"--simple", "subc", "other", "--simple", "--mine"};
     run();
-    
-    EXPECT_EQ(app.remaining_size(), (size_t) 0);
-    EXPECT_EQ(app.remaining_size(true), (size_t) 3);
+
+    EXPECT_EQ(app.remaining_size(), (size_t)0);
+    EXPECT_EQ(app.remaining_size(true), (size_t)3);
     EXPECT_EQ(subc->remaining(), std::vector<std::string>({"other", "--simple", "--mine"}));
 }
 

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -281,6 +281,32 @@ TEST_F(TApp, RequiredSubCom) {
     run();
 }
 
+TEST_F(TApp, SubComExtras) {
+    app.allow_extras();
+    auto sub = app.add_subcommand("sub");
+
+    args = {"extra", "sub"};
+    run();
+    EXPECT_EQ(app.remaining(), std::vector<std::string>({"extra"}));
+    EXPECT_EQ(sub->remaining(), std::vector<std::string>());
+
+    app.reset();
+    
+    args = {"extra1", "extra2", "sub"};
+    run();
+    EXPECT_EQ(app.remaining(), std::vector<std::string>({"extra1", "extra2"}));
+    EXPECT_EQ(sub->remaining(), std::vector<std::string>());
+    
+    app.reset();
+
+    //args = {"sub", "extra"};
+    //run();
+    //EXPECT_EQ(app.remaining(), std::vector<std::string>());
+    //EXPECT_EQ(sub->remaining(), std::vector<std::string>({"extra"}));
+
+
+}
+
 TEST_F(TApp, Required1SubCom) {
     app.require_subcommand(1);
     app.add_subcommand("sub1");

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -291,20 +291,18 @@ TEST_F(TApp, SubComExtras) {
     EXPECT_EQ(sub->remaining(), std::vector<std::string>());
 
     app.reset();
-    
+
     args = {"extra1", "extra2", "sub"};
     run();
     EXPECT_EQ(app.remaining(), std::vector<std::string>({"extra1", "extra2"}));
     EXPECT_EQ(sub->remaining(), std::vector<std::string>());
-    
+
     app.reset();
 
-    //args = {"sub", "extra"};
-    //run();
-    //EXPECT_EQ(app.remaining(), std::vector<std::string>());
-    //EXPECT_EQ(sub->remaining(), std::vector<std::string>({"extra"}));
-
-
+    // args = {"sub", "extra"};
+    // run();
+    // EXPECT_EQ(app.remaining(), std::vector<std::string>());
+    // EXPECT_EQ(sub->remaining(), std::vector<std::string>({"extra"}));
 }
 
 TEST_F(TApp, Required1SubCom) {

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -339,9 +339,9 @@ TEST_F(TApp, PrefixProgram) {
     app.add_flag("--simple");
 
     args = {"--simple", "other", "--simple", "--mine"};
-    auto ret_args = run();
+    run();
 
-    EXPECT_EQ(ret_args, std::vector<std::string>({"--mine", "--simple", "other"}));
+    EXPECT_EQ(app.remaining(), std::vector<std::string>({"other", "--simple", "--mine"}));
 }
 
 struct SubcommandProgram : public TApp {

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -299,10 +299,10 @@ TEST_F(TApp, SubComExtras) {
 
     app.reset();
 
-    // args = {"sub", "extra"};
-    // run();
-    // EXPECT_EQ(app.remaining(), std::vector<std::string>());
-    // EXPECT_EQ(sub->remaining(), std::vector<std::string>({"extra"}));
+    args = {"sub", "extra1", "extra2"};
+    run();
+    EXPECT_EQ(app.remaining(), std::vector<std::string>());
+    EXPECT_EQ(sub->remaining(), std::vector<std::string>({"extra1", "extra2"}));
 }
 
 TEST_F(TApp, Required1SubCom) {
@@ -340,6 +340,20 @@ TEST_F(TApp, PrefixProgram) {
     run();
 
     EXPECT_EQ(app.remaining(), std::vector<std::string>({"other", "--simple", "--mine"}));
+}
+
+TEST_F(TApp, PrefixSubcom) {
+    auto subc = app.add_subcommand("subc");
+    subc->prefix_command();
+    
+    app.add_flag("--simple");
+    
+    args = {"--simple", "subc", "other", "--simple", "--mine"};
+    run();
+    
+    EXPECT_EQ(app.remaining_size(), (size_t) 0);
+    EXPECT_EQ(app.remaining_size(true), (size_t) 3);
+    EXPECT_EQ(subc->remaining(), std::vector<std::string>({"other", "--simple", "--mine"}));
 }
 
 struct SubcommandProgram : public TApp {

--- a/tests/app_helper.hpp
+++ b/tests/app_helper.hpp
@@ -15,10 +15,10 @@ struct TApp : public ::testing::Test {
     CLI::App app{"My Test Program"};
     input_t args;
 
-    std::vector<std::string> run() {
+    void run() {
         input_t newargs = args;
         std::reverse(std::begin(newargs), std::end(newargs));
-        return app.parse(newargs);
+        app.parse(newargs);
     }
 };
 


### PR DESCRIPTION
In the interests of solving #36, this PR refactors the way extras are handled. The implementation:
* `parse` no longer returns a vector (not well supported anyway, for example with `CLI11_PARSE`
* Added `remaining()` and `remaining_size()`, which provide access into the unparsed options. They support a "recurse" bool flag that causes them to collect all subcommand arguments, too. They are not "reversed".
* `allow_extras` and `prefix_command` are now valid on subcommands, and inherit the setting from the parent upon creation (like the other options)

Oddities that remain:
* The vector form of parse still expects a "reversed" vector; it updates itself with the remaining options, however. Reordering might be unintentionally possible with multiple subcommands.

Will need to maybe add more tests, and needs docs and changelog.