### PR TITLE
Adding take_last

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The add commands return a pointer to an internally stored `Option`. If you set t
 * `->envname(name)`: Gets the value from the environment if present and not passed on the command line.
 * `->group(name)`: The help group to put the option in. No effect for positional options. Defaults to `"Options"`. `"Hidden"` will not show up in the help print.
 * `->ignore_case()`: Ignore the case on the command line (also works on subcommands, does not affect arguments).
+* `->take_last()`: Only take the last option/flag given on the command line, automatically true for bool flags
 * `->check(CLI::ExistingFile)`: Requires that the file exists if given.
 * `->check(CLI::ExistingDirectory)`: Requires that the directory exists.
 * `->check(CLI::NonexistentPath)`: Requires that the path does not exist.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -351,22 +351,23 @@ class App {
         return opt;
     }
 
-    /// Bool version
+    /// Bool version - defaults to allowing multiple passings, but can be forced to one if `take_last(false)` is used.
     template <typename T, enable_if_t<is_bool<T>::value, detail::enabler> = detail::dummy>
     Option *add_flag(std::string name,
                      T &count, ///< A varaible holding true if passed
                      std::string description = "") {
 
         count = false;
-        CLI::callback_t fun = [&count](CLI::results_t) {
+        CLI::callback_t fun = [&count](CLI::results_t res) {
             count = true;
-            return true;
+            return res.size() == 1;
         };
 
         Option *opt = add_option(name, fun, description, false);
         if(opt->get_positional())
             throw IncorrectConstruction("Flags cannot be positional");
         opt->set_custom_option("", 0);
+        opt->take_last();
         return opt;
     }
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -167,6 +167,20 @@ TEST_F(TApp, BoolAndIntFlags) {
     EXPECT_EQ((unsigned int)2, uflag);
 }
 
+TEST_F(TApp, BoolOnlyFlag) {
+    bool bflag;
+    app.add_flag("-b", bflag)->take_last(false);
+
+    args = {"-b"};
+    EXPECT_NO_THROW(run());
+    EXPECT_TRUE(bflag);
+
+    app.reset();
+
+    args = {"-b", "-b"};
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
 TEST_F(TApp, ShortOpts) {
 
     unsigned long long funnyint;
@@ -202,6 +216,18 @@ TEST_F(TApp, DefaultOpts) {
     EXPECT_EQ((size_t)1, app.count("-s"));
     EXPECT_EQ(2, i);
     EXPECT_EQ("9", s);
+}
+
+TEST_F(TApp, TakeLastOpt) {
+
+    std::string str;
+    app.add_option("--str", str)->take_last();
+
+    args = {"--str=one", "--str=two"};
+
+    run();
+
+    EXPECT_EQ(str, "two");
 }
 
 TEST_F(TApp, EnumTest) {

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -137,6 +137,20 @@ TEST_F(TApp, IncorrectConstructionVectorAsFlag) {
     EXPECT_THROW(cat->expected(0), CLI::IncorrectConstruction);
 }
 
+TEST_F(TApp, IncorrectConstructionVectorTakeLast) {
+    std::vector<int> vec;
+    auto cat = app.add_option("--vec", vec);
+    EXPECT_THROW(cat->take_last(), CLI::IncorrectConstruction);
+}
+
+TEST_F(TApp, IncorrectConstructionTakeLastExpected) {
+    std::vector<int> vec;
+    auto cat = app.add_option("--vec", vec);
+    cat->expected(1);
+    ASSERT_NO_THROW(cat->take_last());
+    EXPECT_THROW(cat->expected(2), CLI::IncorrectConstruction);
+}
+
 TEST_F(TApp, IncorrectConstructionRequiresCannotFind) {
     auto cat = app.add_flag("--cat");
     EXPECT_THROW(cat->requires("--nothing"), CLI::IncorrectConstruction);


### PR DESCRIPTION
This adds `take_last`, which causes the final option given to be the only one considered. So:

```bash
--opt one --opt two
```

Would set opt to two. `opt->count` is still 2. This was also used to implement bool flags (on by default), which allows someone to restore the behavior seen before #38 by setting `->take_last(false)` and is a better/more general fix than #38 . This is a partial fix for #39 ; the other part of the fix would be giving the user more power over the failure messages.