### PR TITLE
Allow to set a footer in the description

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ There are several options that are supported on the main app and subcommands. Th
 * `.set_callback(void() function)`: Set the callback that runs at the end of parsing. The options have already run at this point.
 * `.allow_extras()`: Do not throw an error if extra arguments are left over
 * `.prefix_command()`: Like `allow_extras`, but stop immediately on the first unrecognised item. It is ideal for allowing your app or subcommand to be a "prefix" to calling another app.
+* `.set_footer(message)`: Set text to appear at the bottom of the help string.
 
 > Note: if you have a fixed number of required positional options, that will match before subcommand names.
 

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -836,8 +836,8 @@ class App {
                 detail::format_help(out, com->get_name(), com->description_, wid);
         }
 
-        if (!footer_.empty()) {
-          out << std::endl << footer_ << std::endl;
+        if(!footer_.empty()) {
+            out << std::endl << footer_ << std::endl;
         }
 
         return out.str();

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -63,6 +63,9 @@ class App {
     /// Description of the current program/subcommand
     std::string description_;
 
+    /// Footer to put after all options in the help output
+    std::string footer_;
+
     /// If true, allow extra arguments (ie, don't throw an error).
     bool allow_extras_{false};
 
@@ -146,6 +149,12 @@ class App {
 
     /// Create a new program. Pass in the same arguments as main(), along with a help string.
     App(std::string description_ = "", bool help = true) : App(description_, help, detail::dummy) {}
+
+    /// Set footer.
+    App *set_footer(std::string footer) {
+        footer_ = footer;
+        return this;
+    }
 
     /// Set a callback for the end of parsing.
     ///
@@ -794,18 +803,17 @@ class App {
                 out << " [SUBCOMMAND]";
         }
 
-        out << std::endl << std::endl;
+        out << std::endl;
 
         // Positional descriptions
         if(pos) {
-            out << "Positionals:" << std::endl;
+            out << std::endl << "Positionals:" << std::endl;
             for(const Option_p &opt : options_) {
                 if(detail::to_lower(opt->get_group()) == "hidden")
                     continue;
                 if(opt->_has_help_positional())
                     detail::format_help(out, opt->help_pname(), opt->get_description(), wid);
             }
-            out << std::endl;
         }
 
         // Options
@@ -813,21 +821,25 @@ class App {
             for(const std::string &group : groups) {
                 if(detail::to_lower(group) == "hidden")
                     continue;
-                out << group << ":" << std::endl;
+                out << std::endl << group << ":" << std::endl;
                 for(const Option_p &opt : options_) {
                     if(opt->nonpositional() && opt->get_group() == group)
                         detail::format_help(out, opt->help_name(), opt->get_description(), wid);
                 }
-                out << std::endl;
             }
         }
 
         // Subcommands
         if(!subcommands_.empty()) {
-            out << "Subcommands:" << std::endl;
+            out << std::endl << "Subcommands:" << std::endl;
             for(const App_p &com : subcommands_)
                 detail::format_help(out, com->get_name(), com->description_, wid);
         }
+
+        if (!footer_.empty()) {
+          out << std::endl << footer_ << std::endl;
+        }
+
         return out.str();
     }
 

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -22,6 +22,19 @@ TEST(THelp, Basic) {
     EXPECT_THAT(help, HasSubstr("Usage:"));
 }
 
+TEST(THelp, Footer) {
+    CLI::App app{"My prog"};
+    app.set_footer("Report bugs to bugs@example.com");
+
+    std::string help = app.help();
+
+    EXPECT_THAT(help, HasSubstr("My prog"));
+    EXPECT_THAT(help, HasSubstr("-h,--help"));
+    EXPECT_THAT(help, HasSubstr("Options:"));
+    EXPECT_THAT(help, HasSubstr("Usage:"));
+    EXPECT_THAT(help, HasSubstr("Report bugs to bugs@example.com"));
+}
+
 TEST(THelp, OptionalPositional) {
     CLI::App app{"My prog"};
 


### PR DESCRIPTION
Let's see what you think :)  Setting a footer for a bug report address or other notes is common enough that I think it should be supported without subclassing.  If you agree, here is a simple implementation that does the trick for me.