### PR TITLE
Fix ExtrasError.

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -954,7 +954,7 @@ class App {
         if(recurse) {
             for(const App_p &sub : subcommands_) {
                 std::vector<std::string> output = sub->remaining(recurse);
-                miss_list.assign(std::begin(output), std::end(output));
+                std::copy(std::begin(output), std::end(output), std::back_inserter(miss_list));
             }
         }
         return miss_list;
@@ -1114,15 +1114,14 @@ class App {
             throw RequiredError(std::to_string(require_subcommand_) + " subcommand(s) required");
 
         // Convert missing (pairs) to extras (string only)
-        if(parent_ == nullptr) {
-            args = remaining(true);
-            std::reverse(std::begin(args), std::end(args));
+        if(!(allow_extras_ || prefix_command_)) {
+            size_t num_left_over = remaining_size();
+            if(num_left_over > 0) {
+                args = remaining(false);
+                std::reverse(std::begin(args), std::end(args));
+                throw ExtrasError("[" + detail::rjoin(args, " ") + "]");
+            }
         }
-
-        size_t num_left_over = remaining_size();
-
-        if(num_left_over > 0 && !(allow_extras_ || prefix_command_))
-            throw ExtrasError("[" + detail::rjoin(args, " ") + "]");
     }
 
     /// Parse one ini param, return false if not found in any subcommand, remove if it is

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -44,11 +44,10 @@ TEST_F(TApp, BasicSubcommands) {
     app.reset();
     args = {"sub1", "extra"};
     try {
-      run();
+        run();
     } catch(const CLI::ExtrasError &e) {
         EXPECT_THAT(e.what(), HasSubstr("extra"));
     }
-
 }
 
 TEST_F(TApp, MultiSubFallthrough) {

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -32,6 +32,23 @@ TEST_F(TApp, BasicSubcommands) {
     app.reset();
     args = {"SUb2"};
     EXPECT_THROW(run(), CLI::ExtrasError);
+
+    app.reset();
+    args = {"SUb2"};
+    try {
+        run();
+    } catch(const CLI::ExtrasError &e) {
+        EXPECT_THAT(e.what(), HasSubstr("SUb2"));
+    }
+
+    app.reset();
+    args = {"sub1", "extra"};
+    try {
+      run();
+    } catch(const CLI::ExtrasError &e) {
+        EXPECT_THAT(e.what(), HasSubstr("extra"));
+    }
+
 }
 
 TEST_F(TApp, MultiSubFallthrough) {
@@ -339,6 +356,14 @@ TEST_F(TApp, SubComExtras) {
     run();
     EXPECT_EQ(app.remaining(), std::vector<std::string>());
     EXPECT_EQ(sub->remaining(), std::vector<std::string>({"extra1", "extra2"}));
+
+    app.reset();
+
+    args = {"extra1", "extra2", "sub", "extra3", "extra4"};
+    run();
+    EXPECT_EQ(app.remaining(), std::vector<std::string>({"extra1", "extra2"}));
+    EXPECT_EQ(app.remaining(true), std::vector<std::string>({"extra1", "extra2", "extra3", "extra4"}));
+    EXPECT_EQ(sub->remaining(), std::vector<std::string>({"extra3", "extra4"}));
 }
 
 TEST_F(TApp, Required1SubCom) {


### PR DESCRIPTION
I noticed that ExtrasError wasn't showing the extra argument in a subcommand.  So I dug deeper, and I could identify a bug in remaining(true), which was overwriting the miss_list instead of extending it.  So, I added some tests and fixed it.
But then I noticed some bargled logic in triggering ExtrasError: Firstly, there is a mismatch between remaining(true) and remaining_size() (without true). Secondly, it didn't handle allow_extras_ and prefix_command_ on a per-subcommand basis.  I tried a couple of things, but the easiest fix was to just let each subcommand fail on its own, by not using recurse=true at all.
As recurse=true is not used anymore (and because it does not handle allow_extras_ and prefix_command_), the recurse=true case could be removed from the code base.  My patch doesn't do that, though, to keep the change minimal, in case there are some other plans or cases I missed.  My recommendation would be to remove it if it doesn't serve any other purpose.  I am not firm on the logic behind the fallthrough_ cases, so it may be that I am missing something.