### PR TITLE
Failure message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * The clang-format script is now no longer "hidden" [#48](https://github.com/CLIUtils/CLI11/pull/48)
 * The order is now preserved for subcommands (list and callbacks) [#49](https://github.com/CLIUtils/CLI11/pull/49)
 * Tests now run individually, utilizing CMake 3.10 additions if possible [#50](https://github.com/CLIUtils/CLI11/pull/50)
+* Failure messages are now customizable, with a shorter default [#52](https://github.com/CLIUtils/CLI11/pull/52)
 
 
 ## Version 1.2

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ There are several options that are supported on the main app and subcommands. Th
 * `.allow_extras()`: Do not throw an error if extra arguments are left over
 * `.prefix_command()`: Like `allow_extras`, but stop immediately on the first unrecognised item. It is ideal for allowing your app or subcommand to be a "prefix" to calling another app.
 * `.set_footer(message)`: Set text to appear at the bottom of the help string.
+* `.set_failure_message(func)`: Set the failure message function. Two provided: `CLI::FailureMessage::help` and CLI::FailureMessage::simple` (the default).
 * `.group(name)`: Set a group name, defaults to `"Subcommands"`. Setting `""` will be hide the subcommand.
 
 > Note: if you have a fixed number of required positional options, that will match before subcommand names.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -727,20 +727,20 @@ class App {
     }
 
     /// Print a nice error message and return the exit code
-    int exit(const Error &e) const {
+    int exit(const Error &e, std::ostream &out = std::cout, std::ostream &err = std::cerr) const {
 
         /// Avoid printing anything if this is a CLI::RuntimeError
         if(dynamic_cast<const CLI::RuntimeError *>(&e) != nullptr)
             return e.get_exit_code();
 
         if(dynamic_cast<const CLI::CallForHelp *>(&e) != nullptr) {
-            std::cout << help();
+            out << help();
             return e.get_exit_code();
         }
 
         if(e.exit_code != static_cast<int>(ExitCodes::Success)) {
             if(failure_message_)
-                std::cerr << failure_message_(this, e) << std::flush;
+                err << failure_message_(this, e) << std::flush;
         }
 
         return e.get_exit_code();
@@ -1428,17 +1428,20 @@ class App {
 };
 
 namespace FailureMessage {
+
 inline std::string simple(const App *app, const Error &e) {
     std::string header = std::string("ERROR: ") + e.what() + "\n";
     if(app->get_help_ptr() != nullptr)
-        header += "Run with " + app->get_help_ptr()->single_name() + " for more help\n";
+        header += "Run with " + app->get_help_ptr()->single_name() + " for more information.\n";
     return header;
 };
+
 inline std::string help(const App *app, const Error &e) {
     std::string header = std::string("ERROR: ") + e.what() + "\n";
     header += app->help();
     return header;
 };
+
 } // namespace FailureMessage
 
 namespace detail {

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -41,25 +41,19 @@ enum class ExitCodes {
 /// All errors derive from this one
 struct Error : public std::runtime_error {
     int exit_code;
-    bool print_help;
     int get_exit_code() const { return exit_code; }
-    Error(std::string parent, std::string name, ExitCodes exit_code = ExitCodes::BaseClass, bool print_help = true)
-        : runtime_error(parent + ": " + name), exit_code(static_cast<int>(exit_code)), print_help(print_help) {}
-    Error(std::string parent,
-          std::string name,
-          int exit_code = static_cast<int>(ExitCodes::BaseClass),
-          bool print_help = true)
-        : runtime_error(parent + ": " + name), exit_code(exit_code), print_help(print_help) {}
+
+    Error(std::string parent, std::string name, ExitCodes exit_code = ExitCodes::BaseClass)
+        : runtime_error(parent + ": " + name), exit_code(static_cast<int>(exit_code)) {}
+    Error(std::string parent, std::string name, int exit_code = static_cast<int>(ExitCodes::BaseClass))
+        : runtime_error(parent + ": " + name), exit_code(exit_code) {}
 };
 
 /// Construction errors (not in parsing)
 struct ConstructionError : public Error {
     // Using Error::Error constructors seem to not work on GCC 4.7
-    ConstructionError(std::string parent,
-                      std::string name,
-                      ExitCodes exit_code = ExitCodes::BaseClass,
-                      bool print_help = true)
-        : Error(parent, name, exit_code, print_help) {}
+    ConstructionError(std::string parent, std::string name, ExitCodes exit_code = ExitCodes::BaseClass)
+        : Error(parent, name, exit_code) {}
 };
 
 /// Thrown when an option is set to conflicting values (non-vector and multi args, for example)
@@ -83,20 +77,17 @@ struct OptionAlreadyAdded : public ConstructionError {
 
 /// Anything that can error in Parse
 struct ParseError : public Error {
-    ParseError(std::string parent, std::string name, ExitCodes exit_code = ExitCodes::BaseClass, bool print_help = true)
-        : Error(parent, name, exit_code, print_help) {}
-    ParseError(std::string parent,
-               std::string name,
-               int exit_code = static_cast<int>(ExitCodes::BaseClass),
-               bool print_help = true)
-        : Error(parent, name, exit_code, print_help) {}
+    ParseError(std::string parent, std::string name, ExitCodes exit_code = ExitCodes::BaseClass)
+        : Error(parent, name, exit_code) {}
+    ParseError(std::string parent, std::string name, int exit_code = static_cast<int>(ExitCodes::BaseClass))
+        : Error(parent, name, exit_code) {}
 };
 
 // Not really "errors"
 
 /// This is a successful completion on parsing, supposed to exit
 struct Success : public ParseError {
-    Success() : ParseError("Success", "Successfully completed, should be caught and quit", ExitCodes::Success, false) {}
+    Success() : ParseError("Success", "Successfully completed, should be caught and quit", ExitCodes::Success) {}
 };
 
 /// -h or --help on command line
@@ -107,7 +98,7 @@ struct CallForHelp : public ParseError {
 
 /// Does not output a diagnostic in CLI11_PARSE, but allows to return from main() with a specific error code.
 struct RuntimeError : public ParseError {
-    RuntimeError(int exit_code = 1) : ParseError("RuntimeError", "runtime error", exit_code, false) {}
+    RuntimeError(int exit_code = 1) : ParseError("RuntimeError", "runtime error", exit_code) {}
 };
 
 /// Thrown when parsing an INI file and it is missing

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -359,10 +359,20 @@ class Option : public OptionBase<Option> {
         return out;
     }
 
-    /// The first half of the help print, name plus default, etc
-    std::string help_name() const {
+    /// The most discriptive name available
+    std::string single_name() const {
+        if(!lnames_.empty())
+            return lnames_[0];
+        else if(!snames_.empty())
+            return snames_[0];
+        else
+            return pname_;
+    }
+
+    /// The first half of the help print, name plus default, etc. Setting opt_only to true avoids the positional name.
+    std::string help_name(bool opt_only = false) const {
         std::stringstream out;
-        out << get_name(true) << help_aftername();
+        out << get_name(opt_only) << help_aftername();
         return out.str();
     }
 


### PR DESCRIPTION
This adds tests for the failure message, and makes it customizable. Two options are provided. The default has changed to the more concise version of the message.

To set the old default, the "help print" message:

```cpp
app.set_failure_message(CLI::FailureMessage::help);
```