### PR TITLE
Convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,12 @@
 * The order is now preserved for subcommands (list and callbacks) [#49](https://github.com/CLIUtils/CLI11/pull/49)
 * Tests now run individually, utilizing CMake 3.10 additions if possible [#50](https://github.com/CLIUtils/CLI11/pull/50)
 * Failure messages are now customizable, with a shorter default [#52](https://github.com/CLIUtils/CLI11/pull/52)
+* Some improvements to error codes [#53](https://github.com/CLIUtils/CLI11/pull/53)
 * `require_subcommand` now offers a two-argument form and negative values on the one-argument form are more useful [#51](https://github.com/CLIUtils/CLI11/pull/51)
 * Subcommands no longer match after the max required number is obtained [#51](https://github.com/CLIUtils/CLI11/pull/51)
 * Unlimited options no longer prioritize over remaining/unlimited positionals [#51](https://github.com/CLIUtils/CLI11/pull/51)
+* Added `->transform` which modifies the string parsed [#54](https://github.com/CLIUtils/CLI11/pull/54)
+* Changed of API in validators to `void(std::string &)` (const for users), throwing providing nicer errors [#54](https://github.com/CLIUtils/CLI11/pull/54)
 
 ## Version 1.2
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ The add commands return a pointer to an internally stored `Option`. If you set t
 * `->check(CLI::ExistingDirectory)`: Requires that the directory exists.
 * `->check(CLI::NonexistentPath)`: Requires that the path does not exist.
 * `->check(CLI::Range(min,max))`: Requires that the option be between min and max (make sure to use floating point if needed). Min defaults to 0.
+* `->transform(std::string(std::string))`: Converts the input string into the output string, in-place in the parsed options.
 
-These options return the `Option` pointer, so you can chain them together, and even skip storing the pointer entirely. Check takes any function that has the signature `bool(std::string)`. If you just want to see the unconverted values, use `.results()` to get the `std::vector<std::string>` of results.
+These options return the `Option` pointer, so you can chain them together, and even skip storing the pointer entirely. Check takes any function that has the signature `void(const std::string&)`; it should throw a `ValidationError` when validation fails. The help message will have the name of the parent option prepended. Since `check` and `transform` use the same underlying mechanism, you can chain as many as you want, and they will be executed in order. If you just want to see the unconverted values, use `.results()` to get the `std::vector<std::string>` of results.
 
 
 On the command line, options can be given as:
@@ -256,10 +257,10 @@ arguments, use `.config_to_str(default_also=false)`, where `default_also` will a
 
 Many of the defaults for subcommands and even options are inherited from their creators. The inherited default values for subcommands are `allow_extras`, `prefix_command`, `ignore_case`, `fallthrough`, `group`, `footer`, and maximum number of required subcommands. The help flag existence, name, and description are inherited, as well.
 
-Options have defaults for `group`, `required`, `take_last`, and `ignore_case`. To set these defaults, you should set the `option_defauts()` object, for example:
+Options have defaults for `group`, `required`, `take_last`, and `ignore_case`. To set these defaults, you should set the `option_defaults()` object, for example:
 
 ```cpp
-app.option_defauts()->required();
+app.option_defaults()->required();
 // All future options will be required
 ```
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -226,8 +226,11 @@ class Option : public OptionBase<Option> {
     }
 
     /// Adds a validator-like function that can change result
-    Option *transform(std::function<bool(std::string &)> validator) {
-        validators_.push_back(validator);
+    Option *transform(std::function<std::string(std::string)> func) {
+        validators_.push_back([func](std::string &inout) {
+            inout = func(inout);
+            return true;
+        });
         return this;
     }
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -437,7 +437,7 @@ class Option : public OptionBase<Option> {
                 for(const std::function<std::string(std::string &)> &vali : validators_) {
                     std::string err_msg = vali(result);
                     if(!err_msg.empty())
-                        throw ValidationError(get_name() + ": " + err_msg);
+                        throw ValidationError(single_name() + ": " + err_msg);
                 }
         }
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -220,8 +220,13 @@ class Option : public OptionBase<Option> {
     }
 
     /// Adds a validator
-    Option *check(std::function<bool(std::string &)> validator) {
+    Option *check(std::function<bool(const std::string &)> validator) {
+        validators_.emplace_back(validator);
+        return this;
+    }
 
+    /// Adds a validator-like function that can change result
+    Option *transform(std::function<bool(std::string &)> validator) {
         validators_.push_back(validator);
         return this;
     }

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -19,7 +19,7 @@ namespace CLI {
 /// @defgroup validator_group Validators
 /// @brief Some validators that are provided
 ///
-/// These are simple `bool(std::string)` validators that are useful.
+/// These are simple `bool(std::string&)` validators that are useful.
 /// @{
 
 /// Check for an existing file

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -23,7 +23,7 @@ namespace CLI {
 /// @{
 
 /// Check for an existing file
-inline bool ExistingFile(std::string filename) {
+inline bool ExistingFile(const std::string &filename) {
     struct stat buffer;
     bool exist = stat(filename.c_str(), &buffer) == 0;
     bool is_dir = (buffer.st_mode & S_IFDIR) != 0;
@@ -39,7 +39,7 @@ inline bool ExistingFile(std::string filename) {
 }
 
 /// Check for an existing directory
-inline bool ExistingDirectory(std::string filename) {
+inline bool ExistingDirectory(const std::string &filename) {
     struct stat buffer;
     bool exist = stat(filename.c_str(), &buffer) == 0;
     bool is_dir = (buffer.st_mode & S_IFDIR) != 0;
@@ -55,7 +55,7 @@ inline bool ExistingDirectory(std::string filename) {
 }
 
 /// Check for a non-existing path
-inline bool NonexistentPath(std::string filename) {
+inline bool NonexistentPath(const std::string &filename) {
     struct stat buffer;
     bool exist = stat(filename.c_str(), &buffer) == 0;
     if(!exist) {
@@ -67,7 +67,7 @@ inline bool NonexistentPath(std::string filename) {
 }
 
 /// Produce a range validator function
-template <typename T> std::function<bool(std::string)> Range(T min, T max) {
+template <typename T> std::function<bool(const std::string &)> Range(T min, T max) {
     return [min, max](std::string input) {
         T val;
         detail::lexical_cast(input, val);
@@ -76,7 +76,7 @@ template <typename T> std::function<bool(std::string)> Range(T min, T max) {
 }
 
 /// Range of one value is 0 to value
-template <typename T> std::function<bool(std::string)> Range(T max) { return Range(static_cast<T>(0), max); }
+template <typename T> std::function<bool(const std::string &)> Range(T max) { return Range(static_cast<T>(0), max); }
 
 /// @}
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -606,7 +606,7 @@ TEST_F(TApp, RemoveOption) {
 
 TEST_F(TApp, FileNotExists) {
     std::string myfile{"TestNonFileNotUsed.txt"};
-    EXPECT_TRUE(CLI::NonexistentPath(myfile));
+    EXPECT_NO_THROW(CLI::NonexistentPath(myfile));
 
     std::string filename;
     app.add_option("--file", filename)->check(CLI::NonexistentPath);
@@ -622,12 +622,12 @@ TEST_F(TApp, FileNotExists) {
     EXPECT_THROW(run(), CLI::ValidationError);
 
     std::remove(myfile.c_str());
-    EXPECT_FALSE(CLI::ExistingFile(myfile));
+    EXPECT_FALSE(CLI::ExistingFile(myfile).empty());
 }
 
 TEST_F(TApp, FileExists) {
     std::string myfile{"TestNonFileNotUsed.txt"};
-    EXPECT_FALSE(CLI::ExistingFile(myfile));
+    EXPECT_FALSE(CLI::ExistingFile(myfile).empty());
 
     std::string filename = "Failed";
     app.add_option("--file", filename)->check(CLI::ExistingFile);
@@ -643,7 +643,7 @@ TEST_F(TApp, FileExists) {
     EXPECT_EQ(myfile, filename);
 
     std::remove(myfile.c_str());
-    EXPECT_FALSE(CLI::ExistingFile(myfile));
+    EXPECT_FALSE(CLI::ExistingFile(myfile).empty());
 }
 
 TEST_F(TApp, InSet) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1176,14 +1176,8 @@ TEST_F(TApp, SetWithDefaultsIC) {
 TEST_F(TApp, OrderedModifingValidators) {
     std::vector<std::string> val;
     auto m = app.add_option("-m", val);
-    m->transform([](std::string &x) {
-        x += "1";
-        return true;
-    });
-    m->transform([](std::string &x) {
-        x += "2";
-        return true;
-    });
+    m->transform([](std::string x) { return x + "1"; });
+    m->transform([](std::string x) { return x + "2"; });
 
     args = {"-mone", "-mtwo"};
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1171,3 +1171,23 @@ TEST_F(TApp, SetWithDefaultsIC) {
 
     EXPECT_THROW(run(), CLI::ConversionError);
 }
+
+// Added to test defaults on dual method
+TEST_F(TApp, OrderedModifingValidators) {
+    std::vector<std::string> val;
+    auto m = app.add_option("-m", val);
+    m->transform([](std::string &x) {
+        x += "1";
+        return true;
+    });
+    m->transform([](std::string &x) {
+        x += "2";
+        return true;
+    });
+
+    args = {"-mone", "-mtwo"};
+
+    run();
+
+    EXPECT_EQ(val, std::vector<std::string>({"one12", "two12"}));
+}

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -87,50 +87,50 @@ TEST(Trim, TrimCopy) {
 
 TEST(Validators, FileExists) {
     std::string myfile{"TestFileNotUsed.txt"};
-    EXPECT_FALSE(CLI::ExistingFile(myfile));
+    EXPECT_FALSE(CLI::ExistingFile(myfile).empty());
     bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a')); // create file
     EXPECT_TRUE(ok);
-    EXPECT_TRUE(CLI::ExistingFile(myfile));
+    EXPECT_TRUE(CLI::ExistingFile(myfile).empty());
 
     std::remove(myfile.c_str());
-    EXPECT_FALSE(CLI::ExistingFile(myfile));
+    EXPECT_FALSE(CLI::ExistingFile(myfile).empty());
 }
 
 TEST(Validators, FileNotExists) {
     std::string myfile{"TestFileNotUsed.txt"};
-    EXPECT_TRUE(CLI::NonexistentPath(myfile));
+    EXPECT_TRUE(CLI::NonexistentPath(myfile).empty());
     bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a')); // create file
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(CLI::NonexistentPath(myfile));
+    EXPECT_FALSE(CLI::NonexistentPath(myfile).empty());
 
     std::remove(myfile.c_str());
-    EXPECT_TRUE(CLI::NonexistentPath(myfile));
+    EXPECT_TRUE(CLI::NonexistentPath(myfile).empty());
 }
 
 TEST(Validators, FileIsDir) {
     std::string mydir{"../tests"};
-    EXPECT_FALSE(CLI::ExistingFile(mydir));
+    EXPECT_NE(CLI::ExistingFile(mydir), "");
 }
 
 TEST(Validators, DirectoryExists) {
     std::string mydir{"../tests"};
-    EXPECT_TRUE(CLI::ExistingDirectory(mydir));
+    EXPECT_EQ(CLI::ExistingDirectory(mydir), "");
 }
 
 TEST(Validators, DirectoryNotExists) {
     std::string mydir{"nondirectory"};
-    EXPECT_FALSE(CLI::ExistingDirectory(mydir));
+    EXPECT_NE(CLI::ExistingDirectory(mydir), "");
 }
 
 TEST(Validators, DirectoryIsFile) {
     std::string myfile{"TestFileNotUsed.txt"};
-    EXPECT_TRUE(CLI::NonexistentPath(myfile));
+    EXPECT_TRUE(CLI::NonexistentPath(myfile).empty());
     bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a')); // create file
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(CLI::ExistingDirectory(myfile));
+    EXPECT_FALSE(CLI::ExistingDirectory(myfile).empty());
 
     std::remove(myfile.c_str());
-    EXPECT_TRUE(CLI::NonexistentPath(myfile));
+    EXPECT_TRUE(CLI::NonexistentPath(myfile).empty());
 }
 
 // Yes, this is testing an app_helper :)
@@ -139,14 +139,14 @@ TEST(AppHelper, TempfileCreated) {
     {
         TempFile myfile{name};
 
-        EXPECT_FALSE(CLI::ExistingFile(myfile));
+        EXPECT_FALSE(CLI::ExistingFile(myfile).empty());
 
         bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a')); // create file
         EXPECT_TRUE(ok);
-        EXPECT_TRUE(CLI::ExistingFile(name));
+        EXPECT_TRUE(CLI::ExistingFile(name).empty());
         EXPECT_THROW({ TempFile otherfile(name); }, std::runtime_error);
     }
-    EXPECT_FALSE(CLI::ExistingFile(name));
+    EXPECT_FALSE(CLI::ExistingFile(name).empty());
 }
 
 TEST(AppHelper, TempfileNotCreated) {
@@ -154,9 +154,9 @@ TEST(AppHelper, TempfileNotCreated) {
     {
         TempFile myfile{name};
 
-        EXPECT_FALSE(CLI::ExistingFile(myfile));
+        EXPECT_FALSE(CLI::ExistingFile(myfile).empty());
     }
-    EXPECT_FALSE(CLI::ExistingFile(name));
+    EXPECT_FALSE(CLI::ExistingFile(name).empty());
 }
 
 TEST(AppHelper, Ofstream) {
@@ -170,9 +170,9 @@ TEST(AppHelper, Ofstream) {
             out << "this is output" << std::endl;
         }
 
-        EXPECT_TRUE(CLI::ExistingFile(myfile));
+        EXPECT_TRUE(CLI::ExistingFile(myfile).empty());
     }
-    EXPECT_FALSE(CLI::ExistingFile(name));
+    EXPECT_FALSE(CLI::ExistingFile(name).empty());
 }
 
 TEST(Split, StringList) {

--- a/tests/app_helper.hpp
+++ b/tests/app_helper.hpp
@@ -27,7 +27,7 @@ class TempFile {
 
   public:
     TempFile(std::string name) : _name(name) {
-        if(!CLI::NonexistentPath(_name))
+        if(!CLI::NonexistentPath(_name).empty())
             throw std::runtime_error(_name);
     }
 


### PR DESCRIPTION
This is a requested feature: The ability for a transform function. Here is the design suggested:

```cpp
CLI::App main;
std::string path;
main.add_option("--path", path, "description")
  ->check(CLI::ExistingFile)
  ->transform([](std::string val){
          fs::path p = val;
          return fs::absolute(p).string();
});
```

This is internally implemented by giving all validation functions a reference instead of a copy (slight API change), and making `transform` simply the exact same thing as `check`, but with the `const` removed and the function rewritten as a `string(string)` function. CLI11 has always supported a series of validators, so this is not a major change. The validators now run first before the value is filled.

* [x] This might be a good opportunity to add nicer errors for failed validation, since the API is changing a little.
* [x] I could also transform the `transform` API only to `string(string)`. Thoughts?

Validation functions now return a string representing an error message. If it is empty, the validation succeeds. As always, they can also throw a `ValidationError`.