### PR TITLE
Error work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 * Unlimited options no longer prioritize over remaining/unlimited positionals [#51](https://github.com/CLIUtils/CLI11/pull/51)
 * Added `->transform` which modifies the string parsed [#54](https://github.com/CLIUtils/CLI11/pull/54)
 * Changed of API in validators to `void(std::string &)` (const for users), throwing providing nicer errors [#54](https://github.com/CLIUtils/CLI11/pull/54)
+* Added `CLI::ArgumentMismatch` [#56](https://github.com/CLIUtils/CLI11/pull/56) and fixed missing failure if one arg expected [#55](https://github.com/CLIUtils/CLI11/issues/55)
+* Support for minimum unlimited expected arguments [#56](https://github.com/CLIUtils/CLI11/pull/56)
+* Single internal arg parse function [#56](https://github.com/CLIUtils/CLI11/pull/56)
 
 ## Version 1.2
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ On a C++14 compiler, you can pass a callback function directly to `.add_flag`, w
 The add commands return a pointer to an internally stored `Option`. If you set the final argument to true, the default value is captured and printed on the command line with the help flag. This option can be used directly to check for the count (`->count()`) after parsing to avoid a string based lookup. Before parsing, you can set the following options:
 
 * `->required()`: The program will quit if this option is not present. This is `mandatory` in Plumbum, but required options seems to be a more standard term. For compatibility, `->mandatory()` also works.
-* `->expected(N)`: Take `N` values instead of as many as possible, only for vector args.
+* `->expected(N)`: Take `N` values instead of as many as possible, only for vector args. If negative, require at least `-N`.
 * `->requires(opt)`: This option requires another option to also be present, opt is an `Option` pointer.
 * `->excludes(opt)`: This option cannot be given with `opt` present, opt is an `Option` pointer.
 * `->envname(name)`: Gets the value from the environment if present and not passed on the command line.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -274,8 +274,6 @@ class App {
 
         std::string simple_name = CLI::detail::split(name, ',').at(0);
         CLI::callback_t fun = [&variable, simple_name](CLI::results_t res) {
-            if(res.size() != 1)
-                throw ConversionError("Only one " + simple_name + " allowed");
             return detail::lexical_cast(res[0], variable);
         };
 
@@ -293,8 +291,6 @@ class App {
 
         std::string simple_name = CLI::detail::split(name, ',').at(0);
         CLI::callback_t fun = [&variable, simple_name](CLI::results_t res) {
-            if(res.size() != 1)
-                throw ConversionError("Only one " + simple_name + " allowed");
             return detail::lexical_cast(res[0], variable);
         };
 
@@ -325,7 +321,7 @@ class App {
         };
 
         Option *opt = add_option(name, fun, description, false);
-        opt->set_custom_option(detail::type_name<T>(), -1, true);
+        opt->set_custom_option(detail::type_name<T>(), -1);
         return opt;
     }
 
@@ -347,7 +343,7 @@ class App {
         };
 
         Option *opt = add_option(name, fun, description, defaulted);
-        opt->set_custom_option(detail::type_name<T>(), -1, true);
+        opt->set_custom_option(detail::type_name<T>(), -1);
         if(defaulted)
             opt->set_default_str("[" + detail::join(variable) + "]");
         return opt;
@@ -454,9 +450,6 @@ class App {
 
         std::string simple_name = CLI::detail::split(name, ',').at(0);
         CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            if(res.size() != 1) {
-                throw ConversionError("Only one " + simple_name + " allowed");
-            }
             bool retval = detail::lexical_cast(res[0], member);
             if(!retval)
                 throw ConversionError("The value " + res[0] + "is not an allowed value for " + simple_name);
@@ -480,9 +473,6 @@ class App {
 
         std::string simple_name = CLI::detail::split(name, ',').at(0);
         CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            if(res.size() != 1) {
-                throw ConversionError("Only one " + simple_name + " allowed");
-            }
             bool retval = detail::lexical_cast(res[0], member);
             if(!retval)
                 throw ConversionError("The value " + res[0] + "is not an allowed value for " + simple_name);
@@ -509,9 +499,6 @@ class App {
 
         std::string simple_name = CLI::detail::split(name, ',').at(0);
         CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            if(res.size() != 1) {
-                throw ConversionError("Only one " + simple_name + " allowed");
-            }
             member = detail::to_lower(res[0]);
             auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
                 return detail::to_lower(val) == member;
@@ -541,9 +528,6 @@ class App {
 
         std::string simple_name = CLI::detail::split(name, ',').at(0);
         CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            if(res.size() != 1) {
-                throw ConversionError("Only one " + simple_name + " allowed");
-            }
             member = detail::to_lower(res[0]);
             auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
                 return detail::to_lower(val) == member;

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -623,7 +623,7 @@ class App {
         for(const App_p &subcomptr : subcommands_)
             if(subcomptr.get() == subcom)
                 return subcom;
-        throw CLI::OptionNotFound(subcom->get_name());
+        throw OptionNotFound(subcom->get_name());
     }
 
     /// Check to see if a subcommand is part of this command (text version)
@@ -631,7 +631,7 @@ class App {
         for(const App_p &subcomptr : subcommands_)
             if(subcomptr->check_name(subcom))
                 return subcomptr.get();
-        throw CLI::OptionNotFound(subcom);
+        throw OptionNotFound(subcom);
     }
 
     /// Changes the group membership
@@ -1030,7 +1030,7 @@ class App {
             return opt->get_expected() == -1 && opt->get_positional();
         });
         if(count > 1)
-            throw InvalidError(name_ + ": Too many positional arguments with unlimited expected args");
+            throw InvalidError(name_);
         for(const App_p &app : subcommands_)
             app->_validate();
     }
@@ -1173,9 +1173,7 @@ class App {
             if(num_left_over > 0) {
                 args = remaining(false);
                 std::reverse(std::begin(args), std::end(args));
-                throw ExtrasError((args.size() > 1 ? "The following argument was not expected: "
-                                                   : "The following arguments were not expected: ") +
-                                  detail::rjoin(args, " "));
+                throw ExtrasError(args);
             }
         }
     }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1146,6 +1146,10 @@ class App {
         for(const Option_p &opt : options_) {
             // Required or partially filled
             if(opt->get_required() || opt->count() != 0) {
+                // Make sure enough -N arguments parsed (+N is already handled in parsing function)
+                if(opt->get_expected() < 0 && opt->count() < static_cast<size_t>(-opt->get_expected()))
+                    throw ArgumentMismatch(opt->single_name() + ": At least " + std::to_string(-opt->get_expected()) +
+                                           " required");
 
                 // Required but empty
                 if(opt->get_required() && opt->count() == 0)
@@ -1408,8 +1412,6 @@ class App {
                 args.pop_back();
                 collected++;
             }
-            if(op->results_.size() < static_cast<size_t>(-num))
-                throw ArgumentMismatch(op->single_name() + ": At least " + std::to_string(-num) + " required");
 
         } else {
             while(num > 0 && !args.empty()) {

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -452,7 +452,7 @@ class App {
         CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
             bool retval = detail::lexical_cast(res[0], member);
             if(!retval)
-                throw ConversionError("The value " + res[0] + "is not an allowed value for " + simple_name);
+                throw ConversionError(res[0], simple_name);
             return std::find(std::begin(options), std::end(options), member) != std::end(options);
         };
 
@@ -475,7 +475,7 @@ class App {
         CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
             bool retval = detail::lexical_cast(res[0], member);
             if(!retval)
-                throw ConversionError("The value " + res[0] + "is not an allowed value for " + simple_name);
+                throw ConversionError(res[0], simple_name);
             return std::find(std::begin(options), std::end(options), member) != std::end(options);
         };
 
@@ -504,7 +504,7 @@ class App {
                 return detail::to_lower(val) == member;
             });
             if(iter == std::end(options))
-                throw ConversionError("The value " + member + "is not an allowed value for " + simple_name);
+                throw ConversionError(member, simple_name);
             else {
                 member = *iter;
                 return true;
@@ -533,7 +533,7 @@ class App {
                 return detail::to_lower(val) == member;
             });
             if(iter == std::end(options))
-                throw ConversionError("The value " + member + "is not an allowed value for " + simple_name);
+                throw ConversionError(member, simple_name);
             else {
                 member = *iter;
                 return true;
@@ -1149,12 +1149,7 @@ class App {
 
                 // Required but empty
                 if(opt->get_required() && opt->count() == 0)
-                    throw RequiredError(opt->help_name() + " is required");
-
-                // Partially filled
-                if(opt->get_expected() > 0 && static_cast<int>(opt->count()) < opt->get_expected())
-                    throw RequiredError(opt->help_name() + " requires " + std::to_string(opt->get_expected()) +
-                                        " arguments");
+                    throw RequiredError(opt->single_name() + " is required");
             }
             // Requires
             for(const Option *opt_req : opt->requires_)
@@ -1409,8 +1404,8 @@ class App {
             }
 
             if(num > 0) {
-                throw RequiredError(op->single_name() + ": " + std::to_string(num) + " required " +
-                                    op->get_type_name() + " missing");
+                throw ArgumentMismatch(op->single_name() + ": " + std::to_string(num) + " required " +
+                                       op->get_type_name() + " missing");
             }
         }
 
@@ -1490,8 +1485,8 @@ class App {
                 args.pop_back();
             }
             if(num > 0) {
-                throw RequiredError(op->single_name() + ": " + std::to_string(num) + " required " +
-                                    op->get_type_name() + " missing");
+                throw ArgumentMismatch(op->single_name() + ": " + std::to_string(num) + " required " +
+                                       op->get_type_name() + " missing");
             }
         }
         return;

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1371,10 +1371,10 @@ class App {
         }
 
         // Unlimited vector parser
-        if(num == -1) {
-            bool already_ate_one = false; // Make sure we always eat one
+        if(num < 0) {
+            int collected = 0; // Make sure we always eat the minimum
             while(!args.empty() && _recognize(args.back()) == detail::Classifer::NONE) {
-                if(already_ate_one) {
+                if(collected >= -num) {
                     // We could break here for allow extras, but we don't
 
                     // If any positionals remain, don't keep eating
@@ -1390,8 +1390,11 @@ class App {
                 op->add_result(args.back());
                 parse_order_.push_back(op.get());
                 args.pop_back();
-                already_ate_one = true;
+                collected++;
             }
+            //if(collected < -num)
+            //    throw ArgumentMismatch(op->single_name() + ": At least " + std::to_string(-num) + " required");
+            
         } else {
             while(num > 0 && !args.empty()) {
                 num--;
@@ -1453,11 +1456,11 @@ class App {
         } else if(num == 0) {
             op->add_result("");
             parse_order_.push_back(op.get());
-        } else if(num == -1) {
+        } else if(num < 0) {
             // Unlimited vector parser
-            bool already_ate_one = false; // Make sure we always eat one
+            int collected = 0; // Make sure we always eat the minimum
             while(!args.empty() && _recognize(args.back()) == detail::Classifer::NONE) {
-                if(already_ate_one) {
+                if(collected >= -num) {
                     // We could break here for allow extras, but we don't
 
                     // If any positionals remain, don't keep eating
@@ -1473,8 +1476,10 @@ class App {
                 op->add_result(args.back());
                 parse_order_.push_back(op.get());
                 args.pop_back();
-                already_ate_one = true;
+                collected++;
             }
+            //if(collected < -num)
+            //    throw ArgumentMismatch(op->single_name() + ": At least " + std::to_string(-num) + " required");
         } else {
             while(num > 0 && !args.empty()) {
                 num--;

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1370,7 +1370,6 @@ class App {
 
         int num = op->get_expected();
 
-        /// ONE ///////////////////////////////////////////////////////////////
         if(!value.empty()) {
             if(num != -1)
                 num--;
@@ -1409,8 +1408,8 @@ class App {
                 args.pop_back();
                 collected++;
             }
-            // if(collected < -num)
-            //    throw ArgumentMismatch(op->single_name() + ": At least " + std::to_string(-num) + " required");
+            if(op->results_.size() < static_cast<size_t>(-num))
+                throw ArgumentMismatch(op->single_name() + ": At least " + std::to_string(-num) + " required");
 
         } else {
             while(num > 0 && !args.empty()) {

--- a/include/CLI/CLI.hpp
+++ b/include/CLI/CLI.hpp
@@ -6,11 +6,11 @@
 // CLI Library includes
 // Order is important for combiner script
 
+#include "CLI/StringTools.hpp"
+
 #include "CLI/Error.hpp"
 
 #include "CLI/TypeTools.hpp"
-
-#include "CLI/StringTools.hpp"
 
 #include "CLI/Split.hpp"
 

--- a/include/CLI/CLI.hpp
+++ b/include/CLI/CLI.hpp
@@ -7,10 +7,17 @@
 // Order is important for combiner script
 
 #include "CLI/Error.hpp"
+
 #include "CLI/TypeTools.hpp"
+
 #include "CLI/StringTools.hpp"
+
 #include "CLI/Split.hpp"
+
 #include "CLI/Ini.hpp"
+
 #include "CLI/Validators.hpp"
+
 #include "CLI/Option.hpp"
+
 #include "CLI/App.hpp"

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -183,8 +183,8 @@ class ExcludesError : public ParseError {
 class ExtrasError : public ParseError {
     CLI11_ERROR_DEF(ParseError, ExtrasError)
     ExtrasError(std::vector<std::string> args)
-        : ExtrasError((args.size() > 1 ? "The following argument was not expected: "
-                                       : "The following arguments were not expected: ") +
+        : ExtrasError((args.size() > 1 ? "The following arguments were not expected: "
+                                       : "The following argument was not expected: ") +
                           detail::rjoin(args, " "),
                       ExitCodes::ExtrasError) {}
 };

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -8,6 +8,9 @@
 #include <string>
 #include <utility>
 
+// CLI library includes
+#include "CLI/StringTools.hpp"
+
 namespace CLI {
 
 // Use one of these on all error classes
@@ -179,19 +182,25 @@ class ExcludesError : public ParseError {
 /// Thrown when too many positionals or options are found
 class ExtrasError : public ParseError {
     CLI11_ERROR_DEF(ParseError, ExtrasError)
-    CLI11_ERROR_SIMPLE(ExtrasError)
+    ExtrasError(std::vector<std::string> args)
+        : ExtrasError((args.size() > 1 ? "The following argument was not expected: "
+                                       : "The following arguments were not expected: ") +
+                          detail::rjoin(args, " "),
+                      ExitCodes::ExtrasError) {}
 };
 
 /// Thrown when extra values are found in an INI file
 class ExtrasINIError : public ParseError {
     CLI11_ERROR_DEF(ParseError, ExtrasINIError)
-    CLI11_ERROR_SIMPLE(ExtrasINIError)
+    ExtrasINIError(std::string item) : ExtrasINIError("INI was not able to parse " + item, ExitCodes::ExtrasINIError) {}
 };
 
 /// Thrown when validation fails before parsing
 class InvalidError : public ParseError {
     CLI11_ERROR_DEF(ParseError, InvalidError)
-    CLI11_ERROR_SIMPLE(InvalidError)
+    InvalidError(std::string name)
+        : InvalidError(name + ": Too many positional arguments with unlimited expected args", ExitCodes::InvalidError) {
+    }
 };
 
 /// This is just a safety check to verify selection and parsing match - you should not ever see it
@@ -205,7 +214,7 @@ class HorribleError : public ParseError {
 /// Thrown when counting a non-existent option
 class OptionNotFound : public Error {
     CLI11_ERROR_DEF(Error, OptionNotFound)
-    CLI11_ERROR_SIMPLE(OptionNotFound)
+    OptionNotFound(std::string name) : OptionNotFound(name + " not found", ExitCodes::OptionNotFound) {}
 };
 
 /// @}

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -126,19 +126,22 @@ class RuntimeError : public ParseError {
 /// Thrown when parsing an INI file and it is missing
 class FileError : public ParseError {
     CLI11_ERROR_DEF(ParseError, FileError)
-    FileError(std::string msg) : FileError(msg, ExitCodes::File) {}
+    FileError(std::string name) : FileError(name + " was not readable (missing?)", ExitCodes::File) {}
 };
 
 /// Thrown when conversion call back fails, such as when an int fails to coerce to a string
 class ConversionError : public ParseError {
     CLI11_ERROR_DEF(ParseError, ConversionError)
     CLI11_ERROR_SIMPLE(ConversionError)
+    ConversionError(std::string member, std::string name)
+        : ConversionError("The value " + member + "is not an allowed value for " + name) {}
 };
 
 /// Thrown when validation of results fails
 class ValidationError : public ParseError {
     CLI11_ERROR_DEF(ParseError, ValidationError)
     CLI11_ERROR_SIMPLE(ValidationError)
+    ValidationError(std::string name, std::string msg) : ValidationError(name + ": " + msg) {}
 };
 
 /// Thrown when a required option is missing
@@ -150,6 +153,7 @@ class RequiredError : public ParseError {
 /// Thrown when the wrong number of arguments has been recieved
 class ArgumentMismatch : ParseError {
     CLI11_ERROR_DEF(ParseError, ArgumentMismatch)
+    CLI11_ERROR_SIMPLE(ArgumentMismatch)
     ArgumentMismatch(std::string name, int expected, size_t recieved)
         : ArgumentMismatch(expected > 0 ? ("Expected exactly " + std::to_string(expected) + " arguments to " + name +
                                            ", got " + std::to_string(recieved))

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -43,6 +43,7 @@ enum class ExitCodes {
     InvalidError,
     HorribleError,
     OptionNotFound,
+    ArgumentMismatch,
     BaseClass = 127
 };
 
@@ -144,6 +145,17 @@ class ValidationError : public ParseError {
 class RequiredError : public ParseError {
     CLI11_ERROR_DEF(ParseError, RequiredError)
     CLI11_ERROR_SIMPLE(RequiredError)
+};
+
+/// Thrown when the wrong number of arguments has been recieved
+class ArgumentMismatch : ParseError {
+    CLI11_ERROR_DEF(ParseError, ArgumentMismatch)
+    ArgumentMismatch(std::string name, int expected, size_t recieved)
+        : ArgumentMismatch(expected > 0 ? ("Expected exactly " + std::to_string(expected) + " arguments to " + name +
+                                           ", got " + std::to_string(recieved))
+                                        : ("Expected at least " + std::to_string(-expected) + " arguments to " + name +
+                                           ", got " + std::to_string(recieved)),
+                           ExitCodes::ArgumentMismatch) {}
 };
 
 /// Thrown when a requires option is missing

--- a/include/CLI/Ini.hpp
+++ b/include/CLI/Ini.hpp
@@ -106,7 +106,7 @@ inline std::vector<ini_ret_t> parse_ini(const std::string &name) {
 
     std::ifstream input{name};
     if(!input.good())
-        throw FileError(name + " was not readable (missing?)");
+        throw FileError(name);
 
     return parse_ini(input);
 }

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -438,7 +438,7 @@ class Option : public OptionBase<Option> {
                 for(const std::function<std::string(std::string &)> &vali : validators_) {
                     std::string err_msg = vali(result);
                     if(!err_msg.empty())
-                        throw ValidationError(single_name() + ": " + err_msg);
+                        throw ValidationError(single_name(), err_msg);
                 }
         }
 

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -8,6 +8,7 @@
 #include <locale>
 #include <sstream>
 #include <string>
+#include <vector>
 #include <type_traits>
 
 namespace CLI {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -235,12 +235,27 @@ TEST_F(TApp, MissingValueNonRequiredOpt) {
     app.add_option("-c,--count", count);
 
     args = {"-c"};
-    EXPECT_ANY_THROW(run());
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 
     app.reset();
 
     args = {"--count"};
-    EXPECT_ANY_THROW(run());
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, MissingValueMoreThan) {
+    std::vector<int> vals1;
+    std::vector<int> vals2;
+    app.add_option("-v", vals1)->expected(-2);
+    app.add_option("--vals", vals2)->expected(-2);
+    
+    args = {"-v", "2"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+    
+    app.reset();
+    
+    args = {"--vals","4"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
 TEST_F(TApp, NotRequiredOptsSingle) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -338,7 +338,7 @@ TEST_F(TApp, RequiredOptsUnlimited) {
     app.add_option("--str", strs)->required();
 
     args = {"--str"};
-    EXPECT_THROW(run(), CLI::RequiredError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 
     app.reset();
     args = {"--str", "one", "--str", "two"};
@@ -372,7 +372,7 @@ TEST_F(TApp, RequiredOptsUnlimitedShort) {
     app.add_option("-s", strs)->required();
 
     args = {"-s"};
-    EXPECT_THROW(run(), CLI::RequiredError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 
     app.reset();
     args = {"-s", "one", "-s", "two"};

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -325,9 +325,32 @@ TEST_F(TApp, RequiredOptsDoubleShort) {
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
 
     app.reset();
+
+    args = {"-s", "one", "-s", "one", "-s", "one"};
+
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, RequiredOptsDoubleNeg) {
+    std::vector<std::string> strs;
+    app.add_option("-s", strs)->required()->expected(-2);
+
+    args = {"-s", "one"};
+
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+
+    app.reset();
+
+    args = {"-s", "one", "two", "-s", "three"};
+
+    EXPECT_NO_THROW(run());
+
+    EXPECT_EQ(strs, std::vector<std::string>({"one", "two", "three"}));
+
+    app.reset();
     args = {"-s", "one", "two"};
 
-    run();
+    EXPECT_NO_THROW(run());
 
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
 }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -248,13 +248,13 @@ TEST_F(TApp, MissingValueMoreThan) {
     std::vector<int> vals2;
     app.add_option("-v", vals1)->expected(-2);
     app.add_option("--vals", vals2)->expected(-2);
-    
+
     args = {"-v", "2"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-    
+
     app.reset();
-    
-    args = {"--vals","4"};
+
+    args = {"--vals", "4"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
@@ -1173,14 +1173,14 @@ TEST_F(TApp, AllowExtrasOrder) {
 TEST_F(TApp, CheckShortFail) {
     args = {"--two"};
 
-    EXPECT_THROW(CLI::detail::AppFriend::parse_short(&app, args), CLI::HorribleError);
+    EXPECT_THROW(CLI::detail::AppFriend::parse_arg(&app, args, false), CLI::HorribleError);
 }
 
 // Test horrible error
 TEST_F(TApp, CheckLongFail) {
     args = {"-t"};
 
-    EXPECT_THROW(CLI::detail::AppFriend::parse_long(&app, args), CLI::HorribleError);
+    EXPECT_THROW(CLI::detail::AppFriend::parse_arg(&app, args, true), CLI::HorribleError);
 }
 
 // Test horrible error

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -243,6 +243,26 @@ TEST_F(TApp, MissingValueNonRequiredOpt) {
     EXPECT_ANY_THROW(run());
 }
 
+TEST_F(TApp, NotRequiredOptsSingle) {
+
+    std::string str;
+    app.add_option("--str", str);
+
+    args = {"--str"};
+
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, NotRequiredOptsSingleShort) {
+
+    std::string str;
+    app.add_option("-s", str);
+
+    args = {"-s"};
+
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
 TEST_F(TApp, RequiredOptsSingle) {
 
     std::string str;
@@ -250,7 +270,7 @@ TEST_F(TApp, RequiredOptsSingle) {
 
     args = {"--str"};
 
-    EXPECT_THROW(run(), CLI::RequiredError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
 TEST_F(TApp, RequiredOptsSingleShort) {
@@ -260,7 +280,7 @@ TEST_F(TApp, RequiredOptsSingleShort) {
 
     args = {"-s"};
 
-    EXPECT_THROW(run(), CLI::RequiredError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
 TEST_F(TApp, RequiredOptsDouble) {
@@ -270,7 +290,7 @@ TEST_F(TApp, RequiredOptsDouble) {
 
     args = {"--str", "one"};
 
-    EXPECT_THROW(run(), CLI::RequiredError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 
     app.reset();
     args = {"--str", "one", "two"};
@@ -287,7 +307,7 @@ TEST_F(TApp, RequiredOptsDoubleShort) {
 
     args = {"-s", "one"};
 
-    EXPECT_THROW(run(), CLI::RequiredError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 
     app.reset();
     args = {"-s", "one", "two"};
@@ -414,7 +434,17 @@ TEST_F(TApp, NotRequiedExpectedDouble) {
 
     args = {"--str", "one"};
 
-    EXPECT_THROW(run(), CLI::RequiredError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, NotRequiedExpectedDoubleShort) {
+
+    std::vector<std::string> strs;
+    app.add_option("-s", strs)->expected(2);
+
+    args = {"-s", "one"};
+
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
 TEST_F(TApp, EnumTest) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -119,7 +119,7 @@ TEST_F(TApp, DualOptions) {
     EXPECT_EQ(ans, vstr);
 
     args = {"--string=one", "--string=two"};
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
 TEST_F(TApp, LotsOfFlags) {
@@ -737,7 +737,7 @@ TEST_F(TApp, FailSet) {
     app.add_set("-q,--quick", choice, {1, 2, 3});
 
     args = {"--quick", "3", "--quick=2"};
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 
     app.reset();
 
@@ -770,7 +770,7 @@ TEST_F(TApp, InSetIgnoreCase) {
 
     app.reset();
     args = {"--quick=one", "--quick=two"};
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
 TEST_F(TApp, VectorFixedString) {
@@ -1145,27 +1145,24 @@ TEST_F(TApp, CheckSubcomFail) {
     EXPECT_THROW(CLI::detail::AppFriend::parse_subcommand(&app, args), CLI::HorribleError);
 }
 
-// Added to test defaults on dual method
 TEST_F(TApp, OptionWithDefaults) {
     int someint = 2;
     app.add_option("-a", someint, "", true);
 
     args = {"-a1", "-a2"};
 
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
-// Added to test defaults on dual method
 TEST_F(TApp, SetWithDefaults) {
     int someint = 2;
     app.add_set("-a", someint, {1, 2, 3, 4}, "", true);
 
     args = {"-a1", "-a2"};
 
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
-// Added to test defaults on dual method
 TEST_F(TApp, SetWithDefaultsConversion) {
     int someint = 2;
     app.add_set("-a", someint, {1, 2, 3, 4}, "", true);
@@ -1175,14 +1172,13 @@ TEST_F(TApp, SetWithDefaultsConversion) {
     EXPECT_THROW(run(), CLI::ConversionError);
 }
 
-// Added to test defaults on dual method
 TEST_F(TApp, SetWithDefaultsIC) {
     std::string someint = "ho";
     app.add_set_ignore_case("-a", someint, {"Hi", "Ho"}, "", true);
 
     args = {"-aHi", "-aHo"};
 
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
 // Added to test ->transform

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -125,13 +125,16 @@ TEST_F(TApp, IncorrectConstructionFlagPositional3) {
 
 TEST_F(TApp, IncorrectConstructionFlagExpected) {
     auto cat = app.add_flag("--cat");
+    EXPECT_NO_THROW(cat->expected(0));
     EXPECT_THROW(cat->expected(1), CLI::IncorrectConstruction);
 }
 
 TEST_F(TApp, IncorrectConstructionOptionAsFlag) {
     int x;
     auto cat = app.add_option("--cat", x);
+    EXPECT_NO_THROW(cat->expected(1));
     EXPECT_THROW(cat->expected(0), CLI::IncorrectConstruction);
+    EXPECT_THROW(cat->expected(2), CLI::IncorrectConstruction);
 }
 
 TEST_F(TApp, IncorrectConstructionOptionAsVector) {

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -395,7 +395,7 @@ TEST(Exit, ExitCodes) {
     auto i = static_cast<int>(CLI::ExitCodes::ExtrasError);
     EXPECT_EQ(0, app.exit(CLI::Success()));
     EXPECT_EQ(0, app.exit(CLI::CallForHelp()));
-    EXPECT_EQ(i, app.exit(CLI::ExtrasError("Thing")));
+    EXPECT_EQ(i, app.exit(CLI::ExtrasError({"Thing"})));
     EXPECT_EQ(42, app.exit(CLI::RuntimeError(42)));
     EXPECT_EQ(1, app.exit(CLI::RuntimeError())); // Not sure if a default here is a good thing
 }
@@ -432,7 +432,7 @@ TEST_F(CapturedHelp, CallForHelp) {
 }
 
 TEST_F(CapturedHelp, NormalError) {
-    EXPECT_EQ(run(CLI::ExtrasError("Thing")), static_cast<int>(CLI::ExitCodes::ExtrasError));
+    EXPECT_EQ(run(CLI::ExtrasError({"Thing"})), static_cast<int>(CLI::ExitCodes::ExtrasError));
     EXPECT_EQ(out.str(), "");
     EXPECT_THAT(err.str(), HasSubstr("for more information"));
     EXPECT_THAT(err.str(), Not(HasSubstr("ExtrasError")));
@@ -443,7 +443,7 @@ TEST_F(CapturedHelp, NormalError) {
 TEST_F(CapturedHelp, RepacedError) {
     app.set_failure_message(CLI::FailureMessage::help);
 
-    EXPECT_EQ(run(CLI::ExtrasError("Thing")), static_cast<int>(CLI::ExitCodes::ExtrasError));
+    EXPECT_EQ(run(CLI::ExtrasError({"Thing"})), static_cast<int>(CLI::ExitCodes::ExtrasError));
     EXPECT_EQ(out.str(), "");
     EXPECT_THAT(err.str(), Not(HasSubstr("for more information")));
     EXPECT_THAT(err.str(), HasSubstr("ERROR: ExtrasError"));

--- a/tests/NewParseTest.cpp
+++ b/tests/NewParseTest.cpp
@@ -91,5 +91,5 @@ TEST_F(TApp, BuiltinComplexFail) {
 
     args = {"-c", "4"};
 
-    EXPECT_THROW(run(), CLI::RequiredError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }


### PR DESCRIPTION
This cleans up Error throwing in several cases.

* Requiring N values now throws an `ArgumentMismatch` if that number was not received (changes old error in some cases, finally correctly throws an error in the 0 received for 1 case)
* Options automatically lock if given an exact number of arguments when configured
* At least -N values required when N is negative (need to add test)
* Text processing moved to Error.h in many cases (parse related so far)

This also unifies the old `_parse_short` and `_parse_long` into a single function, `_parse_arg`, reducing a lot of redundancy. 