### PR TITLE
Policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `remaining()` and `remaining_size()` [#37](https://github.com/CLIUtils/CLI11/pull/37)
 * `allow_extras` and `prefix_command` are now valid on subcommands [#37](https://github.com/CLIUtils/CLI11/pull/37)
 * Added `take_last` to only take last value passed [#40](https://github.com/CLIUtils/CLI11/pull/40)
+* Added `multi_option_policy` and shortcuts to provide more control than just a take last policy [#59](https://github.com/CLIUtils/CLI11/pull/59)
 * More detailed error messages in a few cases [#41](https://github.com/CLIUtils/CLI11/pull/41)
 * Footers can be added to help [#42](https://github.com/CLIUtils/CLI11/pull/42)
 * Help flags are easier to customize [#43](https://github.com/CLIUtils/CLI11/pull/43)

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The add commands return a pointer to an internally stored `Option`. If you set t
 * `->envname(name)`: Gets the value from the environment if present and not passed on the command line.
 * `->group(name)`: The help group to put the option in. No effect for positional options. Defaults to `"Options"`. `""` will not show up in the help print (hidden).
 * `->ignore_case()`: Ignore the case on the command line (also works on subcommands, does not affect arguments).
-* `->take_last()`: Only take the last option/flag given on the command line, automatically true for bool flags
+* `->multi_option_policy(CLI::MultiOptionPolicy::Throw)`: Set the multi-option policy. Shortcuts available: `->take_last()`, `->take_first()`, and `->join()`. This will only affect options expecting 1 argument or bool flags (which always default to take last).
 * `->check(CLI::ExistingFile)`: Requires that the file exists if given.
 * `->check(CLI::ExistingDirectory)`: Requires that the directory exists.
 * `->check(CLI::NonexistentPath)`: Requires that the path does not exist.
@@ -266,7 +266,7 @@ arguments, use `.config_to_str(default_also=false)`, where `default_also` will a
 
 Many of the defaults for subcommands and even options are inherited from their creators. The inherited default values for subcommands are `allow_extras`, `prefix_command`, `ignore_case`, `fallthrough`, `group`, `footer`, and maximum number of required subcommands. The help flag existence, name, and description are inherited, as well.
 
-Options have defaults for `group`, `required`, `take_last`, and `ignore_case`. To set these defaults, you should set the `option_defaults()` object, for example:
+Options have defaults for `group`, `required`, `multi_option_policy`, and `ignore_case`. To set these defaults, you should set the `option_defaults()` object, for example:
 
 ```cpp
 app.option_defaults()->required();

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -394,7 +394,8 @@ class App {
         return opt;
     }
 
-    /// Bool version - defaults to allowing multiple passings, but can be forced to one if `take_last(false)` is used.
+    /// Bool version - defaults to allowing multiple passings, but can be forced to one if
+    /// `multi_option_policy(CLI::MultiOptionPolicy::Throw)` is used.
     template <typename T, enable_if_t<is_bool<T>::value, detail::enabler> = detail::dummy>
     Option *add_flag(std::string name,
                      T &count, ///< A variable holding true if passed
@@ -410,7 +411,7 @@ class App {
         if(opt->get_positional())
             throw IncorrectConstruction("Flags cannot be positional");
         opt->set_custom_option("", 0);
-        opt->take_last();
+        opt->multi_option_policy(CLI::MultiOptionPolicy::TakeLast);
         return opt;
     }
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -83,6 +83,29 @@ template <typename CRTP> class OptionBase {
 
     /// The status of the multi option policy
     MultiOptionPolicy get_multi_option_policy() const { return multi_option_policy_; }
+
+    // Shortcuts for multi option policy
+
+    /// Set the multi option policy to take last
+    CRTP *take_last() {
+        CRTP *self = static_cast<CRTP *>(this);
+        self->multi_option_policy(MultiOptionPolicy::TakeLast);
+        return self;
+    }
+
+    /// Set the multi option policy to take last
+    CRTP *take_first() {
+        CRTP *self = static_cast<CRTP *>(this);
+        self->multi_option_policy(MultiOptionPolicy::TakeFirst);
+        return self;
+    }
+
+    /// Set the multi option policy to take last
+    CRTP *join() {
+        CRTP *self = static_cast<CRTP *>(this);
+        self->multi_option_policy(MultiOptionPolicy::Join);
+        return self;
+    }
 };
 
 class OptionDefaults : public OptionBase<OptionDefaults> {
@@ -92,7 +115,7 @@ class OptionDefaults : public OptionBase<OptionDefaults> {
     // Methods here need a different implementation if they are Option vs. OptionDefault
 
     /// Take the last argument if given multiple times
-    OptionDefaults *multi_option_policy(MultiOptionPolicy value) {
+    OptionDefaults *multi_option_policy(MultiOptionPolicy value = MultiOptionPolicy::Throw) {
         multi_option_policy_ = value;
         return this;
     }
@@ -307,7 +330,7 @@ class Option : public OptionBase<Option> {
     }
 
     /// Take the last argument if given multiple times
-    Option *multi_option_policy(MultiOptionPolicy value) {
+    Option *multi_option_policy(MultiOptionPolicy value = MultiOptionPolicy::Throw) {
         if(get_expected() != 0 && get_expected() != 1)
             throw IncorrectConstruction("multi_option_policy only works for flags and single value options!");
         multi_option_policy_ = value;

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -169,7 +169,7 @@ TEST_F(TApp, BoolAndIntFlags) {
 
 TEST_F(TApp, BoolOnlyFlag) {
     bool bflag;
-    app.add_flag("-b", bflag)->take_last(false);
+    app.add_flag("-b", bflag)->multi_option_policy(CLI::MultiOptionPolicy::Throw);
 
     args = {"-b"};
     EXPECT_NO_THROW(run());
@@ -221,13 +221,37 @@ TEST_F(TApp, DefaultOpts) {
 TEST_F(TApp, TakeLastOpt) {
 
     std::string str;
-    app.add_option("--str", str)->take_last();
+    app.add_option("--str", str)->multi_option_policy(CLI::MultiOptionPolicy::TakeLast);
 
     args = {"--str=one", "--str=two"};
 
     run();
 
     EXPECT_EQ(str, "two");
+}
+
+TEST_F(TApp, TakeFirstOpt) {
+
+    std::string str;
+    app.add_option("--str", str)->multi_option_policy(CLI::MultiOptionPolicy::TakeFirst);
+
+    args = {"--str=one", "--str=two"};
+
+    run();
+
+    EXPECT_EQ(str, "one");
+}
+
+TEST_F(TApp, JoinOpt) {
+
+    std::string str;
+    app.add_option("--str", str)->multi_option_policy(CLI::MultiOptionPolicy::Join);
+
+    args = {"--str=one", "--str=two"};
+
+    run();
+
+    EXPECT_EQ(str, "one\ntwo");
 }
 
 TEST_F(TApp, MissingValueNonRequiredOpt) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -230,6 +230,18 @@ TEST_F(TApp, TakeLastOpt) {
     EXPECT_EQ(str, "two");
 }
 
+TEST_F(TApp, TakeLastOpt2) {
+
+    std::string str;
+    app.add_option("--str", str)->take_last();
+
+    args = {"--str=one", "--str=two"};
+
+    run();
+
+    EXPECT_EQ(str, "two");
+}
+
 TEST_F(TApp, TakeFirstOpt) {
 
     std::string str;
@@ -242,10 +254,34 @@ TEST_F(TApp, TakeFirstOpt) {
     EXPECT_EQ(str, "one");
 }
 
+TEST_F(TApp, TakeFirstOpt2) {
+
+    std::string str;
+    app.add_option("--str", str)->take_first();
+
+    args = {"--str=one", "--str=two"};
+
+    run();
+
+    EXPECT_EQ(str, "one");
+}
+
 TEST_F(TApp, JoinOpt) {
 
     std::string str;
     app.add_option("--str", str)->multi_option_policy(CLI::MultiOptionPolicy::Join);
+
+    args = {"--str=one", "--str=two"};
+
+    run();
+
+    EXPECT_EQ(str, "one\ntwo");
+}
+
+TEST_F(TApp, JoinOpt2) {
+
+    std::string str;
+    app.add_option("--str", str)->join();
 
     args = {"--str=one", "--str=two"};
 

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -152,14 +152,14 @@ TEST_F(TApp, IncorrectConstructionVectorAsFlag) {
 TEST_F(TApp, IncorrectConstructionVectorTakeLast) {
     std::vector<int> vec;
     auto cat = app.add_option("--vec", vec);
-    EXPECT_THROW(cat->take_last(), CLI::IncorrectConstruction);
+    EXPECT_THROW(cat->multi_option_policy(CLI::MultiOptionPolicy::TakeLast), CLI::IncorrectConstruction);
 }
 
 TEST_F(TApp, IncorrectConstructionTakeLastExpected) {
     std::vector<int> vec;
     auto cat = app.add_option("--vec", vec);
     cat->expected(1);
-    ASSERT_NO_THROW(cat->take_last());
+    ASSERT_NO_THROW(cat->multi_option_policy(CLI::MultiOptionPolicy::TakeLast));
     EXPECT_THROW(cat->expected(2), CLI::IncorrectConstruction);
 }
 
@@ -301,16 +301,20 @@ TEST_F(TApp, OptionFromDefaults) {
 TEST_F(TApp, OptionFromDefaultsSubcommands) {
     // Initial defaults
     EXPECT_FALSE(app.option_defaults()->get_required());
-    EXPECT_FALSE(app.option_defaults()->get_take_last());
+    EXPECT_EQ(app.option_defaults()->get_multi_option_policy(), CLI::MultiOptionPolicy::Throw);
     EXPECT_FALSE(app.option_defaults()->get_ignore_case());
     EXPECT_EQ(app.option_defaults()->get_group(), "Options");
 
-    app.option_defaults()->required()->take_last()->ignore_case()->group("Something");
+    app.option_defaults()
+        ->required()
+        ->multi_option_policy(CLI::MultiOptionPolicy::TakeLast)
+        ->ignore_case()
+        ->group("Something");
 
     auto app2 = app.add_subcommand("app2");
 
     EXPECT_TRUE(app2->option_defaults()->get_required());
-    EXPECT_TRUE(app2->option_defaults()->get_take_last());
+    EXPECT_EQ(app2->option_defaults()->get_multi_option_policy(), CLI::MultiOptionPolicy::TakeLast);
     EXPECT_TRUE(app2->option_defaults()->get_ignore_case());
     EXPECT_EQ(app2->option_defaults()->get_group(), "Something");
 }


### PR DESCRIPTION
This adds explicit policies for what to do with multiple options passed. The default is to throw if an argument is passed multiple times, but `take_last`, `take_first`, and `join` are all available. Take last is common in many apps. `join` is used (*) for `git commit -m "one" -m "two"`.

* Join in the git case uses two newlines instead of one like CLI11. You can always use `expected(-1)` and join them yourself afterwards, so custom join strings were not added.

Also, AppVeyor now is required to pass before merging, as well.

See #39 and #38. Also #48. This should behave just like the original fix, with the exception that `get_take_last` is no longer available and you cannot give an argument to `take_last`. `MultiOptionPolicy::Throw` remains the default (see #58), but you only have to set this once before setting up your app options and subcommands:

```cpp
app.option_defaults()->take_last();
```