### PR TITLE
Moving error messages definitions to Error.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * Added `CLI::ArgumentMismatch` [#56](https://github.com/CLIUtils/CLI11/pull/56) and fixed missing failure if one arg expected [#55](https://github.com/CLIUtils/CLI11/issues/55)
 * Support for minimum unlimited expected arguments [#56](https://github.com/CLIUtils/CLI11/pull/56)
 * Single internal arg parse function [#56](https://github.com/CLIUtils/CLI11/pull/56)
-* Allow options to be disabled from INI file [#60](https://github.com/CLIUtils/CLI11/pull/60)
+* Allow options to be disabled from INI file, rename `add_config` to `set_config` [#60](https://github.com/CLIUtils/CLI11/pull/60)
 
 ## Version 1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Added `CLI::ArgumentMismatch` [#56](https://github.com/CLIUtils/CLI11/pull/56) and fixed missing failure if one arg expected [#55](https://github.com/CLIUtils/CLI11/issues/55)
 * Support for minimum unlimited expected arguments [#56](https://github.com/CLIUtils/CLI11/pull/56)
 * Single internal arg parse function [#56](https://github.com/CLIUtils/CLI11/pull/56)
+* Allow options to be disabled from INI file [#60](https://github.com/CLIUtils/CLI11/pull/60)
 
 ## Version 1.2
 

--- a/README.md
+++ b/README.md
@@ -238,13 +238,13 @@ There are several options that are supported on the main app and subcommands. Th
 ## Configuration file
 
 ```cpp
-app.add_config(option_name,
+app.set_config(option_name="",
                default_file_name="",
                help_string="Read an ini file",
                required=false)
 ```
 
-Adding a configuration option is special. If it is present, it will be read along with the normal command line arguments. The file will be read if it exists, and does not throw an error unless `required` is `true`. Configuration files are in `ini` format. An example of a file:
+If this is called with no arguments, it will remove the configuration file option (like `set_help_flag`). Setting a configuration option is special. If it is present, it will be read along with the normal command line arguments. The file will be read if it exists, and does not throw an error unless `required` is `true`. Configuration files are in `ini` format. An example of a file:
 
 ```ini
 ; Commments are supported, using a ;

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The add commands return a pointer to an internally stored `Option`. If you set t
 * `->check(CLI::NonexistentPath)`: Requires that the path does not exist.
 * `->check(CLI::Range(min,max))`: Requires that the option be between min and max (make sure to use floating point if needed). Min defaults to 0.
 * `->transform(std::string(std::string))`: Converts the input string into the output string, in-place in the parsed options.
+* `->configurable(false)`: Disable this option from being in an ini configuration file.
 
 These options return the `Option` pointer, so you can chain them together, and even skip storing the pointer entirely. Check takes any function that has the signature `void(const std::string&)`; it should throw a `ValidationError` when validation fails. The help message will have the name of the parent option prepended. Since `check` and `transform` use the same underlying mechanism, you can chain as many as you want, and they will be executed in order. If you just want to see the unconverted values, use `.results()` to get the `std::vector<std::string>` of results.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![License: BSD][license-badge]](./LICENSE)
 [![DOI][DOI-badge]][DOI-link]
 
-[API Docs][api-docs] • [Tutorial series][GitBook] • [What's new](./CHANGELOG.md)
+[Documentation][GitBook] •
+[API Reference][api-docs] •
+[What's new](./CHANGELOG.md)
 
 # CLI11: Command line parser for C++11
 

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -578,8 +578,8 @@ class App {
         return opt;
     }
 
-    /// Add a configuration ini file option
-    Option *add_config(std::string name = "--config",
+    /// Set a configuration ini file option, or clear it if no name passed
+    Option *set_config(std::string name = "",
                        std::string default_filename = "",
                        std::string help = "Read an ini file",
                        bool required = false) {
@@ -587,9 +587,14 @@ class App {
         // Remove existing config if present
         if(config_ptr_ != nullptr)
             remove_option(config_ptr_);
-        config_name_ = default_filename;
-        config_required_ = required;
-        config_ptr_ = add_option(name, config_name_, help, !default_filename.empty());
+
+        // Only add config if option passed
+        if(name) {
+            config_name_ = default_filename;
+            config_required_ = required;
+            config_ptr_ = add_option(name, config_name_, help, !default_filename.empty());
+        }
+
         return config_ptr_;
     }
 

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1209,7 +1209,7 @@ class App {
 
         if(!op->get_configurable())
             throw INIError::NotConfigurable(current.fullname);
-        
+
         if(op->results_.empty()) {
             // Flag parsing
             if(op->get_expected() == 0) {

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -589,7 +589,7 @@ class App {
             remove_option(config_ptr_);
 
         // Only add config if option passed
-        if(name) {
+        if(!name.empty()) {
             config_name_ = default_filename;
             config_required_ = required;
             config_ptr_ = add_option(name, config_name_, help, !default_filename.empty());

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -86,30 +86,32 @@ class IncorrectConstruction : public ConstructionError {
     CLI11_ERROR_DEF(ConstructionError, IncorrectConstruction)
     CLI11_ERROR_SIMPLE(IncorrectConstruction)
     static IncorrectConstruction PositionalFlag(std::string name) {
-        return IncorrectConstruction(name + ": Flags cannot be positional");}
+        return IncorrectConstruction(name + ": Flags cannot be positional");
+    }
     static IncorrectConstruction Set0Opt(std::string name) {
-        return IncorrectConstruction(name + ": Cannot set 0 expected, use a flag instead");}
+        return IncorrectConstruction(name + ": Cannot set 0 expected, use a flag instead");
+    }
     static IncorrectConstruction ChangeNotVector(std::string name) {
-        return IncorrectConstruction(name + ": You can only change the expected arguments for vectors");}
+        return IncorrectConstruction(name + ": You can only change the expected arguments for vectors");
+    }
     static IncorrectConstruction AfterMultiOpt(std::string name) {
-        return IncorrectConstruction(name + ": You can't change expected arguments after you've changed the multi option policy!");}
+        return IncorrectConstruction(
+            name + ": You can't change expected arguments after you've changed the multi option policy!");
+    }
     static IncorrectConstruction MissingOption(std::string name) {
-        return IncorrectConstruction("Option " + name + " is not defined");}
+        return IncorrectConstruction("Option " + name + " is not defined");
+    }
     static IncorrectConstruction MultiOptionPolicy(std::string name) {
-        return IncorrectConstruction(name + ": multi_option_policy only works for flags and single value options");}
-
+        return IncorrectConstruction(name + ": multi_option_policy only works for flags and single value options");
+    }
 };
 
 /// Thrown on construction of a bad name
 class BadNameString : public ConstructionError {
     CLI11_ERROR_DEF(ConstructionError, BadNameString)
     CLI11_ERROR_SIMPLE(BadNameString)
-    static BadNameString OneCharName(std::string name) {
-        return BadNameString("Invalid one char name: " + name);
-    }
-    static BadNameString BadLongName(std::string name) {
-        return BadNameString("Bad long name: " + name);
-    }
+    static BadNameString OneCharName(std::string name) { return BadNameString("Invalid one char name: " + name); }
+    static BadNameString BadLongName(std::string name) { return BadNameString("Bad long name: " + name); }
     static BadNameString DashesOnly(std::string name) {
         return BadNameString("Must have a name, not just dashes: " + name);
     }
@@ -162,7 +164,7 @@ class RuntimeError : public ParseError {
 class FileError : public ParseError {
     CLI11_ERROR_DEF(ParseError, FileError)
     CLI11_ERROR_SIMPLE(FileError)
-    static FileError Missing(std::string name) {return FileError(name + " was not readable (missing?)");}
+    static FileError Missing(std::string name) { return FileError(name + " was not readable (missing?)"); }
 };
 
 /// Thrown when conversion call back fails, such as when an int fails to coerce to a string
@@ -174,9 +176,11 @@ class ConversionError : public ParseError {
     ConversionError(std::string name, std::vector<std::string> results)
         : ConversionError("Could not convert: " + name + " = " + detail::join(results)) {}
     static ConversionError TooManyInputsFlag(std::string name) {
-        return ConversionError(name + ": too many inputs for a flag");}
+        return ConversionError(name + ": too many inputs for a flag");
+    }
     static ConversionError TrueFalse(std::string name) {
-        return ConversionError(name + ": Should be true/false or a number");}
+        return ConversionError(name + ": Should be true/false or a number");
+    }
 };
 
 /// Thrown when validation of results fails
@@ -189,15 +193,14 @@ class ValidationError : public ParseError {
 /// Thrown when a required option is missing
 class RequiredError : public ParseError {
     CLI11_ERROR_DEF(ParseError, RequiredError)
-    RequiredError(std::string name) : RequiredError(name + " is required") {}
+    RequiredError(std::string name) : RequiredError(name + " is required", ExitCodes::RequiredError) {}
     static RequiredError Subcommand(size_t min_subcom) {
         if(min_subcom == 1)
             return RequiredError("A subcommand");
         else
-            return RequiredError("Requires at least " + std::to_string(min_subcom) + " subcommands", ExitCodes::RequiredError);
+            return RequiredError("Requires at least " + std::to_string(min_subcom) + " subcommands",
+                                 ExitCodes::RequiredError);
     }
-    
-    
 };
 
 /// Thrown when the wrong number of arguments has been received
@@ -210,13 +213,13 @@ class ArgumentMismatch : public ParseError {
                                         : ("Expected at least " + std::to_string(-expected) + " arguments to " + name +
                                            ", got " + std::to_string(recieved)),
                            ExitCodes::ArgumentMismatch) {}
-    
+
     static ArgumentMismatch AtLeast(std::string name, int num) {
-        return ArgumentMismatch(name + ": At least " + std::to_string(num) + " required");}
+        return ArgumentMismatch(name + ": At least " + std::to_string(num) + " required");
+    }
     static ArgumentMismatch TypedAtLeast(std::string name, int num, std::string type) {
-        return ArgumentMismatch(name + ": " + std::to_string(num) + " required " + type + " missing");}
-    
-    
+        return ArgumentMismatch(name + ": " + std::to_string(num) + " required " + type + " missing");
+    }
 };
 
 /// Thrown when a requires option is missing
@@ -247,9 +250,10 @@ class ExtrasError : public ParseError {
 class INIError : public ParseError {
     CLI11_ERROR_DEF(ParseError, INIError)
     CLI11_ERROR_SIMPLE(INIError)
-    static INIError Extras(std::string item) {return INIError("INI was not able to parse " + item);}
-    static INIError NotConfigurable(std::string item) {return INIError(item + ": This option is not allowed in a configuration file");}
-    
+    static INIError Extras(std::string item) { return INIError("INI was not able to parse " + item); }
+    static INIError NotConfigurable(std::string item) {
+        return INIError(item + ": This option is not allowed in a configuration file");
+    }
 };
 
 /// Thrown when validation fails before parsing

--- a/include/CLI/Ini.hpp
+++ b/include/CLI/Ini.hpp
@@ -106,7 +106,7 @@ inline std::vector<ini_ret_t> parse_ini(const std::string &name) {
 
     std::ifstream input{name};
     if(!input.good())
-        throw FileError(name);
+        throw FileError::Missing(name);
 
     return parse_ini(input);
 }

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -43,15 +43,15 @@ template <typename CRTP> class OptionBase {
 
     /// Allow this option to be given in a configuration file
     bool configurable_{true};
-    
+
     /// Policy for multiple arguments when `expected_ == 1`  (can be set on bool flags, too)
     MultiOptionPolicy multi_option_policy_{MultiOptionPolicy::Throw};
-    
 
     template <typename T> void copy_to(T *other) const {
         other->group(group_);
         other->required(required_);
         other->ignore_case(ignore_case_);
+        other->configurable(configurable_);
         other->multi_option_policy(multi_option_policy_);
     }
 
@@ -84,7 +84,7 @@ template <typename CRTP> class OptionBase {
 
     /// The status of ignore case
     bool get_ignore_case() const { return ignore_case_; }
-    
+
     /// The status of configurable
     bool get_configurable() const { return configurable_; }
 
@@ -113,7 +113,7 @@ template <typename CRTP> class OptionBase {
         self->multi_option_policy(MultiOptionPolicy::Join);
         return self;
     }
-    
+
     /// Allow in a configuration file
     CRTP *configurable(bool value = true) {
         configurable_ = value;

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -66,18 +66,18 @@ get_names(const std::vector<std::string> &input) {
             if(name.length() == 2 && valid_first_char(name[1]))
                 short_names.emplace_back(1, name[1]);
             else
-                throw BadNameString("Invalid one char name: " + name);
+                throw BadNameString::OneCharName(name);
         } else if(name.length() > 2 && name.substr(0, 2) == "--") {
             name = name.substr(2);
             if(valid_name_string(name))
                 long_names.push_back(name);
             else
-                throw BadNameString("Bad long name: " + name);
+                throw BadNameString::BadLongName(name);
         } else if(name == "-" || name == "--") {
-            throw BadNameString("Must have a name, not just dashes");
+            throw BadNameString::DashesOnly(name);
         } else {
             if(pos_name.length() > 0)
-                throw BadNameString("Only one positional name allowed, remove: " + name);
+                throw BadNameString::MultiPositionalNames(name);
             pos_name = name;
         }
     }

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -303,12 +303,14 @@ TEST_F(TApp, OptionFromDefaultsSubcommands) {
     EXPECT_FALSE(app.option_defaults()->get_required());
     EXPECT_EQ(app.option_defaults()->get_multi_option_policy(), CLI::MultiOptionPolicy::Throw);
     EXPECT_FALSE(app.option_defaults()->get_ignore_case());
+    EXPECT_TRUE(app.option_defaults()->get_configurable());
     EXPECT_EQ(app.option_defaults()->get_group(), "Options");
 
     app.option_defaults()
         ->required()
         ->multi_option_policy(CLI::MultiOptionPolicy::TakeLast)
         ->ignore_case()
+        ->configurable(false)
         ->group("Something");
 
     auto app2 = app.add_subcommand("app2");
@@ -316,6 +318,7 @@ TEST_F(TApp, OptionFromDefaultsSubcommands) {
     EXPECT_TRUE(app2->option_defaults()->get_required());
     EXPECT_EQ(app2->option_defaults()->get_multi_option_policy(), CLI::MultiOptionPolicy::TakeLast);
     EXPECT_TRUE(app2->option_defaults()->get_ignore_case());
+    EXPECT_FALSE(app2->option_defaults()->get_configurable());
     EXPECT_EQ(app2->option_defaults()->get_group(), "Something");
 }
 

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -376,7 +376,7 @@ TEST_F(TApp, IniFailure) {
         out << "val=1" << std::endl;
     }
 
-    EXPECT_THROW(run(), CLI::ExtrasINIError);
+    EXPECT_THROW(run(), CLI::INIError);
 }
 
 TEST_F(TApp, IniSubFailure) {
@@ -392,7 +392,7 @@ TEST_F(TApp, IniSubFailure) {
         out << "val=1" << std::endl;
     }
 
-    EXPECT_THROW(run(), CLI::ExtrasINIError);
+    EXPECT_THROW(run(), CLI::INIError);
 }
 
 TEST_F(TApp, IniNoSubFailure) {
@@ -407,7 +407,7 @@ TEST_F(TApp, IniNoSubFailure) {
         out << "val=1" << std::endl;
     }
 
-    EXPECT_THROW(run(), CLI::ExtrasINIError);
+    EXPECT_THROW(run(), CLI::INIError);
 }
 
 TEST_F(TApp, IniFlagConvertFailure) {

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -429,7 +429,8 @@ TEST_F(TApp, IniSubFailure) {
 
     EXPECT_THROW(run(), CLI::INIError);
 }
-d TEST_F(TApp, IniNoSubFailure) {
+
+TEST_F(TApp, IniNoSubFailure) {
 
     TempFile tmpini{"TestIniTmp.ini"};
 

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -162,7 +162,7 @@ TEST_F(TApp, IniNotRequired) {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -200,7 +200,7 @@ TEST_F(TApp, IniNotRequiredNotDefault) {
     TempFile tmpini{"TestIniTmp.ini"};
     TempFile tmpini2{"TestIniTmp2.ini"};
 
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -237,7 +237,7 @@ TEST_F(TApp, IniNotRequiredNotDefault) {
 TEST_F(TApp, IniRequiredNotFound) {
 
     std::string noini = "TestIniNotExist.ini";
-    app.add_config("--config", noini, "", true);
+    app.set_config("--config", noini, "", true);
 
     EXPECT_THROW(run(), CLI::FileError);
 }
@@ -245,7 +245,7 @@ TEST_F(TApp, IniRequiredNotFound) {
 TEST_F(TApp, IniNotRequiredPassedNotFound) {
 
     std::string noini = "TestIniNotExist.ini";
-    app.add_config("--config", "", "", false);
+    app.set_config("--config", "", "", false);
 
     args = {"--config", noini};
     EXPECT_THROW(run(), CLI::FileError);
@@ -262,9 +262,9 @@ TEST_F(TApp, IniOverwrite) {
 
     std::string orig = "filename_not_exist.ini";
     std::string next = "TestIniTmp.ini";
-    app.add_config("--config", orig);
+    app.set_config("--config", orig);
     // Make sure this can be overwritten
-    app.add_config("--conf", next);
+    app.set_config("--conf", next);
     int two = 7;
     app.add_option("--two", two);
 
@@ -277,7 +277,7 @@ TEST_F(TApp, IniRequired) {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    app.add_config("--config", tmpini, "", true);
+    app.set_config("--config", tmpini, "", true);
 
     {
         std::ofstream out{tmpini};
@@ -316,7 +316,7 @@ TEST_F(TApp, IniVector) {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -339,7 +339,7 @@ TEST_F(TApp, IniLayered) {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -368,7 +368,7 @@ TEST_F(TApp, IniFailure) {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -383,7 +383,7 @@ TEST_F(TApp, IniConfigurable) {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
     bool value;
     app.add_flag("--val", value)->configurable(true);
 
@@ -401,7 +401,7 @@ TEST_F(TApp, IniNotConfigurable) {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
     bool value;
     app.add_flag("--val", value)->configurable(false);
 
@@ -419,7 +419,7 @@ TEST_F(TApp, IniSubFailure) {
     TempFile tmpini{"TestIniTmp.ini"};
 
     app.add_subcommand("other");
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -429,12 +429,11 @@ TEST_F(TApp, IniSubFailure) {
 
     EXPECT_THROW(run(), CLI::INIError);
 }
-
-TEST_F(TApp, IniNoSubFailure) {
+d TEST_F(TApp, IniNoSubFailure) {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -450,7 +449,7 @@ TEST_F(TApp, IniFlagConvertFailure) {
     TempFile tmpini{"TestIniTmp.ini"};
 
     app.add_flag("--flag");
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -466,7 +465,7 @@ TEST_F(TApp, IniFlagNumbers) {
 
     bool boo;
     app.add_flag("--flag", boo);
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -483,7 +482,7 @@ TEST_F(TApp, IniFlagDual) {
 
     bool boo;
     app.add_flag("--flag", boo);
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -502,7 +501,7 @@ TEST_F(TApp, IniFlagText) {
     app.add_flag("--flag2", flag2);
     app.add_flag("--flag3", flag3);
     app.add_flag("--flag4", flag4);
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};
@@ -522,7 +521,7 @@ TEST_F(TApp, IniFlagText) {
 
 TEST_F(TApp, IniFlags) {
     TempFile tmpini{"TestIniTmp.ini"};
-    app.add_config("--config", tmpini);
+    app.set_config("--config", tmpini);
 
     {
         std::ofstream out{tmpini};

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -379,6 +379,41 @@ TEST_F(TApp, IniFailure) {
     EXPECT_THROW(run(), CLI::INIError);
 }
 
+TEST_F(TApp, IniConfigurable) {
+
+    TempFile tmpini{"TestIniTmp.ini"};
+
+    app.add_config("--config", tmpini);
+    bool value;
+    app.add_flag("--val", value)->configurable(true);
+
+    {
+        std::ofstream out{tmpini};
+        out << "[default]" << std::endl;
+        out << "val=1" << std::endl;
+    }
+
+    EXPECT_NO_THROW(run());
+    EXPECT_TRUE(value);
+}
+
+TEST_F(TApp, IniNotConfigurable) {
+
+    TempFile tmpini{"TestIniTmp.ini"};
+
+    app.add_config("--config", tmpini);
+    bool value;
+    app.add_flag("--val", value)->configurable(false);
+
+    {
+        std::ofstream out{tmpini};
+        out << "[default]" << std::endl;
+        out << "val=1" << std::endl;
+    }
+
+    EXPECT_THROW(run(), CLI::INIError);
+}
+
 TEST_F(TApp, IniSubFailure) {
 
     TempFile tmpini{"TestIniTmp.ini"};


### PR DESCRIPTION
This cleans up the rest of the message to make localization easier (still not explicitly included, but easier when most of the localized text is in one place!). This probably is the last PR to 1.3.

This also gives options an inheritable `->configurable(false)` setting, to allow the user to exclude some options from the ini file. 

The add config has been renamed to `set_config`, and calling it with no arguments clears the config option.