### PR TITLE
Add test target for Clang 5.0 and C++14.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,17 @@ matrix:
   - compiler: clang
     addons:
       apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - llvm-toolchain-trusty-5.0
+        packages:
+        - clang++-5.0
+    env:
+    - COMPILER=5.0
+    - CLI_CXX_STD=14
+  - compiler: clang
+    addons:
+      apt:
         packages:
         - clang-3.9
         - clang-format-3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
     - COMPILER=4.7
   - os: osx
     before_install:
-    - python -m ensurepip --default-pip
+    - python -m ensurepip --user
 install:
 - python -c 'import sys; print(sys.version_info[:])'
 - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -12,13 +12,11 @@ namespace CLI {
 
 // Type tools
 
-// Copied from C++14
-#if __cplusplus < 201402L
+// We could check to see if C++14 is being used, but it does not hurt to redefine this
+// (even Google does this: https://github.com/google/skia/blob/master/include/private/SkTLogic.h)
+// It is not in the std namespace anyway, so no harm done.
+
 template <bool B, class T = void> using enable_if_t = typename std::enable_if<B, T>::type;
-#else
-// If your compiler supports C++14, you can use that definition instead
-using std::enable_if_t;
-#endif
 
 template <typename T> struct is_vector { static const bool value = false; };
 

--- a/tests/NewParseTest.cpp
+++ b/tests/NewParseTest.cpp
@@ -36,7 +36,8 @@ TEST_F(TApp, AddingComplexParser) {
 
     run();
 
-    EXPECT_EQ(cx(1.5, 2.5), comp);
+    EXPECT_EQ(1.5, comp.real());
+    EXPECT_EQ(2.5, comp.imag());
 }
 
 TEST_F(TApp, DefaultComplex) {
@@ -49,11 +50,13 @@ TEST_F(TApp, DefaultComplex) {
     EXPECT_THAT(help, HasSubstr("1"));
     EXPECT_THAT(help, HasSubstr("2"));
 
-    EXPECT_EQ(cx(1, 2), comp);
+    EXPECT_EQ(1, comp.real());
+    EXPECT_EQ(2, comp.imag());
 
     run();
 
-    EXPECT_EQ(cx(4, 3), comp);
+    EXPECT_EQ(4, comp.real());
+    EXPECT_EQ(3, comp.imag());
 }
 
 TEST_F(TApp, BuiltinComplex) {
@@ -67,11 +70,13 @@ TEST_F(TApp, BuiltinComplex) {
     EXPECT_THAT(help, HasSubstr("2"));
     EXPECT_THAT(help, HasSubstr("COMPLEX"));
 
-    EXPECT_EQ(cx(1, 2), comp);
+    EXPECT_EQ(1, comp.real());
+    EXPECT_EQ(2, comp.imag());
 
     run();
 
-    EXPECT_EQ(cx(4, 3), comp);
+    EXPECT_EQ(4, comp.real());
+    EXPECT_EQ(3, comp.imag());
 }
 
 TEST_F(TApp, BuiltinComplexIgnoreI) {
@@ -82,7 +87,8 @@ TEST_F(TApp, BuiltinComplexIgnoreI) {
 
     run();
 
-    EXPECT_EQ(cx(4, 3), comp);
+    EXPECT_EQ(4, comp.real());
+    EXPECT_EQ(3, comp.imag());
 }
 
 TEST_F(TApp, BuiltinComplexFail) {


### PR DESCRIPTION
I got a build failure in neopg for clang5 and c++14:

```
CLI11/include/CLI11.hpp:234:12: error: 
      no member named 'enable_if_t' in namespace 'std'; did you mean
      'enable_if'?
using std::enable_if_t;
      ~~~~~^~~~~~~~~~~
           enable_if
/usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/type_traits:1766:12: note: 
      'enable_if' declared here
    struct enable_if 
           ^
```

Let's see if we can trigger this here, too! :fire: :fire_engine: :potable_water: 
