### PR TITLE
Add check if lexical_cast fully consumed input on integer conversion

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -563,6 +563,8 @@ class App {
 
         std::string simple_name = CLI::detail::split(name, ',').at(0);
         CLI::callback_t fun = [&variable, simple_name, label](results_t res) {
+            if(res[1].back() == 'i')
+                res[1].pop_back();
             double x, y;
             bool worked = detail::lexical_cast(res[0], x) && detail::lexical_cast(res[1], y);
             if(worked)

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -110,8 +110,9 @@ bool lexical_cast(std::string input, T &output) {
 template <typename T, enable_if_t<std::is_floating_point<T>::value, detail::enabler> = detail::dummy>
 bool lexical_cast(std::string input, T &output) {
     try {
-        output = static_cast<T>(std::stold(input));
-        return true;
+        size_t n = 0;
+        output = static_cast<T>(std::stold(input, &n));
+        return n == input.size();
     } catch(const std::invalid_argument &) {
         return false;
     } catch(const std::out_of_range &) {

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -92,7 +92,7 @@ bool lexical_cast(std::string input, T &output) {
 template <typename T,
           enable_if_t<std::is_integral<T>::value && std::is_unsigned<T>::value, detail::enabler> = detail::dummy>
 bool lexical_cast(std::string input, T &output) {
-    if (!input.empty() && input.front() == '-')
+    if(!input.empty() && input.front() == '-')
         return false; // std::stoull happily converts negative values to junk without any errors.
 
     try {
@@ -123,7 +123,7 @@ bool lexical_cast(std::string input, T &output) {
 /// String and similar
 template <typename T,
           enable_if_t<!std::is_floating_point<T>::value && !std::is_integral<T>::value && !std::is_enum<T>::value &&
-                          std::is_assignable<T&, std::string>::value,
+                          std::is_assignable<T &, std::string>::value,
                       detail::enabler> = detail::dummy>
 bool lexical_cast(std::string input, T &output) {
     output = input;
@@ -133,7 +133,7 @@ bool lexical_cast(std::string input, T &output) {
 /// Non-string parsable
 template <typename T,
           enable_if_t<!std::is_floating_point<T>::value && !std::is_integral<T>::value && !std::is_enum<T>::value &&
-                          !std::is_assignable<T&, std::string>::value,
+                          !std::is_assignable<T &, std::string>::value,
                       detail::enabler> = detail::dummy>
 bool lexical_cast(std::string input, T &output) {
     static thread_local std::istringstream is;

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -122,11 +122,25 @@ bool lexical_cast(std::string input, T &output) {
 
 /// String and similar
 template <typename T,
-          enable_if_t<!std::is_floating_point<T>::value && !std::is_integral<T>::value && !std::is_enum<T>::value,
+          enable_if_t<!std::is_floating_point<T>::value && !std::is_integral<T>::value && !std::is_enum<T>::value &&
+                          std::is_assignable<T&, std::string>::value,
                       detail::enabler> = detail::dummy>
 bool lexical_cast(std::string input, T &output) {
     output = input;
     return true;
+}
+
+/// Non-string parsable
+template <typename T,
+          enable_if_t<!std::is_floating_point<T>::value && !std::is_integral<T>::value && !std::is_enum<T>::value &&
+                          !std::is_assignable<T&, std::string>::value,
+                      detail::enabler> = detail::dummy>
+bool lexical_cast(std::string input, T &output) {
+    static thread_local std::istringstream is;
+
+    is.str(input);
+    is >> output;
+    return !is.fail() && !is.rdbuf()->in_avail();
 }
 
 } // namespace detail

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -136,7 +136,14 @@ template <typename T,
                           !std::is_assignable<T &, std::string>::value,
                       detail::enabler> = detail::dummy>
 bool lexical_cast(std::string input, T &output) {
+
+// On GCC 4.7, thread_local is not available, so this optimization
+// is turned off (avoiding multiple initialisations on multiple usages
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && __GNUC__ == 4 && (__GNUC_MINOR__ < 8)
+    std::istringstream is;
+#else
     static thread_local std::istringstream is;
+#endif
 
     is.str(input);
     is >> output;

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -405,7 +405,8 @@ TEST(Types, LexicalCastParsable) {
 
     std::complex<double> output;
     EXPECT_TRUE(CLI::detail::lexical_cast(input, output));
-    EXPECT_EQ(output, std::complex<double>(4.2, 7.3));
+    EXPECT_EQ(output.real(), 4.2); // Doing this in one go sometimes has trouble
+    EXPECT_EQ(output.imag(), 7.3); // on clang + c++4.8 due to missing const
 
     EXPECT_FALSE(CLI::detail::lexical_cast(fail_input, output));
     EXPECT_FALSE(CLI::detail::lexical_cast(extra_input, output));

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -327,17 +327,30 @@ TEST(Types, TypeName) {
 }
 
 TEST(Types, LexicalCastInt) {
-    std::string input = "912";
-    int x;
-    EXPECT_TRUE(CLI::detail::lexical_cast(input, x));
-    EXPECT_EQ(912, x);
+    std::string signed_input = "-912";
+    int x_signed;
+    EXPECT_TRUE(CLI::detail::lexical_cast(signed_input, x_signed));
+    EXPECT_EQ(-912, x_signed);
+
+    std::string unsigned_input = "912";
+    unsigned int x_unsigned;
+    EXPECT_TRUE(CLI::detail::lexical_cast(unsigned_input, x_unsigned));
+    EXPECT_EQ(912, x_unsigned);
+
+    EXPECT_FALSE(CLI::detail::lexical_cast(signed_input, x_unsigned));
 
     unsigned char y;
     std::string overflow_input = std::to_string(UINT64_MAX) + "0";
     EXPECT_FALSE(CLI::detail::lexical_cast(overflow_input, y));
 
+    char y_signed;
+    EXPECT_FALSE(CLI::detail::lexical_cast(overflow_input, y_signed));
+
     std::string bad_input = "hello";
     EXPECT_FALSE(CLI::detail::lexical_cast(bad_input, y));
+
+    std::string extra_input = "912i";
+    EXPECT_FALSE(CLI::detail::lexical_cast(extra_input, y));
 }
 
 TEST(Types, LexicalCastDouble) {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <cstdint>
 #include <string>
+#include <complex>
+
 
 TEST(Split, SimpleByToken) {
     auto out = CLI::detail::split("one.two.three", '.');
@@ -374,4 +376,17 @@ TEST(Types, LexicalCastString) {
     std::string output;
     CLI::detail::lexical_cast(input, output);
     EXPECT_EQ(input, output);
+}
+
+TEST(Types, LexicalCastParsable) {
+    std::string input = "(4.2,7.3)";
+    std::string fail_input = "4.2,7.3";
+    std::string extra_input = "(4.2,7.3)e";
+
+    std::complex<double> output;
+    EXPECT_TRUE(CLI::detail::lexical_cast(input, output));
+    EXPECT_EQ(output, std::complex<double>(4.2, 7.3));
+
+    EXPECT_FALSE(CLI::detail::lexical_cast(fail_input, output));
+    EXPECT_FALSE(CLI::detail::lexical_cast(extra_input, output));
 }

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -364,6 +364,9 @@ TEST(Types, LexicalCastDouble) {
 
     std::string overflow_input = "1" + std::to_string(LDBL_MAX);
     EXPECT_FALSE(CLI::detail::lexical_cast(overflow_input, x));
+
+    std::string extra_input = "9.12i";
+    EXPECT_FALSE(CLI::detail::lexical_cast(extra_input, x));
 }
 
 TEST(Types, LexicalCastString) {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <complex>
 
-
 TEST(Split, SimpleByToken) {
     auto out = CLI::detail::split("one.two.three", '.');
     ASSERT_EQ((size_t)3, out.size());


### PR DESCRIPTION
Would be even better to add checks for integer overflow on `long long` to `T` conversions.