### PR TITLE
#76 | Remove "is required" string passed as an argument to RequiredEr…

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1176,7 +1176,7 @@ class App {
 
                 // Required but empty
                 if(opt->get_required() && opt->count() == 0)
-                    throw RequiredError(opt->single_name() + " is required");
+                    throw RequiredError(opt->single_name());
             }
             // Requires
             for(const Option *opt_req : opt->requires_)


### PR DESCRIPTION
…ror() constructor to avoid double printing.

The string "is required" is already added internally by RequiredError() class.