### PR TITLE
Allow MakeSingleHeader.py script to run from non-git source code

### DIFF
--- a/scripts/MakeSingleHeader.py
+++ b/scripts/MakeSingleHeader.py
@@ -7,7 +7,7 @@ from __future__ import print_function, unicode_literals
 import os
 import re
 import argparse
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 
 includes_local = re.compile(r"""^#include "(.*)"$""", re.MULTILINE)
 includes_system = re.compile(r"""^#include \<(.*)\>$""", re.MULTILINE)
@@ -17,7 +17,10 @@ BDIR = os.path.join(os.path.dirname(DIR), 'include') # DIR.parent / 'include'
 
 print("Git directory:", DIR)
 
-TAG = check_output(['git', 'describe', '--tags', '--always'], cwd=str(DIR)).decode("utf-8")
+try:
+    TAG = check_output(['git', 'describe', '--tags', '--always'], cwd=str(DIR)).decode("utf-8")
+except CalledProcessError:
+    TAG = "A non-git source"
 
 def MakeHeader(out):
     main_header = os.path.join(BDIR, 'CLI', 'CLI.hpp')


### PR DESCRIPTION
Currently, if `CLI_SINGLE_FILE` is true, `MakeSingleHeader.py` runs which checks for a tag in the current git repo. This fails if you are not in a repo. This would be the case if, for example, you use the source code from an archive.

This PR just puts a check around the call and adds a nondescript message instead. 