### PR TITLE
Unlimited optionals without space bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## In progress
+
+* Fix unlimited short options eating two values before checking for positionals when no space present #90
+
 ## Version 1.4: More feedback
 
 This version adds lots of smaller fixes and additions after the refactor in version 1.3. More ways to download and use CLI11 in CMake have been added. INI files have improved support.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1422,25 +1422,32 @@ class App {
 
         int num = op->get_expected();
 
+        // Make sure we always eat the minimum for unlimited vectors
+        int collected = 0;
+
+        // --this=value
         if(!value.empty()) {
-            if(num != -1)
+            // If exact number expected
+            if(num > 0)
                 num--;
             op->add_result(value);
             parse_order_.push_back(op.get());
+            collected += 1;
         } else if(num == 0) {
             op->add_result("");
             parse_order_.push_back(op.get());
+            // -Trest
         } else if(!rest.empty()) {
             if(num > 0)
                 num--;
             op->add_result(rest);
             parse_order_.push_back(op.get());
             rest = "";
+            collected += 1;
         }
 
         // Unlimited vector parser
         if(num < 0) {
-            int collected = 0; // Make sure we always eat the minimum
             while(!args.empty() && _recognize(args.back()) == detail::Classifer::NONE) {
                 if(collected >= -num) {
                     // We could break here for allow extras, but we don't

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -707,6 +707,30 @@ TEST_F(TApp, BigPositional) {
     EXPECT_EQ(args, vec);
 }
 
+// This makes sure unlimited option priority is
+// correct for space vs. no space #90
+TEST_F(TApp, PositionalNoSpace) {
+    std::vector<std::string> options;
+    std::string foo, bar;
+
+    app.add_option("-O", options);
+    app.add_option("foo", foo)->required();
+    app.add_option("bar", bar)->required();
+
+    args = {"-O", "Test", "param1", "param2"};
+    run();
+
+    EXPECT_EQ(options.size(), (size_t)1);
+    EXPECT_EQ(options.at(0), "Test");
+
+    app.reset();
+    args = {"-OTest", "param1", "param2"};
+    run();
+
+    EXPECT_EQ(options.size(), (size_t)1);
+    EXPECT_EQ(options.at(0), "Test");
+}
+
 TEST_F(TApp, Reset) {
 
     app.add_flag("--simple");


### PR DESCRIPTION
Fixes an error in the logic when mixing unlimited options and positionals when the option is given in short form with no space. Fixes #90.