### PR TITLE
Adding size instead of expected + unchangable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ Other, non-user facing changes:
 * Informational printout now added to CTest [#95]
 * Better single file generation [#95]
 * Added support for GTest on MSVC 2017 (but not in C++17 mode, will need next version of GTest)
+* Types now have a specific size, separate from the expected number - cleaner and more powerful internally [#92]
 
 [#64]: https://github.com/CLIUtils/CLI11/issues/64
 [#90]: https://github.com/CLIUtils/CLI11/issues/90
+[#92]: https://github.com/CLIUtils/CLI11/issues/92
 [#95]: https://github.com/CLIUtils/CLI11/pull/95
 
 

--- a/cmake/AddGoogletest.cmake
+++ b/cmake/AddGoogletest.cmake
@@ -4,24 +4,39 @@
 # gives output on failed tests without having to set an environment variable.
 #
 #
-set(UPDATE_DISCONNECTED_IF_AVAILABLE "UPDATE_DISCONNECTED 1")
-
-include(DownloadProject)
-download_project(PROJ                googletest
-                 GIT_REPOSITORY      https://github.com/google/googletest.git
-                 GIT_TAG             release-1.8.0
-                 UPDATE_DISCONNECTED 1
-                 QUIET
-)
-
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-# CMake warning suppression will not be needed in version 1.9
-set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "")
-add_subdirectory(${googletest_SOURCE_DIR} ${googletest_SOURCE_DIR} EXCLUDE_FROM_ALL)
-unset(CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
+if(CMAKE_VERSION VERSION_LESS 3.11)
+    set(UPDATE_DISCONNECTED_IF_AVAILABLE "UPDATE_DISCONNECTED 1")
+    include(DownloadProject)
+    download_project(PROJ                googletest
+                     GIT_REPOSITORY      https://github.com/google/googletest.git
+                     GIT_TAG             release-1.8.0
+                     UPDATE_DISCONNECTED 1
+                     QUIET
+    )
+    
+    # CMake warning suppression will not be needed in version 1.9
+    set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "")
+    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_SOURCE_DIR} EXCLUDE_FROM_ALL)
+    unset(CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
+else()
+    include(FetchContent)
+    FetchContent_Declare(googletest
+        GIT_REPOSITORY      https://github.com/google/googletest.git
+        GIT_TAG             release-1.8.0)
+    FetchContent_GetProperties(googletest)
+    if(NOT googletest_POPULATED)
+        FetchContent_Populate(googletest)
+        set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "")
+        add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
+        unset(CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
+    endif()
+endif()
 
-if (CMAKE_CONFIGURATION_TYPES)
+
+
+if(CMAKE_CONFIGURATION_TYPES)
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} 
         --force-new-ctest-process --output-on-failure 
         --build-config "$<CONFIGURATION>")
@@ -54,16 +69,17 @@ macro(add_gtest TESTNAME)
             gtest_add_tests(TARGET ${TESTNAME}
                             TEST_PREFIX "${TESTNAME}."
                             TEST_LIST TmpTestList)
+            set_tests_properties(${TmpTestList} PROPERTIES FOLDER "Tests")
         else()
             gtest_discover_tests(${TESTNAME}
                 TEST_PREFIX "${TESTNAME}."
-                )
+                PROPERTIES FOLDER "Tests")
             
         endif()
     else()
         add_test(${TESTNAME} ${TESTNAME})
+        set_target_properties(${TESTNAME} PROPERTIES FOLDER "Tests")
     endif()
-    set_target_properties(${TESTNAME} PROPERTIES FOLDER "Tests")
 
 endmacro()
 

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -91,6 +91,9 @@ class IncorrectConstruction : public ConstructionError {
     static IncorrectConstruction Set0Opt(std::string name) {
         return IncorrectConstruction(name + ": Cannot set 0 expected, use a flag instead");
     }
+    static IncorrectConstruction SetFlag(std::string name) {
+        return IncorrectConstruction(name + ": Cannot set an expected number for flags");
+    }
     static IncorrectConstruction ChangeNotVector(std::string name) {
         return IncorrectConstruction(name + ": You can only change the expected arguments for vectors");
     }

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -105,7 +105,7 @@ class IncorrectConstruction : public ConstructionError {
         return IncorrectConstruction("Option " + name + " is not defined");
     }
     static IncorrectConstruction MultiOptionPolicy(std::string name) {
-        return IncorrectConstruction(name + ": multi_option_policy only works for flags and single value options");
+        return IncorrectConstruction(name + ": multi_option_policy only works for flags and exact value options");
     }
 };
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -353,6 +353,23 @@ TEST_F(TApp, MissingValueMoreThan) {
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
+TEST_F(TApp, NoMissingValueMoreThan) {
+    std::vector<int> vals1;
+    std::vector<int> vals2;
+    app.add_option("-v", vals1)->expected(-2);
+    app.add_option("--vals", vals2)->expected(-2);
+    
+    args = {"-v", "2", "3", "4"};
+    run();
+    EXPECT_EQ(vals1, std::vector<int>({2,3,4}));
+    
+    app.reset();
+    
+    args = {"--vals", "2", "3", "4"};
+    run();
+    EXPECT_EQ(vals2, std::vector<int>({2,3,4}));
+}
+
 TEST_F(TApp, NotRequiredOptsSingle) {
 
     std::string str;

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -358,16 +358,16 @@ TEST_F(TApp, NoMissingValueMoreThan) {
     std::vector<int> vals2;
     app.add_option("-v", vals1)->expected(-2);
     app.add_option("--vals", vals2)->expected(-2);
-    
+
     args = {"-v", "2", "3", "4"};
     run();
-    EXPECT_EQ(vals1, std::vector<int>({2,3,4}));
-    
+    EXPECT_EQ(vals1, std::vector<int>({2, 3, 4}));
+
     app.reset();
-    
+
     args = {"--vals", "2", "3", "4"};
     run();
-    EXPECT_EQ(vals2, std::vector<int>({2,3,4}));
+    EXPECT_EQ(vals2, std::vector<int>({2, 3, 4}));
 }
 
 TEST_F(TApp, NotRequiredOptsSingle) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1,5 +1,6 @@
 #include "app_helper.hpp"
 #include <cstdlib>
+#include <complex>
 
 TEST_F(TApp, OneFlagShort) {
     app.add_flag("-c,--count");
@@ -288,6 +289,40 @@ TEST_F(TApp, JoinOpt2) {
     run();
 
     EXPECT_EQ(str, "one\ntwo");
+}
+
+TEST_F(TApp, TakeLastOptMulti) {
+    std::vector<int> vals;
+    app.add_option("--long", vals)->expected(2)->take_last();
+
+    args = {"--long", "1", "2", "3"};
+
+    run();
+
+    EXPECT_EQ(vals, std::vector<int>({2, 3}));
+}
+
+TEST_F(TApp, TakeFirstOptMulti) {
+    std::vector<int> vals;
+    app.add_option("--long", vals)->expected(2)->take_first();
+
+    args = {"--long", "1", "2", "3"};
+
+    run();
+
+    EXPECT_EQ(vals, std::vector<int>({1, 2}));
+}
+
+TEST_F(TApp, ComplexOptMulti) {
+    std::complex<double> val;
+    app.add_complex("--long", val)->take_first();
+
+    args = {"--long", "1", "2", "3", "4"};
+
+    run();
+
+    EXPECT_FLOAT_EQ(val.real(), 1);
+    EXPECT_FLOAT_EQ(val.imag(), 2);
 }
 
 TEST_F(TApp, MissingValueNonRequiredOpt) {

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -125,7 +125,7 @@ TEST_F(TApp, IncorrectConstructionFlagPositional3) {
 
 TEST_F(TApp, IncorrectConstructionFlagExpected) {
     auto cat = app.add_flag("--cat");
-    EXPECT_NO_THROW(cat->expected(0));
+    EXPECT_THROW(cat->expected(0), CLI::IncorrectConstruction);
     EXPECT_THROW(cat->expected(1), CLI::IncorrectConstruction);
 }
 


### PR DESCRIPTION
Working on #87.

- [x] Move to using two values instead of one for `expected`: `expected` and `type_size`. Drop `unchangable`, which was really just a hack for not knowing the type size.
- [x] Expand policies to support multiple options
- [x] Check/expand support for expected `-N` where `N>1`.
- [ ] Check/fix help printout for `typeval > 1`. Add test. (@AbcAeffchen)