### PR TITLE
Auto-add symmetric excludes for better help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## In progress
 
-* Fix unlimited short options eating two values before checking for positionals when no space present #90
+* Fix unlimited short options eating two values before checking for positionals when no space present [#90]
+* Symmetric exclude text when excluding options, exclude can be called multiple times [#64]
+
+[#64]: https://github.com/CLIUtils/CLI11/issues/64
+[#90]: https://github.com/CLIUtils/CLI11/issues/90
+
 
 ## Version 1.4: More feedback
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -315,9 +315,14 @@ class Option : public OptionBase<Option> {
 
     /// Sets excluded options
     Option *excludes(Option *opt) {
-        auto tup = excludes_.insert(opt);
-        if(!tup.second)
-            throw OptionAlreadyAdded::Excludes(get_name(), opt->get_name());
+        excludes_.insert(opt);
+
+        // Help text should be symmetric - excluding a should exclude b
+        opt->excludes_.insert(this);
+
+        // Ignoring the insert return value, excluding twice is now allowed.
+        // (Mostly to allow both directions to be excluded by user, even though the library does it for you.)
+
         return this;
     }
 

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -187,18 +187,20 @@ TEST_F(TApp, IncorrectConstructionDuplicateNeedsTxt) {
     EXPECT_THROW(cat->needs("--other"), CLI::OptionAlreadyAdded);
 }
 
-TEST_F(TApp, IncorrectConstructionDuplicateExcludes) {
+// Now allowed
+TEST_F(TApp, CorrectConstructionDuplicateExcludes) {
     auto cat = app.add_flag("--cat");
     auto other = app.add_flag("--other");
     ASSERT_NO_THROW(cat->excludes(other));
-    EXPECT_THROW(cat->excludes(other), CLI::OptionAlreadyAdded);
+    ASSERT_NO_THROW(other->excludes(cat));
 }
 
-TEST_F(TApp, IncorrectConstructionDuplicateExcludesTxt) {
+// Now allowed
+TEST_F(TApp, CorrectConstructionDuplicateExcludesTxt) {
     auto cat = app.add_flag("--cat");
-    app.add_flag("--other");
+    auto other = app.add_flag("--other");
     ASSERT_NO_THROW(cat->excludes("--other"));
-    EXPECT_THROW(cat->excludes("--other"), CLI::OptionAlreadyAdded);
+    ASSERT_NO_THROW(other->excludes("--cat"));
 }
 
 TEST_F(TApp, CheckName) {

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -203,6 +203,17 @@ TEST(THelp, ExcludesPositional) {
     EXPECT_THAT(help, HasSubstr("Excludes: op1"));
 }
 
+TEST(THelp, ExcludesSymmetric) {
+    CLI::App app{"My prog"};
+
+    CLI::Option *op1 = app.add_flag("--op1");
+    app.add_flag("--op2")->excludes(op1);
+
+    std::string help = app.help();
+
+    EXPECT_THAT(help, HasSubstr("Excludes: --op2"));
+}
+
 TEST(THelp, ManualSetters) {
 
     CLI::App app{"My prog"};


### PR DESCRIPTION
Fixes #64.

It is no longer an error to exclude multiple times. (Backward compatibility with old workaround of manually adding both exclude directions).