### PR TITLE
Adding and fixing more warnings

### DIFF
--- a/.ci/check_tidy.sh
+++ b/.ci/check_tidy.sh
@@ -6,7 +6,7 @@ set -evx
 
 mkdir -p build-tidy
 cd build-tidy
-CXX_FLAGS="-Werror -Wall -Wextra -pedantic -std=c++11" cmake .. -DCLANG_TIDY_FIX=ON
+CXX_FLAGS="-Werror -Wcast-align -Wfloat-equal -Wimplicit-atomic-properties -Wmissing-declarations -Woverlength-strings -Wshadow -Wstrict-selector-match -Wundeclared-selector -Wunreachable-code -std=c++11" cmake .. -DCLANG_TIDY_FIX=ON
 cmake --build .
 
 set -evx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     if(MSVC)
         add_definitions("/W4")
     else()
-        add_definitions("-Wall -Wextra -pedantic")
+        add_definitions(-Wall -Wextra -pedantic)
     endif()
 
     if(CMAKE_VERSION VERSION_GREATER 3.6)

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1048,10 +1048,10 @@ class App {
 
     /// This returns the number of remaining options, minus the -- seperator
     size_t remaining_size(bool recurse = false) const {
-        size_t count = std::count_if(
+        size_t count = static_cast<size_t>(std::count_if(
             std::begin(missing_), std::end(missing_), [](const std::pair<detail::Classifer, std::string> &val) {
                 return val.first != detail::Classifer::POSITIONAL_MARK;
-            });
+            }));
         if(recurse) {
             for(const App_p &sub : subcommands_) {
                 count += sub->remaining_size(recurse);

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -633,24 +633,24 @@ TEST_F(TApp, RequiredFlags) {
 
 TEST_F(TApp, CallbackFlags) {
 
-    int value = 0;
+    size_t value = 0;
 
     auto func = [&value](size_t x) { value = x; };
 
     app.add_flag_function("-v", func);
 
     run();
-    EXPECT_EQ(value, 0);
+    EXPECT_EQ(value, (size_t)0);
 
     app.reset();
     args = {"-v"};
     run();
-    EXPECT_EQ(value, 1);
+    EXPECT_EQ(value, (size_t)1);
 
     app.reset();
     args = {"-vv"};
     run();
-    EXPECT_EQ(value, 2);
+    EXPECT_EQ(value, (size_t)2);
 
     EXPECT_THROW(app.add_flag_function("hi", func), CLI::IncorrectConstruction);
 }
@@ -658,24 +658,24 @@ TEST_F(TApp, CallbackFlags) {
 #if __cplusplus >= 201402L
 TEST_F(TApp, CallbackFlagsAuto) {
 
-    int value = 0;
+    size_t value = 0;
 
     auto func = [&value](size_t x) { value = x; };
 
     app.add_flag("-v", func);
 
     run();
-    EXPECT_EQ(value, 0);
+    EXPECT_EQ(value, (size_t)0);
 
     app.reset();
     args = {"-v"};
     run();
-    EXPECT_EQ(value, 1);
+    EXPECT_EQ(value, (size_t)1);
 
     app.reset();
     args = {"-vv"};
     run();
-    EXPECT_EQ(value, 2);
+    EXPECT_EQ(value, (size_t)2);
 
     EXPECT_THROW(app.add_flag("hi", func), CLI::IncorrectConstruction);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(GOOGLE_TEST_INDIVIDUAL ON)
+set(GOOGLE_TEST_INDIVIDUAL OFF)
 include(AddGoogletest)
 
 set(CLI_TESTS

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -415,8 +415,8 @@ TEST(Types, LexicalCastParsable) {
 
     std::complex<double> output;
     EXPECT_TRUE(CLI::detail::lexical_cast(input, output));
-    EXPECT_EQ(output.real(), 4.2); // Doing this in one go sometimes has trouble
-    EXPECT_EQ(output.imag(), 7.3); // on clang + c++4.8 due to missing const
+    EXPECT_DOUBLE_EQ(output.real(), 4.2); // Doing this in one go sometimes has trouble
+    EXPECT_DOUBLE_EQ(output.imag(), 7.3); // on clang + c++4.8 due to missing const
 
     EXPECT_FALSE(CLI::detail::lexical_cast(fail_input, output));
     EXPECT_FALSE(CLI::detail::lexical_cast(extra_input, output));

--- a/tests/NewParseTest.cpp
+++ b/tests/NewParseTest.cpp
@@ -34,8 +34,8 @@ TEST_F(TApp, AddingComplexParser) {
 
     run();
 
-    EXPECT_EQ(1.5, comp.real());
-    EXPECT_EQ(2.5, comp.imag());
+    EXPECT_DOUBLE_EQ(1.5, comp.real());
+    EXPECT_DOUBLE_EQ(2.5, comp.imag());
 }
 
 TEST_F(TApp, DefaultComplex) {
@@ -48,13 +48,13 @@ TEST_F(TApp, DefaultComplex) {
     EXPECT_THAT(help, HasSubstr("1"));
     EXPECT_THAT(help, HasSubstr("2"));
 
-    EXPECT_EQ(1, comp.real());
-    EXPECT_EQ(2, comp.imag());
+    EXPECT_DOUBLE_EQ(1, comp.real());
+    EXPECT_DOUBLE_EQ(2, comp.imag());
 
     run();
 
-    EXPECT_EQ(4, comp.real());
-    EXPECT_EQ(3, comp.imag());
+    EXPECT_DOUBLE_EQ(4, comp.real());
+    EXPECT_DOUBLE_EQ(3, comp.imag());
 }
 
 TEST_F(TApp, BuiltinComplex) {
@@ -68,13 +68,13 @@ TEST_F(TApp, BuiltinComplex) {
     EXPECT_THAT(help, HasSubstr("2"));
     EXPECT_THAT(help, HasSubstr("COMPLEX"));
 
-    EXPECT_EQ(1, comp.real());
-    EXPECT_EQ(2, comp.imag());
+    EXPECT_DOUBLE_EQ(1, comp.real());
+    EXPECT_DOUBLE_EQ(2, comp.imag());
 
     run();
 
-    EXPECT_EQ(4, comp.real());
-    EXPECT_EQ(3, comp.imag());
+    EXPECT_DOUBLE_EQ(4, comp.real());
+    EXPECT_DOUBLE_EQ(3, comp.imag());
 }
 
 TEST_F(TApp, BuiltinComplexIgnoreI) {
@@ -85,8 +85,8 @@ TEST_F(TApp, BuiltinComplexIgnoreI) {
 
     run();
 
-    EXPECT_EQ(4, comp.real());
-    EXPECT_EQ(3, comp.imag());
+    EXPECT_DOUBLE_EQ(4, comp.real());
+    EXPECT_DOUBLE_EQ(3, comp.imag());
 }
 
 TEST_F(TApp, BuiltinComplexFail) {


### PR DESCRIPTION
A list from https://softwareengineering.stackexchange.com/questions/122608/clang-warning-flags-for-objective-c-development/124574#124574

Fixed a few warnings, and some are off due to gtest.