### PR TITLE
Optional

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,6 @@ build_script:
 test_script:
   - cd build
   - ctest --output-on-failure -C Debug
-  - tests\OptionalTest
 
 notifications:
   - provider: Webhook

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ install:
 build_script:
   - mkdir build
   - cd build
-  - cmake .. -DCLI_SINGLE_FILE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_GENERATOR="Visual Studio 14 2015"
+  - cmake .. -DCLI11_SINGLE_FILE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_GENERATOR="Visual Studio 14 2015"
   - cmake --build .
   - cd ..
   - conan create . CLIUtils/CLI11

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,9 @@ build_script:
   - conan create . CLIUtils/CLI11
 
 test_script:
+  - cd build
   - ctest --output-on-failure -C Debug
+  - tests\OptionalTest
 
 notifications:
   - provider: Webhook

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,14 +12,14 @@ install:
 build_script:
   - mkdir build
   - cd build
-  - cmake .. -DCLI11_SINGLE_FILE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_GENERATOR="Visual Studio 14 2015"
-  - cmake --build .
+  - ps: cmake .. -DCLI11_SINGLE_FILE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_GENERATOR="Visual Studio 14 2015"
+  - ps: cmake --build .
   - cd ..
   - conan create . CLIUtils/CLI11
 
 test_script:
   - cd build
-  - ctest --output-on-failure -C Debug
+  - ps: ctest --output-on-failure -C Debug
 
 notifications:
   - provider: Webhook

--- a/.ci/make_and_test.sh
+++ b/.ci/make_and_test.sh
@@ -5,7 +5,7 @@ set -evx
 
 mkdir -p build
 cd build
-cmake .. -DCLI_CXX_STD=$1 -DCLI_SINGLE_FILE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+cmake .. -DCLI11_CXX_STD=$1 -DCLI11_SINGLE_FILE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 cmake --build . -- -j2
 
 set +evx

--- a/.ci/make_and_test.sh
+++ b/.ci/make_and_test.sh
@@ -15,6 +15,7 @@ echo "Testing..."
 set -evx
 
 ctest --output-on-failure
+./tests/OptionalTest
 
 set +evx
 echo -en "travis_fold:end:script.test\\r"

--- a/.ci/make_and_test.sh
+++ b/.ci/make_and_test.sh
@@ -15,7 +15,6 @@ echo "Testing..."
 set -evx
 
 ctest --output-on-failure
-./tests/OptionalTest
 
 set +evx
 echo -en "travis_fold:end:script.test\\r"

--- a/.ci/run_codecov.sh
+++ b/.ci/run_codecov.sh
@@ -7,9 +7,9 @@ set -evx
 cd ${TRAVIS_BUILD_DIR}
 mkdir -p build
 cd build
-cmake .. -DCLI_SINGLE_FILE_TESTS=OFF -DCLI_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Coverage
+cmake .. -DCLI11_SINGLE_FILE_TESTS=OFF -DCLI11_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Coverage
 cmake --build . -- -j2
-cmake --build . --target CLI_coverage
+cmake --build . --target CLI11_coverage
 
 set +evx
 echo -en "travis_fold:end:script.build\\r"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
 
     # Check style/tidy
   - compiler: clang 
+    env:
+    - CHECK_STYLE=yes
     script:
     - cd "${TRAVIS_BUILD_DIR}"
     - scripts/check_style.sh
@@ -54,6 +56,8 @@ matrix:
 
     # GCC 6 and Coverage
   - compiler: gcc
+    env:
+    - GCC_VER=7
     addons:
       apt:
         sources:
@@ -76,6 +80,8 @@ matrix:
 
     # GCC 4.7 and Conan
   - compiler: gcc
+    env:
+    - GCC_VER=4.7
     addons:
       apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
   include:
     # Default clang
   - compiler: clang
+    script:
+    - .ci/make_and_test.sh 11
+    - .ci/make_and_test.sh 14
+    - .ci/make_and_test.sh 17
 
     # Check style/tidy
   - compiler: clang 
@@ -55,16 +59,20 @@ matrix:
         sources:
         - ubuntu-toolchain-r-test
         packages:
-        - g++-6
+        - g++-7
         - curl
         - lcov
     install:
-    - export CC=gcc-6
-    - export CXX=g++-6
+    - export CC=gcc-7
+    - export CXX=g++-7
     - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
     - cd $TRAVIS_BUILD_DIR
     - ". .ci/build_lcov.sh"
     - ".ci/run_codecov.sh"
+    script:
+    - .ci/make_and_test.sh 11
+    - .ci/make_and_test.sh 14
+    - .ci/make_and_test.sh 17
 
     # GCC 4.7 and Conan
   - compiler: gcc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,27 @@
 ## In progress
 
+This version has some internal cleanup and improved support for the newest compilers.
+
+Note: This is the final release with `requires`, please switch to `needs`.
+
 * Fix unlimited short options eating two values before checking for positionals when no space present [#90]
 * Symmetric exclude text when excluding options, exclude can be called multiple times [#64]
+* Support for `std::optional`, `std::experimental::optional`, and `boost::optional` added if `__has_include` is supported [#95]
+* All macros/CMake variables now start with `CLI11_` instead of just `CLI_` [#95]
+* The internal stream was not being cleared before use in some cases. Fixed. [#95]
+
+Other, non-user facing changes:
+
+* Added `Macros.hpp` with better C++ mode discovery [#95]
+* Deprecated macros added for all platforms
+* C++17 is now tested on supported platforms [#95]
+* Informational printout now added to CTest [#95]
+* Better single file generation [#95]
+* Added support for GTest on MSVC 2017 (but not in C++17 mode, will need next version of GTest)
 
 [#64]: https://github.com/CLIUtils/CLI11/issues/64
 [#90]: https://github.com/CLIUtils/CLI11/issues/90
+[#95]: https://github.com/CLIUtils/CLI11/pull/95
 
 
 ## Version 1.4: More feedback

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     if(MSVC)
         add_definitions("/W4")
     else()
-        add_definitions(-Wall -Wextra -pedantic)
+        add_definitions(-Wall -Wextra -pedantic -Wno-deprecated-declarations)
     endif()
 
     if(CMAKE_VERSION VERSION_GREATER 3.6)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,10 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 # Only if built as the main project
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     # User settable
-    set(CLI_CXX_STD "11"  CACHE STRING "The CMake standard to require")
+    set(CLI11_CXX_STD "11"  CACHE STRING "The CMake standard to require")
 
     set(CUR_PROJ ON)
-    set(CMAKE_CXX_STANDARD ${CLI_CXX_STD})
+    set(CMAKE_CXX_STANDARD ${CLI11_CXX_STD})
     set(CMAKE_CXX_EXTENSIONS OFF)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -56,10 +56,10 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if(CMAKE_BUILD_TYPE STREQUAL Coverage)
     include(CodeCoverage)
-    setup_target_for_coverage(CLI_coverage ctest coverage)
+    setup_target_for_coverage(CLI11_coverage ctest coverage)
 endif()
 
-file(GLOB CLI_headers "${CMAKE_CURRENT_SOURCE_DIR}/include/CLI/*")
+file(GLOB CLI11_headers "${CMAKE_CURRENT_SOURCE_DIR}/include/CLI/*")
 # To see in IDE, must be listed for target
 
 add_library(CLI11 INTERFACE)
@@ -113,18 +113,18 @@ export(PACKAGE CLI11)
 # Single file test
 find_package(PythonInterp)
 if(CUR_PROJ AND PYTHONINTERP_FOUND)
-    set(CLI_SINGLE_FILE_DEFAULT ON)
+    set(CLI11_SINGLE_FILE_DEFAULT ON)
 else()
-    set(CLI_SINGLE_FILE_DEFAULT OFF)
+    set(CLI11_SINGLE_FILE_DEFAULT OFF)
 endif()
 
-option(CLI_SINGLE_FILE "Generate a single header file" ${CLI_SINGLE_FILE_DEFAULT})
-if(CLI_SINGLE_FILE)
+option(CLI11_SINGLE_FILE "Generate a single header file" ${CLI11_SINGLE_FILE_DEFAULT})
+if(CLI11_SINGLE_FILE)
     find_package(PythonInterp REQUIRED)
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
     add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp"
         COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/scripts/MakeSingleHeader.py" "${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp"
-        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/CLI/CLI.hpp" ${CLI_headers}
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/CLI/CLI.hpp" ${CLI11_headers}
         )
     add_custom_target(generate_cli_single_file ALL
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp")
@@ -134,25 +134,25 @@ if(CLI_SINGLE_FILE)
     add_library(CLI11_SINGLE INTERFACE)
     target_link_libraries(CLI11_SINGLE INTERFACE CLI11)
     add_dependencies(CLI11_SINGLE generate_cli_single_file)
-    target_compile_definitions(CLI11_SINGLE INTERFACE -DCLI_SINGLE_FILE)
+    target_compile_definitions(CLI11_SINGLE INTERFACE -DCLI11_SINGLE_FILE)
     target_include_directories(CLI11_SINGLE INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/include/")
 endif()
 
-option(CLI_SINGLE_FILE_TESTS "Duplicate all the tests for a single file build" OFF)
+option(CLI11_SINGLE_FILE_TESTS "Duplicate all the tests for a single file build" OFF)
 
-option(CLI_TESTING "Build the tests and add them" ${CUR_PROJ})
-if(CLI_TESTING)
+option(CLI11_TESTING "Build the tests and add them" ${CUR_PROJ})
+if(CLI11_TESTING)
     enable_testing()
     add_subdirectory(tests)
 endif()
 
-option(CLI_EXAMPLES "Build the examples" ${CUR_PROJ})
-if(CLI_EXAMPLES)
+option(CLI11_EXAMPLES "Build the examples" ${CUR_PROJ})
+if(CLI11_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
 if(NOT CUR_PROJ)
-    mark_as_advanced(CLI_SINGLE_FILE_TESTS CLI_EXAMPLES CLI_TESTING)
+    mark_as_advanced(CLI11_SINGLE_FILE_TESTS CLI11_EXAMPLES CLI11_TESTING)
 endif()
 
 # Packaging support

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ An option name must start with a alphabetic character or underscore. For long op
 
 On a C++14 compiler, you can pass a callback function directly to `.add_flag`, while in C++11 mode you'll need to use `.add_flag_function` if you want a callback function. The function will be given the number of times the flag was passed. You can throw a relevant `CLI::ParseError` to signal a failure.
 
-On a compiler that supports C++17's `__has_include`, you can also use `std::optional`, `std::experimental::optional`, and `boost::optional` directly in an `add_option` call. See [CLI11 Internals] for information on how this was done and how you can add your own converters.
+On a compiler that supports C++17's `__has_include`, you can also use `std::optional`, `std::experimental::optional`, and `boost::optional` directly in an `add_option` call. If you don't have `__has_include`, you can define `CLI11_BOOST_OPTIONAL` before including CLI11 to manually add support for `boost::optional`. See [CLI11 Internals] for information on how this was done and how you can add your own converters.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ After I wrote this, I also found the following libraries:
 | [Argh!] | Very minimalistic C++11 parser, single header. Don't have many features. No help generation?!?! At least it's exception-free.|
 | [CLI]   | Custom language and parser. Huge build-system overkill for very little benefit. Last release in 2009, but still occasionally active. |
 
-See [Awesome C++] for a less-biased list of parsers.
+See [Awesome C++] for a less-biased list of parsers. You can also find other single file libraries at [Single file libs].
 
 </p></details>
 <br/>
@@ -434,5 +434,7 @@ CLI11 was developed at the [University of Cincinnati] to support of the [GooFit]
 [wandbox-link]:          https://wandbox.org/permlink/g7tRkuU8xY3aTIVP
 [releases-badge]:        https://img.shields.io/github/release/CLIUtils/CLI11.svg
 [cli11-po-compare]:      https://iscinumpy.gitlab.io/post/comparing-cli11-and-boostpo/
-[DIANA slides]: https://indico.cern.ch/event/619465/contributions/2507949/attachments/1448567/2232649/20170424-diana-2.pdf
-[Awesome C++]: https://github.com/fffaraz/awesome-cpp/blob/master/README.md#cli
+[DIANA slides]:          https://indico.cern.ch/event/619465/contributions/2507949/attachments/1448567/2232649/20170424-diana-2.pdf
+[Awesome C++]:           https://github.com/fffaraz/awesome-cpp/blob/master/README.md#cli
+[CLI]:                   https://codesynthesis.com/projects/cli/
+[Single file libs]:      https://github.com/nothings/single_file_libs/blob/master/README.md

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ An option name must start with a alphabetic character or underscore. For long op
 
 On a C++14 compiler, you can pass a callback function directly to `.add_flag`, while in C++11 mode you'll need to use `.add_flag_function` if you want a callback function. The function will be given the number of times the flag was passed. You can throw a relevant `CLI::ParseError` to signal a failure.
 
+On a compiler that supports C++17's `__has_include`, you can also use `std::optional`, `std::experimental::optional`, and `boost::optional` directly in an `add_option` call. See [CLI11 Internals] for information on how this was done and how you can add your own converters.
+
 ### Example
 
 * `"one,-o,--one"`: Valid as long as not a flag, would create an option that can be specified positionally, or with `-o` or `--one`
@@ -421,6 +423,7 @@ CLI11 was developed at the [University of Cincinnati] to support of the [GooFit]
 [NSF Award 1414736]:     https://nsf.gov/awardsearch/showAward?AWD_ID=1414736
 [University of Cincinnati]: http://www.uc.edu
 [GitBook]:               https://cliutils.gitlab.io/CLI11Tutorial
+[CLI11 Internals]:       https://cliutils.gitlab.io/CLI11Tutorial/chapters/internals.html
 [ProgramOptions.hxx]:    https://github.com/Fytch/ProgramOptions.hxx
 [Argument Aggregator]:   https://github.com/vietjtnguyen/argagg
 [Args]:                  https://github.com/Taywee/args

--- a/cmake/AddGoogletest.cmake
+++ b/cmake/AddGoogletest.cmake
@@ -80,3 +80,10 @@ BUILD_GTEST
 
 set_target_properties(gtest gtest_main gmock gmock_main
     PROPERTIES FOLDER "Extern")
+
+if(MSVC AND MSVC_VERSION GREATER_EQUAL 1900)
+    target_compile_definitions(gtest PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+    target_compile_definitions(gtest_main PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+    target_compile_definitions(gmock PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+    target_compile_definitions(gmock_main PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -22,8 +22,8 @@ class HelloConan(ConanFile):
 
     def build(self): # this is not building a library, just tests
         cmake = CMake(self)
-        cmake.definitions["CLI_EXAMPLES"] = "OFF"
-        cmake.definitions["CLI_SINGLE_FILE"] = "OFF"
+        cmake.definitions["CLI11_EXAMPLES"] = "OFF"
+        cmake.definitions["CLI11_SINGLE_FILE"] = "OFF"
         cmake.configure()
         cmake.build()
         cmake.test()

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -334,7 +334,7 @@ BUILTIN_STL_SUPPORT    = NO
 # enable parsing support.
 # The default value is: NO.
 
-CPP_CLI_SUPPORT        = NO
+CPP_CLI11_SUPPORT        = NO
 
 # Set the SIP_SUPPORT tag to YES if your project consists of sip (see:
 # http://www.riverbankcomputing.co.uk/software/sip/intro) sources only. Doxygen

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 function(add_cli_exe T)
-    add_executable(${T} ${ARGN} ${CLI_headers})
+    add_executable(${T} ${ARGN} ${CLI11_headers})
     target_link_libraries(${T} PUBLIC CLI11)
     set_target_properties(
          ${T} PROPERTIES

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -19,6 +19,7 @@
 // CLI Library includes
 #include "CLI/Error.hpp"
 #include "CLI/Ini.hpp"
+#include "CLI/Macros.hpp"
 #include "CLI/Option.hpp"
 #include "CLI/Split.hpp"
 #include "CLI/StringTools.hpp"
@@ -447,7 +448,7 @@ class App {
         return opt;
     }
 
-#if __cplusplus >= 201402L
+#ifdef CLI11_CPP14
     /// Add option for callback (C++14 or better only)
     Option *add_flag(std::string name,
                      std::function<void(size_t)> function, ///< A function to call, void(size_t)

--- a/include/CLI/CLI.hpp
+++ b/include/CLI/CLI.hpp
@@ -10,6 +10,8 @@
 
 #include "CLI/Macros.hpp"
 
+#include "CLI/Optional.hpp"
+
 #include "CLI/StringTools.hpp"
 
 #include "CLI/Error.hpp"

--- a/include/CLI/CLI.hpp
+++ b/include/CLI/CLI.hpp
@@ -8,6 +8,8 @@
 
 #include "CLI/Version.hpp"
 
+#include "CLI/Macros.hpp"
+
 #include "CLI/StringTools.hpp"
 
 #include "CLI/Error.hpp"

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -10,20 +10,20 @@ namespace CLI {
 // The following version macro is very similar to the one in PyBind11
 
 #if !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-#  if __cplusplus >= 201402L
-#    define CLI11_CPP14
-#    if __cplusplus > 201402L /* Temporary: should be updated to >= the final C++17 value once known */
-#      define CLI11_CPP17
-#    endif
-#  endif
+#if __cplusplus >= 201402L
+#define CLI11_CPP14
+#if __cplusplus > 201402L /* Temporary: should be updated to >= the final C++17 value once known */
+#define CLI11_CPP17
+#endif
+#endif
 #elif defined(_MSC_VER)
 // MSVC sets _MSVC_LANG rather than __cplusplus (supposedly until the standard is fully implemented)
-#  if _MSVC_LANG >= 201402L
-#    define CLI11_CPP14
-#    if _MSVC_LANG > 201402L && _MSC_VER >= 1910
-#      define CLI11_CPP17
-#    endif
-#  endif
+#if _MSVC_LANG >= 201402L
+#define CLI11_CPP14
+#if _MSVC_LANG > 201402L && _MSC_VER >= 1910
+#define CLI11_CPP17
+#endif
+#endif
 #endif
 
 } // namespace CLI

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
+
+namespace CLI {
+
+// Note that all code in CLI11 must be in a namespace, even if it just a define.
+
+// The following version macro is very similar to the one in PyBind11
+
+#if !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#  if __cplusplus >= 201402L
+#    define CLI11_CPP14
+#    if __cplusplus > 201402L /* Temporary: should be updated to >= the final C++17 value once known */
+#      define CLI11_CPP17
+#    endif
+#  endif
+#elif defined(_MSC_VER)
+// MSVC sets _MSVC_LANG rather than __cplusplus (supposedly until the standard is fully implemented)
+#  if _MSVC_LANG >= 201402L
+#    define CLI11_CPP14
+#    if _MSVC_LANG > 201402L && _MSC_VER >= 1910
+#      define CLI11_CPP17
+#    endif
+#  endif
+#endif
+
+} // namespace CLI

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -9,21 +9,34 @@ namespace CLI {
 
 // The following version macro is very similar to the one in PyBind11
 
-#if !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#if !(defined(_MSC_VER) && __cplusplus == 199711L) && !defined(__INTEL_COMPILER)
 #if __cplusplus >= 201402L
 #define CLI11_CPP14
-#if __cplusplus > 201402L /* Temporary: should be updated to >= the final C++17 value once known */
+#if __cplusplus >= 201703L
 #define CLI11_CPP17
+#if __cplusplus > 201703L
+#define CLI11_CPP20
 #endif
 #endif
-#elif defined(_MSC_VER)
+#endif
+#elif defined(_MSC_VER) && __cplusplus == 199711L
 // MSVC sets _MSVC_LANG rather than __cplusplus (supposedly until the standard is fully implemented)
+// Unless you use the /Zc:__cplusplus flag on Visual Studio 2017 15.7 Preview 3 or newer
 #if _MSVC_LANG >= 201402L
 #define CLI11_CPP14
 #if _MSVC_LANG > 201402L && _MSC_VER >= 1910
 #define CLI11_CPP17
+#if __MSVC_LANG > 201703L && _MSC_VER >= 1910
+#define CLI11_CPP20
 #endif
 #endif
+#endif
+#endif
+
+#if defined(PYBIND11_CPP14)
+#define CLI11_DEPRECATED(reason) [[deprecated(reason)]]
+#else
+#define CLI11_DEPRECATED(reason) __attribute__((deprecated(reason)))
 #endif
 
 } // namespace CLI

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -35,6 +35,8 @@ namespace CLI {
 
 #if defined(PYBIND11_CPP14)
 #define CLI11_DEPRECATED(reason) [[deprecated(reason)]]
+#elif defined(_MSC_VER)
+#define CLI11_DEPRECATED(reason) __declspec(deprecated(reason))
 #else
 #define CLI11_DEPRECATED(reason) __attribute__((deprecated(reason)))
 #endif

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -306,14 +306,17 @@ class Option : public OptionBase<Option> {
     Option *requires(Option *opt) { return needs(opt); }
 
     /// Can find a string if needed \deprecated
-    CLI11_DEPRECATED("Use needs instead of requires (eventual keyword clash)")
-    template <typename T = App> Option *requires(std::string opt_name) { return needs<T>(opt_name); }
+    template <typename T = App> Option *requires(std::string opt_name) {
+        for(const Option_p &opt : dynamic_cast<T *>(parent_)->options_)
+            if(opt.get() != this && opt->check_name(opt_name))
+                return requires(opt.get());
+        throw IncorrectConstruction::MissingOption(opt_name);
+    }
 
     /// Any number supported, any mix of string and Opt \deprecated
-    CLI11_DEPRECATED("Use needs instead of requires (eventual keyword clash)")
     template <typename A, typename B, typename... ARG> Option *requires(A opt, B opt1, ARG... args) {
-        needs(opt);
-        return needs(opt1, args...);
+        requires(opt);
+        return requires(opt1, args...);
     }
 #endif
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "CLI/Error.hpp"
+#include "CLI/Macros.hpp"
 #include "CLI/Split.hpp"
 #include "CLI/StringTools.hpp"
 
@@ -299,7 +300,7 @@ class Option : public OptionBase<Option> {
         return needs(opt1, args...);
     }
 
-#if __cplusplus <= 201703L
+#ifndef CLI11_CPP17
     /// Sets required options \deprecated
     Option *requires(Option *opt) { return needs(opt); }
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -309,7 +309,7 @@ class Option : public OptionBase<Option> {
     template <typename T = App> Option *requires(std::string opt_name) {
         for(const Option_p &opt : dynamic_cast<T *>(parent_)->options_)
             if(opt.get() != this && opt->check_name(opt_name))
-                return requires(opt.get());
+                return needs(opt.get());
         throw IncorrectConstruction::MissingOption(opt_name);
     }
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -300,14 +300,17 @@ class Option : public OptionBase<Option> {
         return needs(opt1, args...);
     }
 
-#ifndef CLI11_CPP17
+#ifndef CLI11_CPP20
     /// Sets required options \deprecated
+    CLI11_DEPRECATED("Use needs instead of requires (eventual keyword clash)")
     Option *requires(Option *opt) { return needs(opt); }
 
     /// Can find a string if needed \deprecated
+    CLI11_DEPRECATED("Use needs instead of requires (eventual keyword clash)")
     template <typename T = App> Option *requires(std::string opt_name) { return needs<T>(opt_name); }
 
     /// Any number supported, any mix of string and Opt \deprecated
+    CLI11_DEPRECATED("Use needs instead of requires (eventual keyword clash)")
     template <typename A, typename B, typename... ARG> Option *requires(A opt, B opt1, ARG... args) {
         needs(opt);
         return needs(opt1, args...);

--- a/include/CLI/Optional.hpp
+++ b/include/CLI/Optional.hpp
@@ -11,31 +11,64 @@
 #ifdef __has_include
 #if defined(CLI11_CPP17) && __has_include(<optional>)
 #include <optional>
-#define CLI11_OPTIONAL
-namespace CLI {
-using std::experimental::optional;
-} // namespace CLI
-#elif defined(CPP11_CPP14) && __has_include(<experimental/optional>)
+#ifdef __cpp_lib_optional
+#define CLI11_STD_OPTIONAL
+#endif
+#endif
+#if defined(CPP11_CPP14) && __has_include(<experimental/optional>)
 #include <experimental/optional>
-#define CLI11_OPTIONAL
-namespace CLI {
-using std::optional;
-} // namespace CLI
+#ifdef __cpp_lib_experimental_optional
+#define CLI11_EXPERIMENTAL_OPTIONAL
+#endif
+#endif
+#if __has_include(<boost/optional>)
+#include <boost/optional.hpp>
+#define CLI11_BOOST_OPTIONAL
 #endif
 #endif
 // [CLI11:verbatim]
 
 namespace CLI {
 
-#ifdef CLI11_OPTIONAL
+#ifdef CLI11_STD_OPTIONAL
+template <typename T> std::istream &operator>>(std::istream &in, std::optional<T> &val) {
+    T v;
+    in >> v;
+    val = v;
+    return in;
+}
+#endif
 
-template <typename T> std::istream &operator>>(std::istream &in, optional<T> &val) {
+#ifdef CLI11_EXPERIMENTAL_OPTIONAL
+template <typename T> std::istream &operator>>(std::istream &in, std::experimental::optional<T> &val) {
     T v;
     in >> v;
     val = v;
     return in;
 }
 
+#ifdef CLI11_BOOST_OPTIONAL
+template <typename T> std::istream &operator>>(std::istream &in, boost::optional<T> &val) {
+    T v;
+    in >> v;
+    val = v;
+    return in;
+}
+#endif
+#endif
+
+// Export the best optional to the CLI namespace
+#if defined(CLI11_STD_OPTIONAL)
+using std::optional;
+#elif CLI11_EXPERIMENTAL_OPTIONAL
+using std::experimental::optional;
+#elif CLI11_BOOST_OPTIONAL
+using boost::optionall
+#endif
+
+// This is true if any optional is found
+#if defined(CLI11_STD_OPTIONAL) || defined(CLI11_EXPERIMENTAL_OPTIONAL) || defined(CLI11_BOOST_OPTIONAL)
+#define CLI11_OPTIONAL
 #endif
 
 } // namespace CLI

--- a/include/CLI/Optional.hpp
+++ b/include/CLI/Optional.hpp
@@ -3,7 +3,7 @@
 // Distributed under the 3-Clause BSD License.  See accompanying
 // file LICENSE or https://github.com/CLIUtils/CLI11 for details.
 
-#include <sstream>
+#include <istream>
 
 #include "CLI/Macros.hpp"
 
@@ -15,11 +15,11 @@
 #define CLI11_STD_OPTIONAL
 #endif
 #endif
-#if defined(CPP11_CPP14) && __has_include(<experimental/optional>)
+#if defined(CLI11_CPP14) && __has_include(<experimental/optional>)
 #include <experimental/optional>
 #define CLI11_EXPERIMENTAL_OPTIONAL
 #endif
-#if __has_include(<boost/optional>)
+#if __has_include(<boost/optional.hpp>)
 #include <boost/optional.hpp>
 #define CLI11_BOOST_OPTIONAL
 #endif
@@ -44,15 +44,15 @@ template <typename T> std::istream &operator>>(std::istream &in, std::experiment
     val = v;
     return in;
 }
+#endif
 
 #ifdef CLI11_BOOST_OPTIONAL
-template <typename T> std::istream &operator>>(std::istream &in, boost::optional<T> &val) {
+template <typename T> std::istringstream &operator>>(std::istringstream &in, boost::optional<T> &val) {
     T v;
     in >> v;
     val = v;
     return in;
 }
-#endif
 #endif
 
 // Export the best optional to the CLI namespace

--- a/include/CLI/Optional.hpp
+++ b/include/CLI/Optional.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
+
+#include <sstream>
+
+#include "CLI/Macros.hpp"
+
+// [CLI11:verbatim]
+#ifdef __has_include
+#if defined(CLI11_CPP17) && __has_include(<optional>)
+#include <optional>
+#define CLI11_OPTIONAL
+namespace CLI {
+using std::experimental::optional;
+} // namespace CLI
+#elif defined(CPP11_CPP14) && __has_include(<experimental/optional>)
+#include <experimental/optional>
+#define CLI11_OPTIONAL
+namespace CLI {
+using std::optional;
+} // namespace CLI
+#endif
+#endif
+// [CLI11:verbatim]
+
+namespace CLI {
+
+#ifdef CLI11_OPTIONAL
+
+template <typename T> std::istream &operator>>(std::istream &in, optional<T> &val) {
+    T v;
+    in >> v;
+    val = v;
+    return in;
+}
+
+#endif
+
+} // namespace CLI

--- a/include/CLI/Optional.hpp
+++ b/include/CLI/Optional.hpp
@@ -17,9 +17,7 @@
 #endif
 #if defined(CPP11_CPP14) && __has_include(<experimental/optional>)
 #include <experimental/optional>
-#ifdef __cpp_lib_experimental_optional
 #define CLI11_EXPERIMENTAL_OPTIONAL
-#endif
 #endif
 #if __has_include(<boost/optional>)
 #include <boost/optional.hpp>

--- a/include/CLI/Optional.hpp
+++ b/include/CLI/Optional.hpp
@@ -60,10 +60,10 @@ template <typename T> std::istream &operator>>(std::istream &in, boost::optional
 // Export the best optional to the CLI namespace
 #if defined(CLI11_STD_OPTIONAL)
 using std::optional;
-#elif CLI11_EXPERIMENTAL_OPTIONAL
+#elif defined(CLI11_EXPERIMENTAL_OPTIONAL)
 using std::experimental::optional;
-#elif CLI11_BOOST_OPTIONAL
-using boost::optionall
+#elif defined(CLI11_BOOST_OPTIONAL)
+using boost::optional;
 #endif
 
 // This is true if any optional is found

--- a/include/CLI/Optional.hpp
+++ b/include/CLI/Optional.hpp
@@ -29,7 +29,7 @@
 namespace CLI {
 
 #ifdef CLI11_STD_OPTIONAL
-template <typename T> std::istream &operator>>(std::istream &in, std::optional<T> &val) {
+template <typename T> std::istringstream &operator>>(std::istringstream &in, std::optional<T> &val) {
     T v;
     in >> v;
     val = v;
@@ -38,7 +38,7 @@ template <typename T> std::istream &operator>>(std::istream &in, std::optional<T
 #endif
 
 #ifdef CLI11_EXPERIMENTAL_OPTIONAL
-template <typename T> std::istream &operator>>(std::istream &in, std::experimental::optional<T> &val) {
+template <typename T> std::istringstream &operator>>(std::istringstream &in, std::experimental::optional<T> &val) {
     T v;
     in >> v;
     val = v;

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -140,11 +140,12 @@ template <typename T,
 bool lexical_cast(std::string input, T &output) {
 
 // On GCC 4.7, thread_local is not available, so this optimization
-// is turned off (avoiding multiple initialisations on multiple usages
+// is turned off (avoiding multiple initialisations on multiple usages)
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && __GNUC__ == 4 && (__GNUC_MINOR__ < 8)
     std::istringstream is;
 #else
     static thread_local std::istringstream is;
+    is.clear();
 #endif
 
     is.str(input);

--- a/scripts/MakeSingleHeader.py
+++ b/scripts/MakeSingleHeader.py
@@ -5,60 +5,110 @@ from __future__ import print_function, unicode_literals
 import os
 import re
 import argparse
+import operator
+from copy import copy
 from subprocess import check_output, CalledProcessError
+from functools import reduce
 
 includes_local = re.compile(r"""^#include "(.*)"$""", re.MULTILINE)
 includes_system = re.compile(r"""^#include \<(.*)\>$""", re.MULTILINE)
+verbatim_tag_str = r"""
+^               # Begin of line
+[^\n^\[]+       # Some characters, not including [ or the end of a line
+\[              # A literal [
+[^\]^\n]*       # Anything except a closing ]
+CLI11:verbatim  # The tag
+[^\]^\n]*       # Anything except a closing ]
+\]              # A literal ]
+[^\n]*          # Up to end of line
+$               # End of a line
+"""
+verbatim_all = re.compile(verbatim_tag_str + "(.*)" + verbatim_tag_str,
+                          re.MULTILINE | re.DOTALL | re.VERBOSE)
 
-DIR = os.path.dirname(os.path.abspath(__file__)) # Path(__file__).resolve().parent
-BDIR = os.path.join(os.path.dirname(DIR), 'include') # DIR.parent / 'include'
+DIR = os.path.dirname(os.path.abspath(__file__))
 
-print("Git directory:", DIR)
+class HeaderFile(object):
+    TAG = "Unknown git revision"
 
-try:
-    TAG = check_output(['git', 'describe', '--tags', '--always'], cwd=str(DIR)).decode("utf-8")
-except CalledProcessError:
-    TAG = "A non-git source"
-
-def MakeHeader(out):
-    main_header = os.path.join(BDIR, 'CLI', 'CLI.hpp')
-    with open(main_header) as f:
-        header = f.read()
-
-    include_files = includes_local.findall(header)
-
-    headers = set()
-    output = ''
-    for inc in include_files:
-        with open(os.path.join(BDIR, inc)) as f:
+    def __init__(self, base, inc):
+        with open(os.path.join(base, inc)) as f:
             inner = f.read()
-        headers |= set(includes_system.findall(inner))
-        output += '\n// From {inc}\n\n'.format(inc=inc)
-        output += inner[inner.find('namespace'):]
 
-    header_list = '\n'.join('#include <'+h+'>' for h in headers)
+        # add self.verbatim
+        if 'CLI11:verbatim' in inner:
+            self.verbatim = ["\n\n// Verbatim copy from {}".format(inc)]
+            self.verbatim += verbatim_all.findall(inner)
+            inner = verbatim_all.sub("", inner)
+        else:
+            self.verbatim = []
 
-    output = '''\
+        self.headers = set(includes_system.findall(inner))
+
+        self.body = '\n// From {}\n\n'.format(inc) + inner[inner.find('namespace'):]
+
+    def __add__(self, other):
+        out = copy(self)
+        out.headers |= other.headers
+        out.body += other.body
+        out.verbatim += other.verbatim
+        return out
+
+    @property
+    def header_str(self):
+        return '\n'.join('#include <'+h+'>' for h in sorted(self.headers))
+
+    @property
+    def verbatim_str(self):
+        return '\n'.join(self.verbatim)
+
+    def __str__(self):
+        return '''\
 #pragma once
 
 // Distributed under the 3-Clause BSD License.  See accompanying
 // file LICENSE or https://github.com/CLIUtils/CLI11 for details.
 
 // This file was generated using MakeSingleHeader.py in CLI11/scripts
-// from: {tag}
+// from: {self.TAG}
 // This has the complete CLI library in one file.
 
-{header_list}
-{output}'''.format(header_list=header_list, output=output, tag=TAG)
+{self.header_str}
+{self.verbatim_str}
+{self.body}
+'''.format(self=self)
 
-    with open(out, 'w') as f:
-        f.write(output)
 
-    print("Created {out}".format(out=out))
+def MakeHeader(output, main_header, include_dir = '../include'):
+    # Set tag if possible to class variable
+    try:
+        HeaderFile.TAG = check_output(['git', 'describe', '--tags', '--always'], cwd=str(DIR)).decode("utf-8")
+    except CalledProcessError:
+        pass
+
+    base_dir = os.path.abspath(os.path.join(DIR, include_dir))
+    main_header = os.path.join(base_dir, main_header)
+
+    with open(main_header) as f:
+        header = f.read()
+
+    include_files = includes_local.findall(header)
+
+    headers = [HeaderFile(base_dir, inc) for inc in include_files]
+    single_header = reduce(operator.add, headers)
+
+    with open(output, 'w') as f:
+        f.write(str(single_header))
+
+    print("Created", output)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("output", nargs='?', default=os.path.join(BDIR, 'CLI11.hpp'))
+    parser.add_argument("output", help="Single header file output")
+    parser.add_argument("--main", default='CLI/CLI.hpp', help="The main include file that defines the other files")
+    parser.add_argument("--include", default='../include')
     args = parser.parse_args()
-    MakeHeader(args.output)
+
+    MakeHeader(args.output, args.main, args.include)
+

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1161,7 +1161,7 @@ TEST_F(TApp, NeedsMixedFlags) {
     run();
 }
 
-#if __cplusplus <= 201703L
+#ifndef CLI11_CPP20
 
 TEST_F(TApp, RequiresMixedFlags) {
     CLI::Option *opt1 = app.add_flag("--opt1");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CLI_TESTS
     SubcommandTest
     HelpTest
     NewParseTest
+    OptionalTest
     )
 
 set(CLI_MULTIONLY_TESTS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,3 +53,13 @@ set_target_properties(link_test_1 PROPERTIES FOLDER "Tests")
 add_executable(link_test_2 link_test_2.cpp)
 target_link_libraries(link_test_2 PUBLIC CLI11 link_test_1)
 add_gtest(link_test_2)
+
+# Add informational printout
+add_executable(informational informational.cpp)
+target_link_libraries(informational PUBLIC CLI11)
+set_property(TARGET informational PROPERTY
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+file(WRITE "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
+    "set(CTEST_CUSTOM_PRE_TEST \"${CMAKE_BINARY_DIR}/informational\")"
+    )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,11 +55,18 @@ target_link_libraries(link_test_2 PUBLIC CLI11 link_test_1)
 add_gtest(link_test_2)
 
 # Add informational printout
+# Force this to be in a standard location so CTest can find it
 add_executable(informational informational.cpp)
 target_link_libraries(informational PUBLIC CLI11)
-set_property(TARGET informational PROPERTY
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set_target_properties(informational PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}"
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}"
+    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}"
+    RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_BINARY_DIR}"
+    )
 
+# Adding this printout to CTest
 file(WRITE "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
     "set(CTEST_CUSTOM_PRE_TEST \"${CMAKE_BINARY_DIR}/informational\")"
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(GOOGLE_TEST_INDIVIDUAL OFF)
 include(AddGoogletest)
 
-set(CLI_TESTS
+set(CLI11_TESTS
     HelpersTest
     IniTest
     SimpleTest
@@ -13,20 +13,20 @@ set(CLI_TESTS
     OptionalTest
     )
 
-set(CLI_MULTIONLY_TESTS
+set(CLI11_MULTIONLY_TESTS
     TimerTest
     )
 
 # Only affects current directory, so safe
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-foreach(T ${CLI_TESTS})
+foreach(T ${CLI11_TESTS})
 
-    add_executable(${T} ${T}.cpp ${CLI_headers})
+    add_executable(${T} ${T}.cpp ${CLI11_headers})
     target_link_libraries(${T} PUBLIC CLI11)
     add_gtest(${T})
 
-    if(CLI_SINGLE_FILE AND CLI_SINGLE_FILE_TESTS)
+    if(CLI11_SINGLE_FILE AND CLI11_SINGLE_FILE_TESTS)
         add_executable(${T}_Single ${T}.cpp)
         target_link_libraries(${T}_Single PUBLIC CLI11_SINGLE)
         add_gtest(${T}_Single)
@@ -37,9 +37,9 @@ foreach(T ${CLI_TESTS})
 
 endforeach()
 
-foreach(T ${CLI_MULTIONLY_TESTS})
+foreach(T ${CLI11_MULTIONLY_TESTS})
 
-    add_executable(${T} ${T}.cpp ${CLI_headers})
+    add_executable(${T} ${T}.cpp ${CLI11_headers})
     target_link_libraries(${T} PUBLIC CLI11)
     add_gtest(${T})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,3 +63,11 @@ set_property(TARGET informational PROPERTY
 file(WRITE "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
     "set(CTEST_CUSTOM_PRE_TEST \"${CMAKE_BINARY_DIR}/informational\")"
     )
+
+# Add boost to test boost::optional if available
+find_package(Boost 1.35)
+if(Boost_FOUND)
+    target_link_libraries(informational PUBLIC Boost::boost)
+    target_link_libraries(OptionalTest PUBLIC Boost::boost)
+endif()
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,5 +76,9 @@ find_package(Boost 1.35)
 if(Boost_FOUND)
     target_link_libraries(informational PUBLIC Boost::boost)
     target_link_libraries(OptionalTest PUBLIC Boost::boost)
+
+    # Enforce Boost::Optional even if __has_include is missing on your compiler
+    target_compile_definitions(informational PUBLIC CLI11_BOOST_OPTIONAL)
+    target_compile_definitions(OptionalTest PUBLIC CLI11_BOOST_OPTIONAL)
 endif()
 

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -168,6 +168,13 @@ TEST_F(TApp, IncorrectConstructionNeedsCannotFind) {
     EXPECT_THROW(cat->needs("--nothing"), CLI::IncorrectConstruction);
 }
 
+#ifndef CLI11_CPP20
+TEST_F(TApp, IncorrectConstructionRequiresCannotFind) {
+    auto cat = app.add_flag("--cat");
+    EXPECT_THROW(cat->requires("--nothing"), CLI::IncorrectConstruction);
+}
+#endif
+
 TEST_F(TApp, IncorrectConstructionExcludesCannotFind) {
     auto cat = app.add_flag("--cat");
     EXPECT_THROW(cat->excludes("--nothing"), CLI::IncorrectConstruction);

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -1,4 +1,4 @@
-#ifdef CLI_SINGLE_FILE
+#ifdef CLI11_SINGLE_FILE
 #include "CLI11.hpp"
 #else
 #include "CLI/CLI.hpp"

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -1,0 +1,48 @@
+#include <cstdlib>
+#include <iostream>
+
+#ifdef __has_include
+#if __has_include(<optional>)
+#include <optional>
+#define have_optional 1
+using std::experimental::optional;
+#elif __has_include(<experimental/optional>)
+#include <experimental/optional>
+#define have_optional 1
+using std::optional;
+#else
+#define have_optional 0
+#endif
+#endif
+
+#if have_optional
+
+template <typename T> std::istream &operator>>(std::istream &in, optional<T> &val) {
+    T v;
+    in >> v;
+    val = v;
+    return in;
+}
+
+#include "app_helper.hpp"
+
+TEST_F(TApp, OptionalTest) {
+    optional<int> opt;
+    app.add_option("-c,--count", opt);
+    run();
+    EXPECT_FALSE(opt);
+
+    app.reset();
+    args = {"-c", "1"};
+    run();
+    EXPECT_TRUE(opt);
+    EXPECT_EQ(*opt, 1);
+
+    app.reset();
+    args = {"--count", "3"};
+    run();
+    EXPECT_TRUE(opt);
+    EXPECT_EQ(*opt, 3);
+}
+
+#endif

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -6,7 +6,7 @@
 #ifdef CLI11_OPTIONAL
 
 TEST_F(TApp, OptionalTest) {
-    optional<int> opt;
+    CLI::optional<int> opt;
     app.add_option("-c,--count", opt);
     run();
     EXPECT_FALSE(opt);

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -1,28 +1,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#ifdef __has_include
-#if defined(CLI11_CPP17) && __has_include(<optional>)
-#include <optional>
-#define have_optional 1
-using std::experimental::optional;
-#elif defined(CPP11_CPP14) && __has_include(<experimental/optional>)
-#include <experimental/optional>
-#define have_optional 1
-using std::optional;
-#else
-#define have_optional 0
-#endif
-#endif
-
-#if have_optional
-
-template <typename T> std::istream &operator>>(std::istream &in, optional<T> &val) {
-    T v;
-    in >> v;
-    val = v;
-    return in;
-}
+#if CLI11_OPTIONAL
 
 #include "app_helper.hpp"
 

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -3,7 +3,7 @@
 
 #include "app_helper.hpp"
 
-#if CLI11_OPTIONAL
+#ifdef CLI11_OPTIONAL
 
 TEST_F(TApp, OptionalTest) {
     optional<int> opt;

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -2,11 +2,11 @@
 #include <iostream>
 
 #ifdef __has_include
-#if __has_include(<optional>)
+#if defined(CLI11_CPP17) && __has_include(<optional>)
 #include <optional>
 #define have_optional 1
 using std::experimental::optional;
-#elif __has_include(<experimental/optional>)
+#elif defined(CPP11_CPP14) && __has_include(<experimental/optional>)
 #include <experimental/optional>
 #define have_optional 1
 using std::optional;

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -1,9 +1,9 @@
 #include <cstdlib>
 #include <iostream>
 
-#if CLI11_OPTIONAL
-
 #include "app_helper.hpp"
+
+#if CLI11_OPTIONAL
 
 TEST_F(TApp, OptionalTest) {
     optional<int> opt;
@@ -23,5 +23,9 @@ TEST_F(TApp, OptionalTest) {
     EXPECT_TRUE(opt);
     EXPECT_EQ(*opt, 3);
 }
+
+#else
+
+TEST_F(TApp, DISABLED_OptionalTest) {}
 
 #endif

--- a/tests/SimpleTest.cpp
+++ b/tests/SimpleTest.cpp
@@ -1,4 +1,4 @@
-#ifdef CLI_SINGLE_FILE
+#ifdef CLI11_SINGLE_FILE
 #include "CLI11.hpp"
 #else
 #include "CLI/CLI.hpp"

--- a/tests/app_helper.hpp
+++ b/tests/app_helper.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef CLI_SINGLE_FILE
+#ifdef CLI11_SINGLE_FILE
 #include "CLI11.hpp"
 #else
 #include "CLI/CLI.hpp"

--- a/tests/informational.cpp
+++ b/tests/informational.cpp
@@ -1,0 +1,43 @@
+#ifdef CLI11_SINGLE_FILE
+#include "CLI11.hpp"
+#else
+#include "CLI/CLI.hpp"
+#endif
+
+#include <iostream>
+
+int main() {
+    std::cout << "\nCLI11 information:\n";
+
+    std::cout << "  C++ standard: ";
+#if defined(CLI11_CPP20)
+    std::cout << 20;
+#elif defined(CLI11_CPP17)
+    std::cout << 17;
+#elif defined(CLI11_CPP14)
+    std::cout << 14;
+#else
+    std::cout << 11;
+#endif
+    std::cout << "\n";
+
+#ifdef CLI11_OPTIONAL
+    std::cout << "  [Available as CLI::optional]";
+#else
+    std::cout << "  No optional library found\n";
+#endif
+
+#ifdef CLI11_STD_OPTIONAL
+    std::cout << "  std::optional support active\n";
+#endif
+
+#ifdef CLI11_EXPERIMENTAL_OPTIONAL
+    std::cout << "  std::experimental::optional support active\n";
+#endif
+
+#ifdef CLI11_BOOST_OPTIONAL
+    std::cout << "  boost::optional support active\n";
+#endif
+
+    std::cout << std::endl;
+}

--- a/tests/informational.cpp
+++ b/tests/informational.cpp
@@ -21,10 +21,18 @@ int main() {
 #endif
     std::cout << "\n";
 
+    std::cout << "  __has_include: ";
+#ifdef __has_include
+    std::cout << "yes\n";
+#else
+    std::cout << "no\n";
+#endif
+
 #ifdef CLI11_OPTIONAL
     std::cout << "  [Available as CLI::optional]";
 #else
-    std::cout << "  No optional library found\n";
+        std::cout
+              << "  No optional library found\n";
 #endif
 
 #ifdef CLI11_STD_OPTIONAL

--- a/tests/informational.cpp
+++ b/tests/informational.cpp
@@ -31,8 +31,7 @@ int main() {
 #ifdef CLI11_OPTIONAL
     std::cout << "  [Available as CLI::optional]";
 #else
-        std::cout
-              << "  No optional library found\n";
+    std::cout << "  No optional library found\n";
 #endif
 
 #ifdef CLI11_STD_OPTIONAL


### PR DESCRIPTION
Initial tests for support for Options, and cleanup. Closes #9. Supports `std::optional`, `std::experimental::optional`, and `boost::optional` if your compiler supports `__has_include` (You can manually add support if `__has_include` is missing).

Other changes:
* C++ version check now in `Macros.hpp`, is similar to Pybind11
* Fix for non-cleared stream in some cases
* `CLI11_*` is used for all macros and CMake variables
* Deprecated macros now work properly
* C++17 testing added
* Rewritten single file generator, much more powerful, with "verbatim" support
* Added informational printout to CTest
* Added support for GTest on MSVC 2017 (but not in C++17 mode, will need GTest 1.8.1 when released)