### PR TITLE
Dash dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-## Version 1.5: Optional
-
+## Version 1.5: Optionals
 
 This version introduced support for optionals, along with clarification and examples of custom conversion overloads. Enums now have been dropped from the automatic conversion system, allowing explicit protection for out-of-range ints (or a completely custom conversion). This version has some internal cleanup and improved support for the newest compilers. Several bugs were fixed, as well.
 
@@ -11,6 +10,7 @@ Note: This is the final release with `requires`, please switch to `needs`.
 * All macros/CMake variables now start with `CLI11_` instead of just `CLI_` [#95]
 * The internal stream was not being cleared before use in some cases. Fixed. [#95]
 * Using an emum now requires explicit conversion overload [#97]
+* The separator `--` now is removed when it ends unlimited arguments [#100]
 
 Other, non-user facing changes:
 
@@ -21,12 +21,15 @@ Other, non-user facing changes:
 * Better single file generation [#95]
 * Added support for GTest on MSVC 2017 (but not in C++17 mode, will need next version of GTest)
 * Types now have a specific size, separate from the expected number - cleaner and more powerful internally [#92]
+* Examples now run as part of testing [#99]
 
 [#64]: https://github.com/CLIUtils/CLI11/issues/64
 [#90]: https://github.com/CLIUtils/CLI11/issues/90
 [#92]: https://github.com/CLIUtils/CLI11/issues/92
 [#95]: https://github.com/CLIUtils/CLI11/pull/95
 [#97]: https://github.com/CLIUtils/CLI11/pull/97
+[#99]: https://github.com/CLIUtils/CLI11/pull/99
+[#100]: https://github.com/CLIUtils/CLI11/pull/100
 
 
 ## Version 1.4: More feedback

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ On a compiler that supports C++17's `__has_include`, you can also use `std::opti
 The add commands return a pointer to an internally stored `Option`. If you set the final argument to true, the default value is captured and printed on the command line with the help flag. This option can be used directly to check for the count (`->count()`) after parsing to avoid a string based lookup. Before parsing, you can set the following options:
 
 * `->required()`: The program will quit if this option is not present. This is `mandatory` in Plumbum, but required options seems to be a more standard term. For compatibility, `->mandatory()` also works.
-* `->expected(N)`: Take `N` values instead of as many as possible, only for vector args. If negative, require at least `-N`.
+* `->expected(N)`: Take `N` values instead of as many as possible, only for vector args. If negative, require at least `-N`; end with `--` or another recognized option.
 * `->needs(opt)`: This option requires another option to also be present, opt is an `Option` pointer.
 * `->excludes(opt)`: This option cannot be given with `opt` present, opt is an `Option` pointer.
 * `->envname(name)`: Gets the value from the environment if present and not passed on the command line.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -65,7 +65,7 @@ add_cli_exe(prefix_command prefix_command.cpp)
 add_test(NAME prefix_command COMMAND prefix_command -v 3 2 1 -- other one two 3)
 set_property(TEST prefix_command PROPERTY PASS_REGULAR_EXPRESSION
     "Prefix: 3 : 2 : 1"
-    "Remaining commands: -- other one two 3")
+    "Remaining commands: other one two 3")
 
 add_cli_exe(enum enum.cpp)
 add_test(NAME enum_pass COMMAND enum -l 1)

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1035,12 +1035,14 @@ class App {
     /// This gets a vector of pointers with the original parse order
     const std::vector<Option *> &parse_order() const { return parse_order_; }
 
-    /// This retuns the missing options from the current subcommand
+    /// This returns the missing options from the current subcommand
     std::vector<std::string> remaining(bool recurse = false) const {
         std::vector<std::string> miss_list;
         for(const std::pair<detail::Classifer, std::string> &miss : missing_) {
             miss_list.push_back(std::get<1>(miss));
         }
+
+        // Recurse into subcommands
         if(recurse) {
             for(const App *sub : parsed_subcommands_) {
                 std::vector<std::string> output = sub->remaining(recurse);
@@ -1471,6 +1473,10 @@ class App {
                 args.pop_back();
                 collected++;
             }
+
+            // Allow -- to end an unlimited list and "eat" it
+            if(!args.empty() && _recognize(args.back()) == detail::Classifer::POSITIONAL_MARK)
+                args.pop_back();
 
         } else {
             while(num > 0 && !args.empty()) {

--- a/scripts/clang-format-pre-commit
+++ b/scripts/clang-format-pre-commit
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# To use:
+# ln -s scripts/clang-format.hook .git/hooks/pre-commit
+
+# Based loosely on https://github.com/andrewseidl/githook-clang-format
+
+format_file() {
+    file="${1}"
+    case "$file" in
+    *.hpp | *.cpp | .c | *.cc | *.cu | *.h )
+        echo "Fixing: $file"
+        clang-format -i -style=file "${1}"
+        git add "${1}"
+        ;;
+    *)
+        ;;
+    esac
+}
+
+case "${1}" in
+  --about )
+    echo "Runs clang-format on source files"
+    ;;
+  * )
+    for file in `git diff-index --cached --name-only HEAD` ; do
+      format_file "${file}"
+    done
+    ;;
+esac

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -581,6 +581,19 @@ TEST_F(TApp, RequiredOptsUnlimitedShort) {
     EXPECT_EQ(remain, std::vector<std::string>({"two"}));
 }
 
+TEST_F(TApp, OptsUnlimitedEnd) {
+    std::vector<std::string> strs;
+    app.add_option("-s,--str", strs);
+    app.allow_extras();
+
+    args = {"one", "-s", "two", "three", "--", "four"};
+
+    run();
+
+    EXPECT_EQ(strs, std::vector<std::string>({"two", "three"}));
+    EXPECT_EQ(app.remaining(), std::vector<std::string>({"one", "four"}));
+}
+
 TEST_F(TApp, RequireOptPriority) {
 
     std::vector<std::string> strs;

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -407,6 +407,33 @@ TEST_F(TApp, PrefixProgram) {
     EXPECT_EQ(app.remaining(), std::vector<std::string>({"other", "--simple", "--mine"}));
 }
 
+TEST_F(TApp, PrefixNoSeparation) {
+
+    app.prefix_command();
+
+    std::vector<int> vals;
+    app.add_option("--vals", vals);
+
+    args = {"--vals", "1", "2", "3", "other"};
+
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
+TEST_F(TApp, PrefixSeparation) {
+
+    app.prefix_command();
+
+    std::vector<int> vals;
+    app.add_option("--vals", vals);
+
+    args = {"--vals", "1", "2", "3", "--", "other"};
+
+    run();
+
+    EXPECT_EQ(app.remaining(), std::vector<std::string>({"--", "other"}));
+    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+}
+
 TEST_F(TApp, PrefixSubcom) {
     auto subc = app.add_subcommand("subc");
     subc->prefix_command();

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -430,7 +430,7 @@ TEST_F(TApp, PrefixSeparation) {
 
     run();
 
-    EXPECT_EQ(app.remaining(), std::vector<std::string>({"--", "other"}));
+    EXPECT_EQ(app.remaining(), std::vector<std::string>({"other"}));
     EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
 }
 


### PR DESCRIPTION
Allow `--` to end an unlimited option (specifically, it gets "eaten" when it does end an unlimited option).