### PR TITLE
Better mixing of positionals and unlimited options

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Extra positional arguments will cause the program to exit, so at least one posit
 If you set `.allow_extras()` on the main `App`, you will not get an error. You can access the missing options using `remaining` (if you have subcommands, `app.remaining(true)` will get all remaining options, subcommands included).
 
 You can access a vector of pointers to the parsed options in the original order using `parse_order()`.
-If `--` is present in the command line,
+If `--` is present in the command line that does not end an unlimited option, then
 everything after that is positional only.
 
 

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1461,12 +1461,6 @@ class App {
                     // If any positionals remain, don't keep eating
                     if(_count_remaining_positionals() > 0)
                         break;
-
-                    // If there are any unlimited positionals, those also take priority
-                    if(std::any_of(std::begin(options_), std::end(options_), [](const Option_p &opt) {
-                           return opt->get_positional() && opt->get_items_expected() < 0;
-                       }))
-                        break;
                 }
                 op->add_result(args.back());
                 parse_order_.push_back(op.get());

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -543,8 +543,22 @@ TEST_F(TApp, RequiredOptsUnlimited) {
     std::vector<std::string> remain;
     app.add_option("positional", remain);
     run();
+    EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
+    EXPECT_EQ(remain, std::vector<std::string>());
+
+    app.reset();
+    args = {"--str", "one", "--", "two"};
+
+    run();
     EXPECT_EQ(strs, std::vector<std::string>({"one"}));
     EXPECT_EQ(remain, std::vector<std::string>({"two"}));
+
+    app.reset();
+    args = {"one", "--str", "two"};
+
+    run();
+    EXPECT_EQ(strs, std::vector<std::string>({"two"}));
+    EXPECT_EQ(remain, std::vector<std::string>({"one"}));
 }
 
 TEST_F(TApp, RequiredOptsUnlimitedShort) {
@@ -577,8 +591,22 @@ TEST_F(TApp, RequiredOptsUnlimitedShort) {
     std::vector<std::string> remain;
     app.add_option("positional", remain);
     run();
+    EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
+    EXPECT_EQ(remain, std::vector<std::string>());
+
+    app.reset();
+    args = {"-s", "one", "--", "two"};
+
+    run();
     EXPECT_EQ(strs, std::vector<std::string>({"one"}));
     EXPECT_EQ(remain, std::vector<std::string>({"two"}));
+
+    app.reset();
+    args = {"one", "-s", "two"};
+
+    run();
+    EXPECT_EQ(strs, std::vector<std::string>({"two"}));
+    EXPECT_EQ(remain, std::vector<std::string>({"one"}));
 }
 
 TEST_F(TApp, OptsUnlimitedEnd) {


### PR DESCRIPTION
Since `--` can end an unlimited option, it no longer makes sense to force short-circuiting of unlimited options over positionals. Should give more predictable behavior (closes #102).