### PR TITLE
Adding REQUIRED and Needs, using simple name more often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 * Make unlimited positionals vs. unlimited options more intuitive [#102]
 * Add missing getters `get_options` and `get_description` to App [#105]
 * The app name now can be set, and will override the auto name if present [#105]
+* Add `(REQUIRED)` for required options [#104]
+* Print simple name for Needs/Excludes [#104]
+* Use Needs instead of Requires in help print [#104]
 
 [#102]: https://github.com/CLIUtils/CLI11/issues/102
 [#105]: https://github.com/CLIUtils/CLI11/issues/105
+[#104]: https://github.com/CLIUtils/CLI11/pull/104
 
 
 ## Version 1.5: Optionals

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -295,7 +295,7 @@ class Option : public OptionBase<Option> {
     Option *needs(Option *opt) {
         auto tup = requires_.insert(opt);
         if(!tup.second)
-            throw OptionAlreadyAdded::Requires(get_name(), opt->get_name());
+            throw OptionAlreadyAdded::Requires(single_name(), opt->single_name());
         return this;
     }
 
@@ -503,18 +503,20 @@ class Option : public OptionBase<Option> {
                 out << " x " << get_expected();
             if(get_expected() == -1)
                 out << " ...";
+            if(get_required())
+                out << " (REQUIRED)";
         }
         if(!envname_.empty())
             out << " (env:" << envname_ << ")";
         if(!requires_.empty()) {
-            out << " Requires:";
+            out << " Needs:";
             for(const Option *opt : requires_)
-                out << " " << opt->get_name();
+                out << " " << opt->single_name();
         }
         if(!excludes_.empty()) {
             out << " Excludes:";
             for(const Option *opt : excludes_)
-                out << " " << opt->get_name();
+                out << " " << opt->single_name();
         }
         return out.str();
     }

--- a/scripts/clang-format-pre-commit
+++ b/scripts/clang-format-pre-commit
@@ -9,13 +9,12 @@ format_file() {
     file="${1}"
     case "$file" in
     *.hpp | *.cpp | .c | *.cc | *.cu | *.h )
-        echo "Formatting: $file"
         clang-format -i -style=file -sort-includes "${1}"
-        if git diff-file --quiet -- "${1}" ; then
+        if git diff-files --quiet -- "${1}" ; then
+            echo "Already formatted: ${1}"
+        else
             git add "${1}"
             echo "Reformatting file: ${1}"
-        else
-            echo "Already formatted: ${1}"
         fi;
         ;;
     *)

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -331,13 +331,15 @@ TEST_F(TApp, OptionFromDefaultsSubcommands) {
     EXPECT_EQ(app2->option_defaults()->get_group(), "Something");
 }
 
-TEST_F(TApp, HelpFlagFromDefaultsSubcommands) {
-    app.set_help_flag("--that", "Wow");
+TEST_F(TApp, GetNameCheck) {
+    int x;
+    auto a = app.add_flag("--that");
+    auto b = app.add_flag("-x");
+    auto c = app.add_option("pos", x);
 
-    auto app2 = app.add_subcommand("app2");
-
-    EXPECT_EQ(app2->get_help_ptr()->get_name(), "--that");
-    EXPECT_EQ(app2->get_help_ptr()->get_description(), "Wow");
+    EXPECT_EQ(a->get_name(), "--that");
+    EXPECT_EQ(b->get_name(), "-x");
+    EXPECT_EQ(c->get_name(), "pos");
 }
 
 TEST_F(TApp, SubcommandDefaults) {

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -162,7 +162,7 @@ TEST(THelp, Needs) {
 
     std::string help = app.help();
 
-    EXPECT_THAT(help, HasSubstr("Requires: --op1"));
+    EXPECT_THAT(help, HasSubstr("Needs: --op1"));
 }
 
 TEST(THelp, NeedsPositional) {
@@ -176,7 +176,7 @@ TEST(THelp, NeedsPositional) {
     std::string help = app.help();
 
     EXPECT_THAT(help, HasSubstr("Positionals:"));
-    EXPECT_THAT(help, HasSubstr("Requires: op1"));
+    EXPECT_THAT(help, HasSubstr("Needs: op1"));
 }
 
 TEST(THelp, Excludes) {
@@ -494,4 +494,25 @@ TEST(THelp, AccessDescription) {
     CLI::App app{"My description goes here"};
 
     EXPECT_EQ(app.get_description(), "My description goes here");
+}
+
+TEST(THelp, CleanNeeds) {
+    CLI::App app;
+
+    int x;
+    auto a_name = app.add_option("-a,--alpha", x);
+    app.add_option("-b,--boo", x)->needs(a_name);
+
+    EXPECT_THAT(app.help(), Not(HasSubstr("Requires")));
+    EXPECT_THAT(app.help(), Not(HasSubstr("Needs: -a,--alpha")));
+    EXPECT_THAT(app.help(), HasSubstr("Needs: --alpha"));
+}
+
+TEST(THelp, RequiredPrintout) {
+    CLI::App app;
+
+    int x;
+    app.add_option("-a,--alpha", x)->required();
+
+    EXPECT_THAT(app.help(), HasSubstr("(REQUIRED)"));
 }


### PR DESCRIPTION
Changes:

* `(REQUIRED)` is now added for required options
* `Needs` is printed instead of `Requires` in help
* Simple name is used in more places to keep help readable