### PR TITLE
Adding smart validators

### DIFF
--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -272,6 +272,14 @@ class Option : public OptionBase<Option> {
         return this;
     }
 
+    /// Adds a validator with a built in type name
+    Option *check(const Validator &validator) {
+        validators_.emplace_back(validator.func);
+        if(!validator.tname.empty())
+            set_type_name(validator.tname);
+        return this;
+    }
+
     /// Adds a validator
     Option *check(std::function<std::string(const std::string &)> validator) {
         validators_.emplace_back(validator);


### PR DESCRIPTION
This adds smart validators to CLI11. They look and work just like the old ones, and user validators work as well... But the type name now changes automagically to fit the validator, and you can combine validators with `&` and `|`. A custom class is provided for users to add validators that support these new features.