### PR TITLE
Add virtual destructor to Config class

### DIFF
--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -78,6 +78,9 @@ class Config {
 
         return from_config(input);
     }
+
+    /// virtual destructor
+    virtual ~Config() = default;
 };
 
 /// This converter works with INI files


### PR DESCRIPTION
Clang++/LLVM 6.0 complains about this from warning `-Wdelete-non-virtual-dtor` which is included when using `-Wall`. This also follows virtual destructor usage in `App` and `FormatterBase`.

By the way, I am still working on #128, I just saw this particular warning when I bumped the compiler version in my own project and figured I'd fix it!