### PR TITLE
Rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
         .ci/build_docs.sh
       fi
 
-    # GCC 6 and Coverage
+    # GCC 7 and coverage (8 does not support lcov, wait till 9 and new lcov)
   - compiler: gcc
     env:
     - GCC_VER=7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ Validators are now much more powerful [#118], all built in validators upgraded t
 
 Other changes:
 
-* Dropped `set_*` names on options, using `type_name` and `type_size` instead of `set_custom_option`. Methods return this.
+* Dropped `set_` on Option's `type_name`, `default_str`, and `default_val`
+* Replaced `set_custom_option` with `type_name` and `type_size` instead of `set_custom_option`. Methods return `this`.
+* Removed `set_` from App's `failure_message`, `footer`, `callback`, and `name`
 * Added `->each()` to make adding custom callbacks easier [#126]
 * Added filter argument to `get_subcommands`, `get_options`; use empty filter `{}` to avoid filtering
 * Added `get_groups()` to get groups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Validators are now much more powerful [#118], all built in validators upgraded t
 
 Other changes:
 
+* Dropped `set_*` names on options, using `type_name` and `type_size` instead of `set_custom_option`. Methods return this.
 * Added `->each()` to make adding custom callbacks easier [#126]
 * Added filter argument to `get_subcommands`, `get_options`; use empty filter `{}` to avoid filtering
 * Added `get_groups()` to get groups

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     if(MSVC)
         add_definitions("/W4")
     else()
-        add_definitions(-Wall -Wextra -pedantic -Wno-deprecated-declarations)
+        add_definitions(-Wall -Wextra -pedantic)
     endif()
 
     if(CMAKE_VERSION VERSION_GREATER 3.6)

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ subcommand name from matching.
 If an `App` (main or subcommand) has been parsed on the command line, `->parsed` will be true (or convert directly to bool).
 All `App`s have a `get_subcommands()` method, which returns a list of pointers to the subcommands passed on the command line. A `got_subcommand(App_or_name)` method is also provided that will check to see if an `App` pointer or a string name was collected on the command line.
 
-For many cases, however, using an app's callback may be easier. Every app executes a callback function after it parses; just use a lambda function (with capture to get parsed values) to `.set_callback`. If you throw `CLI::Success` or `CLI::RuntimeError(return_value)`, you can
+For many cases, however, using an app's callback may be easier. Every app executes a callback function after it parses; just use a lambda function (with capture to get parsed values) to `.callback`. If you throw `CLI::Success` or `CLI::RuntimeError(return_value)`, you can
 even exit the program through the callback. The main `App` has a callback slot, as well, but it is generally not as useful.
 You are allowed to throw `CLI::Success` in the callbacks.
 Multiple subcommands are allowed, to allow [`Click`][Click] like series of commands (order is preserved).
@@ -254,14 +254,14 @@ There are several options that are supported on the main app and subcommands. Th
 * `.formatter(fmt)`: Set a formatter, with signature `std::string(const App*, std::string, AppFormatMode)`. See Formatting for more details.
 * `.get_description()`: Access the description.
 * `.parsed()`: True if this subcommand was given on the command line.
-* `.set_name(name)`: Add or change the name.
-* `.set_callback(void() function)`: Set the callback that runs at the end of parsing. The options have already run at this point.
+* `.name(name)`: Add or change the name.
+* `.callback(void() function)`: Set the callback that runs at the end of parsing. The options have already run at this point.
 * `.allow_extras()`: Do not throw an error if extra arguments are left over.
 * `.prefix_command()`: Like `allow_extras`, but stop immediately on the first unrecognised item. It is ideal for allowing your app or subcommand to be a "prefix" to calling another app.
-* `.set_footer(message)`: Set text to appear at the bottom of the help string.
+* `.footer(message)`: Set text to appear at the bottom of the help string.
 * `.set_help_flag(name, message)`: Set the help flag name and message, returns a pointer to the created option.
 * `.set_help_all_flag(name, message)`: Set the help all flag name and message, returns a pointer to the created option. Expands subcommands.
-* `.set_failure_message(func)`: Set the failure message function. Two provided: `CLI::FailureMessage::help` and `CLI::FailureMessage::simple` (the default).
+* `.failure_message(func)`: Set the failure message function. Two provided: `CLI::FailureMessage::help` and `CLI::FailureMessage::simple` (the default).
 * `.group(name)`: Set a group name, defaults to `"Subcommands"`. Setting `""` will be hide the subcommand.
 
 > Note: if you have a fixed number of required positional options, that will match before subcommand names. `{}` is an empty filter function.
@@ -320,7 +320,7 @@ their own formatter since you can't access anything but the call operator once a
 
 The App class was designed allow toolkits to subclass it, to provide preset default options (see above) and setup/teardown code. Subcommands remain an unsubclassed `App`, since those are not expected to need setup and teardown. The default `App` only adds a help flag, `-h,--help`, than can removed/replaced using `.set_help_flag(name, help_string)`. You can also set a help-all flag with `.set_help_all_flag(name, help_string)`; this will expand the subcommands (one level only). You can remove options if you have pointers to them using `.remove_option(opt)`. You can add a `pre_callback` override to customize the after parse
 but before run behavior, while
-still giving the user freedom to `set_callback` on the main app.
+still giving the user freedom to `callback` on the main app.
 
 The most important parse function is `parse(std::vector<std::string>)`, which takes a reversed list of arguments (so that `pop_back` processes the args in the correct order). `get_help_ptr` and `get_config_ptr` give you access to the help/config option pointers. The standard `parse` manually sets the name from the first argument, so it should not be in this vector.
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ The add commands return a pointer to an internally stored `Option`. If you set t
 
 * `->required()`: The program will quit if this option is not present. This is `mandatory` in Plumbum, but required options seems to be a more standard term. For compatibility, `->mandatory()` also works.
 * `->expected(N)`: Take `N` values instead of as many as possible, only for vector args. If negative, require at least `-N`; end with `--` or another recognized option.
-* `->set_custom_option(typename, N)`: Set the name and (optional) intrinsic size of an option. The parser will require multiples of this number if negative.
+* `->type_name(typename)`: Set the name of an Option's type (`type_name_fn` allows a function instead)
+* `->type_size(N)`: Set the intrinsic size of an option. The parser will require multiples of this number if negative.
 * `->needs(opt)`: This option requires another option to also be present, opt is an `Option` pointer.
 * `->excludes(opt)`: This option cannot be given with `opt` present, opt is an `Option` pointer.
 * `->envname(name)`: Gets the value from the environment if present and not passed on the command line.

--- a/examples/enum.cpp
+++ b/examples/enum.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
 
     Level level;
     app.add_set("-l,--level", level, {Level::High, Level::Medium, Level::Low}, "Level settings")
-        ->set_type_name("enum/Level in {High=0, Medium=1, Low=2}");
+        ->type_name("enum/Level in {High=0, Medium=1, Low=2}");
 
     CLI11_PARSE(app, argc, argv);
 

--- a/examples/subcom_in_files/subcommand_a.cpp
+++ b/examples/subcom_in_files/subcommand_a.cpp
@@ -18,7 +18,7 @@ void setup_subcommand_a(CLI::App &app) {
     sub->add_flag("--with-foo", opt->with_foo, "Counter");
 
     // Set the run function as callback to be called when this subcommand is issued.
-    sub->set_callback([opt]() { run_subcommand_a(*opt); });
+    sub->callback([opt]() { run_subcommand_a(*opt); });
 }
 
 /// The function that runs our code.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1039,6 +1039,18 @@ class App {
             return formatter_->make_help(this, prev, mode);
     }
 
+    /// Provided for backwards compatibility \deprecated
+    CLI11_DEPRECATED("Please use footer instead")
+    App *set_footer(std::string msg) { return footer(msg); }
+
+    /// Provided for backwards compatibility \deprecated
+    CLI11_DEPRECATED("Please use name instead")
+    App *set_name(std::string msg) { return name(msg); }
+
+    /// Provided for backwards compatibility \deprecated
+    CLI11_DEPRECATED("Please use callback instead")
+    App *set_callback(std::function<void()> fn) { return callback(fn); }
+
     ///@}
     /// @name Getters
     ///@{

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -331,7 +331,7 @@ class App {
         CLI::callback_t fun = [&variable](CLI::results_t res) { return detail::lexical_cast(res[0], variable); };
 
         Option *opt = add_option(name, fun, description, false);
-        opt->set_custom_option(detail::type_name<T>());
+        opt->type_name(detail::type_name<T>());
         return opt;
     }
 
@@ -345,11 +345,11 @@ class App {
         CLI::callback_t fun = [&variable](CLI::results_t res) { return detail::lexical_cast(res[0], variable); };
 
         Option *opt = add_option(name, fun, description, defaulted);
-        opt->set_custom_option(detail::type_name<T>());
+        opt->type_name(detail::type_name<T>());
         if(defaulted) {
             std::stringstream out;
             out << variable;
-            opt->set_default_str(out.str());
+            opt->default_str(out.str());
         }
         return opt;
     }
@@ -371,7 +371,7 @@ class App {
         };
 
         Option *opt = add_option(name, fun, description, false);
-        opt->set_custom_option(detail::type_name<T>(), -1);
+        opt->type_name(detail::type_name<T>())->type_size(-1);
         return opt;
     }
 
@@ -393,9 +393,9 @@ class App {
         };
 
         Option *opt = add_option(name, fun, description, defaulted);
-        opt->set_custom_option(detail::type_name<T>(), -1);
+        opt->type_name(detail::type_name<T>())->type_size(-1);
         if(defaulted)
-            opt->set_default_str("[" + detail::join(variable) + "]");
+            opt->default_str("[" + detail::join(variable) + "]");
         return opt;
     }
 
@@ -440,7 +440,7 @@ class App {
         Option *opt = add_option(name, fun, description, false);
         if(opt->get_positional())
             throw IncorrectConstruction::PositionalFlag(name);
-        opt->set_custom_option("", 0);
+        opt->type_size(0);
         return opt;
     }
 
@@ -460,7 +460,7 @@ class App {
         Option *opt = add_option(name, fun, description, false);
         if(opt->get_positional())
             throw IncorrectConstruction::PositionalFlag(name);
-        opt->set_custom_option("", 0);
+        opt->type_size(0);
         return opt;
     }
 
@@ -480,7 +480,7 @@ class App {
         Option *opt = add_option(name, fun, description, false);
         if(opt->get_positional())
             throw IncorrectConstruction::PositionalFlag(name);
-        opt->set_custom_option("", 0);
+        opt->type_size(0);
         opt->multi_option_policy(CLI::MultiOptionPolicy::TakeLast);
         return opt;
     }
@@ -499,7 +499,7 @@ class App {
         Option *opt = add_option(name, fun, description, false);
         if(opt->get_positional())
             throw IncorrectConstruction::PositionalFlag(name);
-        opt->set_custom_option("", 0);
+        opt->type_size(0);
         return opt;
     }
 
@@ -530,7 +530,7 @@ class App {
         Option *opt = add_option(name, fun, description, false);
         std::string typeval = detail::type_name<T>();
         typeval += " in {" + detail::join(options) + "}";
-        opt->set_custom_option(typeval);
+        opt->type_name(typeval);
         return opt;
     }
 
@@ -550,7 +550,7 @@ class App {
         };
 
         Option *opt = add_option(name, fun, description, false);
-        opt->set_type_name_fn(
+        opt->type_name_fn(
             [&options]() { return std::string(detail::type_name<T>()) + " in {" + detail::join(options) + "}"; });
 
         return opt;
@@ -575,11 +575,11 @@ class App {
         Option *opt = add_option(name, fun, description, defaulted);
         std::string typeval = detail::type_name<T>();
         typeval += " in {" + detail::join(options) + "}";
-        opt->set_custom_option(typeval);
+        opt->type_name(typeval);
         if(defaulted) {
             std::stringstream out;
             out << member;
-            opt->set_default_str(out.str());
+            opt->default_str(out.str());
         }
         return opt;
     }
@@ -601,12 +601,12 @@ class App {
         };
 
         Option *opt = add_option(name, fun, description, defaulted);
-        opt->set_type_name_fn(
+        opt->type_name_fn(
             [&options]() { return std::string(detail::type_name<T>()) + " in {" + detail::join(options) + "}"; });
         if(defaulted) {
             std::stringstream out;
             out << member;
-            opt->set_default_str(out.str());
+            opt->default_str(out.str());
         }
         return opt;
     }
@@ -634,7 +634,7 @@ class App {
         Option *opt = add_option(name, fun, description, false);
         std::string typeval = detail::type_name<std::string>();
         typeval += " in {" + detail::join(options) + "}";
-        opt->set_custom_option(typeval);
+        opt->type_name(typeval);
 
         return opt;
     }
@@ -660,7 +660,7 @@ class App {
         };
 
         Option *opt = add_option(name, fun, description, false);
-        opt->set_type_name_fn([&options]() {
+        opt->type_name_fn([&options]() {
             return std::string(detail::type_name<std::string>()) + " in {" + detail::join(options) + "}";
         });
 
@@ -691,9 +691,9 @@ class App {
         Option *opt = add_option(name, fun, description, defaulted);
         std::string typeval = detail::type_name<std::string>();
         typeval += " in {" + detail::join(options) + "}";
-        opt->set_custom_option(typeval);
+        opt->type_name(typeval);
         if(defaulted) {
-            opt->set_default_str(member);
+            opt->default_str(member);
         }
         return opt;
     }
@@ -720,11 +720,11 @@ class App {
         };
 
         Option *opt = add_option(name, fun, description, defaulted);
-        opt->set_type_name_fn([&options]() {
+        opt->type_name_fn([&options]() {
             return std::string(detail::type_name<std::string>()) + " in {" + detail::join(options) + "}";
         });
         if(defaulted) {
-            opt->set_default_str(member);
+            opt->default_str(member);
         }
         return opt;
     }
@@ -749,11 +749,11 @@ class App {
         };
 
         CLI::Option *opt = add_option(name, fun, description, defaulted);
-        opt->set_custom_option(label, 2);
+        opt->type_name(label)->type_size(2);
         if(defaulted) {
             std::stringstream out;
             out << variable;
-            opt->set_default_str(out.str());
+            opt->default_str(out.str());
         }
         return opt;
     }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -222,13 +222,13 @@ class App {
     /// it is not possible to overload on std::function (fixed in c++14
     /// and backported to c++11 on newer compilers). Use capture by reference
     /// to get a pointer to App if needed.
-    App *set_callback(std::function<void()> callback) {
+    App *callback(std::function<void()> callback) {
         callback_ = callback;
         return this;
     }
 
     /// Set a name for the app (empty will use parser to set the name)
-    App *set_name(std::string name = "") {
+    App *name(std::string name = "") {
         name_ = name;
         return this;
     }
@@ -901,7 +901,7 @@ class App {
     }
 
     /// Provide a function to print a help message. The function gets access to the App pointer and error.
-    void set_failure_message(std::function<std::string(const App *, const Error &e)> function) {
+    void failure_message(std::function<std::string(const App *, const Error &e)> function) {
         failure_message_ = function;
     }
 
@@ -1012,7 +1012,7 @@ class App {
     ///@{
 
     /// Set footer.
-    App *set_footer(std::string footer) {
+    App *footer(std::string footer) {
         footer_ = footer;
         return this;
     }

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -30,7 +30,7 @@
 #endif
 #endif
 
-#if defined(PYBIND11_CPP14)
+#if defined(CLI11_CPP14)
 #define CLI11_DEPRECATED(reason) [[deprecated(reason)]]
 #elif defined(_MSC_VER)
 #define CLI11_DEPRECATED(reason) __declspec(deprecated(reason))

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -665,6 +665,10 @@ class Option : public OptionBase<Option> {
         return this;
     }
 
+    /// Provided for backward compatibility \deprecated
+    CLI11_DEPRECATED("Please use type_name instead")
+    Option *set_type_name(std::string typeval) { return type_name(typeval); }
+
     /// Set a custom option size
     Option *type_size(int type_size) {
         type_size_ = type_size;

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1504,7 +1504,7 @@ TEST_F(TApp, CustomDoubleOption) {
         custom_opt = {stol(vals.at(0)), stod(vals.at(1))};
         return true;
     });
-    opt->set_custom_option("INT FLOAT", 2);
+    opt->type_name("INT FLOAT")->type_size(2);
 
     args = {"12", "1.5"};
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CLI11_TESTS
     FormatterTest
     NewParseTest
     OptionalTest
+    DeprecatedTest
     )
 
 set(CLI11_MULTIONLY_TESTS
@@ -66,6 +67,13 @@ foreach(T ${CLI11_MULTIONLY_TESTS})
 
 endforeach()
 
+# Add -Wno-deprecated-declarations to DeprecatedTest
+if(NOT MSVC)
+    target_compile_options(DeprecatedTest PRIVATE -Wno-deprecated-declarations)
+    if(TARGET DeprecatedTest_Single)
+        target_compile_options(DeprecatedTest_Single PRIVATE -Wno-deprecated-declarations)
+    endif()
+endif()
 
 # Link test (build error if inlines missing)
 add_library(link_test_1 link_test_1.cpp)

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -362,7 +362,7 @@ TEST_F(TApp, SubcommandDefaults) {
     app.prefix_command();
     app.ignore_case();
     app.fallthrough();
-    app.set_footer("footy");
+    app.footer("footy");
     app.group("Stuff");
     app.require_subcommand(2, 3);
 

--- a/tests/DeprecatedTest.cpp
+++ b/tests/DeprecatedTest.cpp
@@ -1,0 +1,43 @@
+#ifdef CLI11_SINGLE_FILE
+#include "CLI11.hpp"
+#else
+#include "CLI/CLI.hpp"
+#endif
+
+#include "gtest/gtest.h"
+
+TEST(Deprecated, SetFooter) {
+    CLI::App app{"My prog"};
+
+    app.set_footer("My Footer");
+    EXPECT_EQ("My Footer", app.get_footer());
+}
+
+TEST(Deprecated, SetName) {
+    CLI::App app{"My prog"};
+
+    app.set_name("My Name");
+    EXPECT_EQ("My Name", app.get_name());
+}
+
+TEST(Deprecated, SetCallback) {
+    CLI::App app{"My prog"};
+
+    bool val;
+    app.set_callback([&val]() { val = true; });
+
+    std::vector<std::string> something;
+    app.parse(something);
+
+    EXPECT_TRUE(val);
+}
+
+TEST(Deprecated, SetTypeName) {
+    CLI::App app{"My prog"};
+
+    std::string val;
+    auto opt = app.add_option("--val", val);
+    opt->set_type_name("THAT");
+
+    EXPECT_EQ(opt->get_type_name(), "THAT");
+}

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -24,7 +24,7 @@ TEST(THelp, Basic) {
 
 TEST(THelp, Footer) {
     CLI::App app{"My prog"};
-    app.set_footer("Report bugs to bugs@example.com");
+    app.footer("Report bugs to bugs@example.com");
 
     std::string help = app.help();
 
@@ -128,7 +128,7 @@ TEST(THelp, VectorOpts) {
 
 TEST(THelp, MultiPosOpts) {
     CLI::App app{"My prog"};
-    app.set_name("program");
+    app.name("program");
     std::vector<int> x, y;
     app.add_option("quick", x, "Disc")->expected(2);
     app.add_option("vals", y, "Other");
@@ -535,7 +535,7 @@ TEST_F(CapturedHelp, NormalError) {
 }
 
 TEST_F(CapturedHelp, RepacedError) {
-    app.set_failure_message(CLI::FailureMessage::help);
+    app.failure_message(CLI::FailureMessage::help);
 
     EXPECT_EQ(run(CLI::ExtrasError({"Thing"})), static_cast<int>(CLI::ExitCodes::ExtrasError));
     EXPECT_EQ(out.str(), "");

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -222,8 +222,8 @@ TEST(THelp, ManualSetters) {
     int x = 1;
 
     CLI::Option *op1 = app.add_option("--op", x);
-    op1->set_default_str("12");
-    op1->set_type_name("BIGGLES");
+    op1->default_str("12");
+    op1->type_name("BIGGLES");
     EXPECT_EQ(x, 1);
 
     std::string help = app.help();
@@ -231,7 +231,7 @@ TEST(THelp, ManualSetters) {
     EXPECT_THAT(help, HasSubstr("=12"));
     EXPECT_THAT(help, HasSubstr("BIGGLES"));
 
-    op1->set_default_val("14");
+    op1->default_val("14");
     EXPECT_EQ(x, 14);
     help = app.help();
     EXPECT_THAT(help, HasSubstr("=14"));
@@ -556,7 +556,7 @@ TEST(THelp, CustomDoubleOption) {
         custom_opt = {stol(vals.at(0)), stod(vals.at(1))};
         return true;
     });
-    opt->set_custom_option("INT FLOAT", 2);
+    opt->type_name("INT FLOAT")->type_size(2);
 
     EXPECT_THAT(app.help(), Not(HasSubstr("x 2")));
 }

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -561,6 +561,14 @@ TEST(THelp, CustomDoubleOption) {
     EXPECT_THAT(app.help(), Not(HasSubstr("x 2")));
 }
 
+TEST(THelp, CheckEmptyTypeName) {
+    CLI::App app;
+
+    auto opt = app.add_flag("-f,--flag");
+    std::string name = opt->get_type_name();
+    EXPECT_TRUE(name.empty());
+}
+
 TEST(THelp, AccessDescription) {
     CLI::App app{"My description goes here"};
 

--- a/tests/NewParseTest.cpp
+++ b/tests/NewParseTest.cpp
@@ -17,11 +17,11 @@ add_option(CLI::App &app, std::string name, cx &variable, std::string descriptio
     };
 
     CLI::Option *opt = app.add_option(name, fun, description, defaulted);
-    opt->set_custom_option("COMPLEX", 2);
+    opt->type_name("COMPLEX")->type_size(2);
     if(defaulted) {
         std::stringstream out;
         out << variable;
-        opt->set_default_str(out.str());
+        opt->default_str(out.str());
     }
     return opt;
 }

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -178,10 +178,10 @@ TEST_F(TApp, FooFooProblem) {
 
 TEST_F(TApp, Callbacks) {
     auto sub1 = app.add_subcommand("sub1");
-    sub1->set_callback([]() { throw CLI::Success(); });
+    sub1->callback([]() { throw CLI::Success(); });
     auto sub2 = app.add_subcommand("sub2");
     bool val = false;
-    sub2->set_callback([&val]() { val = true; });
+    sub2->callback([&val]() { val = true; });
 
     args = {"sub2"};
     EXPECT_FALSE(val);
@@ -191,9 +191,9 @@ TEST_F(TApp, Callbacks) {
 
 TEST_F(TApp, RuntimeErrorInCallback) {
     auto sub1 = app.add_subcommand("sub1");
-    sub1->set_callback([]() { throw CLI::RuntimeError(); });
+    sub1->callback([]() { throw CLI::RuntimeError(); });
     auto sub2 = app.add_subcommand("sub2");
-    sub2->set_callback([]() { throw CLI::RuntimeError(2); });
+    sub2->callback([]() { throw CLI::RuntimeError(2); });
 
     args = {"sub1"};
     EXPECT_THROW(run(), CLI::RuntimeError);
@@ -309,7 +309,7 @@ TEST_F(TApp, CallbackOrdering) {
     app.add_option("--val", val);
 
     auto sub = app.add_subcommand("sub");
-    sub->set_callback([&val, &sub_val]() { sub_val = val; });
+    sub->callback([&val, &sub_val]() { sub_val = val; });
 
     args = {"sub", "--val=2"};
     run();
@@ -573,7 +573,7 @@ TEST_F(SubcommandProgram, HelpOrder) {
 
 TEST_F(SubcommandProgram, Callbacks) {
 
-    start->set_callback([]() { throw CLI::Success(); });
+    start->callback([]() { throw CLI::Success(); });
 
     run();
 
@@ -668,8 +668,8 @@ TEST_F(SubcommandProgram, MixedOrderExtras) {
 
 TEST_F(SubcommandProgram, CallbackOrder) {
     std::vector<int> callback_order;
-    start->set_callback([&callback_order]() { callback_order.push_back(1); });
-    stop->set_callback([&callback_order]() { callback_order.push_back(2); });
+    start->callback([&callback_order]() { callback_order.push_back(1); });
+    stop->callback([&callback_order]() { callback_order.push_back(2); });
 
     args = {"start", "stop"};
     run();


### PR DESCRIPTION
Finishing off #128 . Summary:

* Dropped `set_` on Option's `type_name`, `default_str`, and `default_val`. Deprecated `set_type_name`, removed the others.
* Replaced `set_custom_option` with `type_name` and `type_size` instead of `set_custom_option`. Methods now properly return `this`. `set_type_name_fn` also has the `set_` removed.
* Removed `set_` from App's `failure_message`, `footer`, `callback`, and `name`. The final three `set_*` names are deprecated, while `set_failure_message` is simply removed.

The way #128 would look after this PR:

```cpp
->type_name("KEY VALUE")->type_size(-2);
```

That makes a repeating option of size 2. This syntax was chosen over multiple arguments because it is clearer to read and doesn't require a special version for `type_name_fn`.