### PR TITLE
Rename inijoin to ini_join

### DIFF
--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -29,7 +29,7 @@ ConfigINI::to_config(const App *app, bool default_also, bool write_description, 
 
                 // If the option was found on command line
                 if(opt->count() > 0)
-                    value = detail::inijoin(opt->results());
+                    value = detail::ini_join(opt->results());
 
                 // If the option has a default and is requested by optional argument
                 else if(default_also && !opt->get_defaultval().empty())

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -16,7 +16,8 @@ class App;
 
 namespace detail {
 
-inline std::string inijoin(std::vector<std::string> args) {
+/// Comma separated join, adds quotes if needed
+inline std::string ini_join(std::vector<std::string> args) {
     std::ostringstream s;
     size_t start = 0;
     for(const auto &arg : args) {
@@ -37,6 +38,7 @@ inline std::string inijoin(std::vector<std::string> args) {
 
 } // namespace detail
 
+/// Holds values to load into Options
 struct ConfigItem {
     /// This is the list of parents
     std::vector<std::string> parents;

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -7,6 +7,13 @@
 using ::testing::HasSubstr;
 using ::testing::Not;
 
+TEST(StringBased, IniJoin) {
+    std::vector<std::string> items = {"one", "two", "three four"};
+    std::string result = "one two \"three four\"";
+
+    EXPECT_EQ(CLI::detail::ini_join(items), result);
+}
+
 TEST(StringBased, First) {
     std::stringstream ofile;
 


### PR DESCRIPTION
A few small bits of documentation, an extra test, and the rename mentioned above.