### PR TITLE
Add failing test for repeating multi-argument options

### DIFF
--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1593,5 +1593,5 @@ TEST_F(TApp, RepeatingMultiArgumentOptions) {
 
     app.reset();
     args.pop_back();
-    ASSERT_THROW(run(), CLI::ValidationError);
+    ASSERT_THROW(run(), CLI::ArgumentMismatch);
 }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1581,3 +1581,17 @@ TEST_F(TApp, AddRemoveSetItemsNoCase) {
     args = {"--type2", "TYpE2"};
     EXPECT_THROW(run(), CLI::ConversionError);
 }
+
+// #128
+TEST_F(TApp, RepeatingMultiArgumentOptions) {
+    std::vector<std::string> entries;
+    app.add_option("--entry", entries, "set a key and value")->type_name("KEY VALUE")->type_size(-2);
+
+    args = {"--entry", "key1", "value1", "--entry", "key2", "value2"};
+    EXPECT_NO_THROW(run());
+    EXPECT_EQ(entries, std::vector<std::string>({"key1", "value1", "key2", "value2"}));
+
+    app.reset();
+    args.pop_back();
+    ASSERT_THROW(run(), CLI::ValidationError);
+}


### PR DESCRIPTION
Hi @henryiii, I still wasn't able to get #128 working. But I've finally had some time to work on this, so here is a failing test that showcases what I understand to be the proper success and failure behaviors. The success test passes but the `ValidationError` one does not.

Let me know what you think and thank you for working on this issue!