### PR TITLE
Auto-clearing in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,29 +3,29 @@
 Added a new formatting system [#109]. You can now set the formatter on Apps. This has also simplified the internals of Apps and Options a bit by separating most formatting code.
 
 * Added `CLI::Formatter` and `formatter` slot for apps, inherited.
-* `FormatterBase` is the minimum required
-* `FormatterLambda` provides for the easy addition of an arbitrary function
-* Added `help_all` support (not added by default)
+* `FormatterBase` is the minimum required.
+* `FormatterLambda` provides for the easy addition of an arbitrary function.
+* Added `help_all` support (not added by default).
 
 Changes to the help system (most normal users will not notice this):
 
-* Renamed `single_name` to `get_name(false, false)` (the default)
-* The old `get_name()` is now `get_name(false, true)`
-* The old `get_pname()` is now `get_name(true, false)`
-* Removed `help_*` functions
-* Protected function `_has_help_positional` removed
-* `format_help` can now be chained
+* Renamed `single_name` to `get_name(false, false)` (the default).
+* The old `get_name()` is now `get_name(false, true)`.
+* The old `get_pname()` is now `get_name(true, false)`.
+* Removed `help_*` functions.
+* Protected function `_has_help_positional` removed.
+* `format_help` can now be chained.
 
 
 New for Config file reading and writing [#121]:
 
-* Overridable, bidirectional Config
-* ConfigINI provided and used by default
-* Renamed ini to config in many places
-* Has `config_formatter()` and `get_config_formatter()`
-* Dropped prefix argument from `config_to_str`
-* Added `ConfigItem`
-* Added an example of a custom config format using [json](https://github.com/nlohmann/json) [#138]
+* Overridable, bidirectional Config.
+* ConfigINI provided and used by default.
+* Renamed ini to config in many places.
+* Has `config_formatter()` and `get_config_formatter()`.
+* Dropped prefix argument from `config_to_str`.
+* Added `ConfigItem`.
+* Added an example of a custom config format using [nlohmann/json]. [#138]
 
 
 Validators are now much more powerful [#118], all built in validators upgraded to the new form:
@@ -37,24 +37,27 @@ Validators are now much more powerful [#118], all built in validators upgraded t
 
 Other changes:
 
+* Fixing `parse(args)`'s `args` setting and ordering after parse. [#141]
+* Cleaner tests without `app.reset()` (and `reset` is now `clear`). [#141]
 * Replaced `set_custom_option` with `type_name` and `type_size` instead of `set_custom_option`. Methods return `this`. [#136]
-* Dropped `set_` on Option's `type_name`, `default_str`, and `default_val` [#136]
-* Removed `set_` from App's `failure_message`, `footer`, `callback`, and `name` [#136]
-* Added `->each()` to make adding custom callbacks easier [#126]
-* Added filter argument to `get_subcommands`, `get_options`; use empty filter `{}` to avoid filtering
-* Added `get_groups()` to get groups
-* Added getters for the missing parts of options (help no longer uses any private parts)
-* Better support for manual options with `get_option`, `set_results`, and `empty` [#119]
-* `lname` and `sname` have getters, added `const get_parent` [#120]
-* Using `add_set` will now capture L-values for sets, allowing further modification [#113]
-* Internally, `type_name` is now a lambda function; for sets, this reads the set live [#116] 
-* Dropped duplicate way to run `get_type_name` (`get_typeval`)
+* Dropped `set_` on Option's `type_name`, `default_str`, and `default_val`. [#136]
+* Removed `set_` from App's `failure_message`, `footer`, `callback`, and `name`. [#136]
+* Fixed support `N<-1` for `type_size`. [#140]
+* Added `->each()` to make adding custom callbacks easier. [#126]
+* Added filter argument to `get_subcommands`, `get_options`; use empty filter `{}` to avoid filtering.
+* Added `get_groups()` to get groups.
+* Added getters for the missing parts of options (help no longer uses any private parts).
+* Better support for manual options with `get_option`, `set_results`, and `empty`. [#119]
+* `lname` and `sname` have getters, added `const get_parent`. [#120]
+* Using `add_set` will now capture L-values for sets, allowing further modification. [#113]
+* Internally, `type_name` is now a lambda function; for sets, this reads the set live. [#116] 
+* Dropped duplicate way to run `get_type_name` (`get_typeval`).
 * Testing (only) now uses submodules. [#111]
-* Removed `requires` in favor of `needs` (deprecated in last version) [#112]
-* Better CMake policy handling [#110]
-* Includes are properly sorted [#120]
-* Help flags now use new `short_circuit` property to simplify parsing [#121]
-* Const added to argv [#126]
+* Removed `requires` in favor of `needs` (deprecated in last version). [#112]
+* Better CMake policy handling. [#110]
+* Includes are properly sorted. [#120]
+* Help flags now use new `short_circuit` property to simplify parsing. [#121]
+* Const added to argv. [#126]
 
 [#109]: https://github.com/CLIUtils/CLI11/pull/109
 [#110]: https://github.com/CLIUtils/CLI11/pull/110
@@ -69,6 +72,10 @@ Other changes:
 [#126]: https://github.com/CLIUtils/CLI11/pull/126
 [#127]: https://github.com/CLIUtils/CLI11/pull/127
 [#138]: https://github.com/CLIUtils/CLI11/pull/138
+[#140]: https://github.com/CLIUtils/CLI11/pull/140
+[#141]: https://github.com/CLIUtils/CLI11/pull/141
+
+[nlohmann/json]: https://github.com/nlohmann/json
 
 ### Version 1.5.4: Optionals
 This version fixes the optional search in the single file version; some macros were not yet defined when it did the search. You can define the `CLI11_*_OPTIONAL` macros to 0 if needed to eliminate the search.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -878,6 +878,21 @@ class App {
     ///@}
     /// @name Parsing
     ///@{
+    //
+    /// Reset the parsed data
+    void clear() {
+
+        parsed_ = false;
+        missing_.clear();
+        parsed_subcommands_.clear();
+
+        for(const Option_p &opt : options_) {
+            opt->clear();
+        }
+        for(const App_p &app : subcommands_) {
+            app->clear();
+        }
+    }
 
     /// Parses the command line - throws errors
     /// This must be called after the options are in but before the rest of the program.
@@ -895,6 +910,10 @@ class App {
     /// The real work is done here. Expects a reversed vector.
     /// Changes the vector to the remaining options.
     void parse(std::vector<std::string> &args) {
+        // Clear if parsed
+        if(parsed_)
+            clear();
+
         _validate();
         _parse(args);
         run_callback();
@@ -928,21 +947,6 @@ class App {
         }
 
         return e.get_exit_code();
-    }
-
-    /// Reset the parsed data
-    void reset() {
-
-        parsed_ = false;
-        missing_.clear();
-        parsed_subcommands_.clear();
-
-        for(const Option_p &opt : options_) {
-            opt->clear();
-        }
-        for(const App_p &app : subcommands_) {
-            app->reset();
-        }
     }
 
     ///@}

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1365,9 +1365,12 @@ class App {
             size_t num_left_over = remaining_size();
             if(num_left_over > 0) {
                 args = remaining(false);
-                std::reverse(std::begin(args), std::end(args));
                 throw ExtrasError(args);
             }
+        }
+
+        if(parent_ == nullptr) {
+            args = remaining(false);
         }
     }
 

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -914,6 +914,11 @@ class App {
         if(parsed_)
             clear();
 
+        // Redundant (set by _parse on commands/subcommands)
+        // but placed here to make sure this is cleared when
+        // running parse after an error is thrown, even by _validate.
+        parsed_ = true;
+
         _validate();
         _parse(args);
         run_callback();

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1208,7 +1208,7 @@ class App {
 
     /// This returns the number of remaining options, minus the -- seperator
     size_t remaining_size(bool recurse = false) const {
-        size_t count = static_cast<size_t>(std::count_if(
+        auto count = static_cast<size_t>(std::count_if(
             std::begin(missing_), std::end(missing_), [](const std::pair<detail::Classifer, std::string> &val) {
                 return val.first != detail::Classifer::POSITIONAL_MARK;
             }));

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -326,7 +326,6 @@ TEST_F(TApp, MissingValueNonRequiredOpt) {
 
     args = {"-c"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-    app.clear();
 
     args = {"--count"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
@@ -340,7 +339,6 @@ TEST_F(TApp, MissingValueMoreThan) {
 
     args = {"-v", "2"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-    app.clear();
 
     args = {"--vals", "4"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
@@ -410,7 +408,6 @@ TEST_F(TApp, RequiredOptsDouble) {
 
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
 
-    app.clear();
     args = {"--str", "one", "two"};
 
     run();
@@ -426,7 +423,6 @@ TEST_F(TApp, RequiredOptsDoubleShort) {
     args = {"-s", "one"};
 
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-    app.clear();
 
     args = {"-s", "one", "-s", "one", "-s", "one"};
 
@@ -440,7 +436,6 @@ TEST_F(TApp, RequiredOptsDoubleNeg) {
     args = {"-s", "one"};
 
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-    app.clear();
 
     args = {"-s", "one", "two", "-s", "three"};
 
@@ -503,7 +498,6 @@ TEST_F(TApp, RequiredOptsUnlimited) {
 
     args = {"--str"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-    app.clear();
 
     args = {"--str", "one", "--str", "two"};
     run();
@@ -546,7 +540,6 @@ TEST_F(TApp, RequiredOptsUnlimitedShort) {
 
     args = {"-s"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-    app.clear();
 
     args = {"-s", "one", "-s", "two"};
     run();
@@ -660,15 +653,12 @@ TEST_F(TApp, RequiredFlags) {
     app.add_flag("-b")->mandatory(); // Alternate term
 
     EXPECT_THROW(run(), CLI::RequiredError);
-    app.clear();
 
     args = {"-a"};
     EXPECT_THROW(run(), CLI::RequiredError);
-    app.clear();
 
     args = {"-b"};
     EXPECT_THROW(run(), CLI::RequiredError);
-    app.clear();
 
     args = {"-a", "-b"};
     run();
@@ -854,7 +844,6 @@ TEST_F(TApp, FileExists) {
     args = {"--file", myfile};
 
     EXPECT_THROW(run(), CLI::ValidationError);
-    app.clear();
 
     bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a')); // create file
     EXPECT_TRUE(ok);
@@ -934,7 +923,6 @@ TEST_F(TApp, FailSet) {
 
     args = {"--quick", "3", "--quick=2"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-    app.clear();
 
     args = {"--quick=hello"};
     EXPECT_THROW(run(), CLI::ConversionError);
@@ -949,7 +937,6 @@ TEST_F(TApp, FailLValueSet) {
 
     args = {"--quick=hello"};
     EXPECT_THROW(run(), CLI::ConversionError);
-    app.clear();
 
     args = {"--slow=hello"};
     EXPECT_THROW(run(), CLI::ConversionError);
@@ -974,7 +961,6 @@ TEST_F(TApp, InSetIgnoreCase) {
 
     args = {"--quick", "four"};
     EXPECT_THROW(run(), CLI::ConversionError);
-    app.clear();
 
     args = {"--quick=one", "--quick=two"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
@@ -1038,7 +1024,6 @@ TEST_F(TApp, VectorFancyOpts) {
 
     args = {"one", "two"};
     EXPECT_THROW(run(), CLI::RequiredError);
-    app.clear();
 
     EXPECT_THROW(run(), CLI::ParseError);
 }
@@ -1089,7 +1074,6 @@ TEST_F(TApp, ExcludesFlags) {
 
     args = {"--nostr", "-s"};
     EXPECT_THROW(run(), CLI::ExcludesError);
-    app.clear();
 
     args = {"--string", "--nostr"};
     EXPECT_THROW(run(), CLI::ExcludesError);
@@ -1111,7 +1095,6 @@ TEST_F(TApp, ExcludesMixedFlags) {
 
     args = {"--no", "--opt1"};
     EXPECT_THROW(run(), CLI::ExcludesError);
-    app.clear();
 
     args = {"--no", "--opt2"};
     EXPECT_THROW(run(), CLI::ExcludesError);
@@ -1133,15 +1116,12 @@ TEST_F(TApp, NeedsMultiFlags) {
 
     args = {"--optall"};
     EXPECT_THROW(run(), CLI::RequiresError);
-    app.clear();
 
     args = {"--optall", "--opt1"};
     EXPECT_THROW(run(), CLI::RequiresError);
-    app.clear();
 
     args = {"--optall", "--opt2", "--opt1"};
     EXPECT_THROW(run(), CLI::RequiresError);
-    app.clear();
 
     args = {"--optall", "--opt1", "--opt2", "--opt3"};
     run();
@@ -1163,15 +1143,12 @@ TEST_F(TApp, NeedsMixedFlags) {
 
     args = {"--optall"};
     EXPECT_THROW(run(), CLI::RequiresError);
-    app.clear();
 
     args = {"--optall", "--opt1"};
     EXPECT_THROW(run(), CLI::RequiresError);
-    app.clear();
 
     args = {"--optall", "--opt2", "--opt1"};
     EXPECT_THROW(run(), CLI::RequiresError);
-    app.clear();
 
     args = {"--optall", "--opt1", "--opt2", "--opt3"};
     run();
@@ -1189,19 +1166,15 @@ TEST_F(TApp, NeedsChainedFlags) {
 
     args = {"--opt2"};
     EXPECT_THROW(run(), CLI::RequiresError);
-    app.clear();
 
     args = {"--opt3"};
     EXPECT_THROW(run(), CLI::RequiresError);
-    app.clear();
 
     args = {"--opt3", "--opt2"};
     EXPECT_THROW(run(), CLI::RequiresError);
-    app.clear();
 
     args = {"--opt3", "--opt1"};
     EXPECT_THROW(run(), CLI::RequiresError);
-    app.clear();
 
     args = {"--opt2", "--opt1"};
     run();
@@ -1235,11 +1208,9 @@ TEST_F(TApp, RangeInt) {
 
     args = {"--one=1"};
     EXPECT_THROW(run(), CLI::ValidationError);
-    app.clear();
 
     args = {"--one=7"};
     EXPECT_THROW(run(), CLI::ValidationError);
-    app.clear();
 
     args = {"--one=3"};
     run();
@@ -1259,11 +1230,9 @@ TEST_F(TApp, RangeDouble) {
 
     args = {"--one=1"};
     EXPECT_THROW(run(), CLI::ValidationError);
-    app.clear();
 
     args = {"--one=7"};
     EXPECT_THROW(run(), CLI::ValidationError);
-    app.clear();
 
     args = {"--one=3"};
     run();
@@ -1385,7 +1354,6 @@ TEST_F(TApp, ThrowingTransform) {
     args = {"-mone"};
 
     ASSERT_THROW(run(), CLI::ValidationError);
-    app.clear();
 
     try {
         run();
@@ -1456,7 +1424,6 @@ TEST_F(TApp, AddRemoveSetItems) {
 
     args = {"--type1", "TYPE1"};
     EXPECT_THROW(run(), CLI::ConversionError);
-    app.clear();
 
     args = {"--type2", "TYPE2"};
     EXPECT_THROW(run(), CLI::ConversionError);
@@ -1488,7 +1455,6 @@ TEST_F(TApp, AddRemoveSetItemsNoCase) {
 
     args = {"--type1", "TYPe1"};
     EXPECT_THROW(run(), CLI::ConversionError);
-    app.clear();
 
     args = {"--type2", "TYpE2"};
     EXPECT_THROW(run(), CLI::ConversionError);

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -152,13 +152,10 @@ TEST_F(TApp, BoolAndIntFlags) {
     EXPECT_EQ(1, iflag);
     EXPECT_EQ((unsigned int)1, uflag);
 
-    app.reset();
-
     args = {"-b", "-b"};
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_TRUE(bflag);
 
-    app.reset();
     bflag = false;
 
     args = {"-iiiuu"};
@@ -173,10 +170,8 @@ TEST_F(TApp, BoolOnlyFlag) {
     app.add_flag("-b", bflag)->multi_option_policy(CLI::MultiOptionPolicy::Throw);
 
     args = {"-b"};
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_TRUE(bflag);
-
-    app.reset();
 
     args = {"-b", "-b"};
     EXPECT_THROW(run(), CLI::ConversionError);
@@ -331,8 +326,7 @@ TEST_F(TApp, MissingValueNonRequiredOpt) {
 
     args = {"-c"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-
-    app.reset();
+    app.clear();
 
     args = {"--count"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
@@ -346,8 +340,7 @@ TEST_F(TApp, MissingValueMoreThan) {
 
     args = {"-v", "2"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-
-    app.reset();
+    app.clear();
 
     args = {"--vals", "4"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
@@ -362,8 +355,6 @@ TEST_F(TApp, NoMissingValueMoreThan) {
     args = {"-v", "2", "3", "4"};
     run();
     EXPECT_EQ(vals1, std::vector<int>({2, 3, 4}));
-
-    app.reset();
 
     args = {"--vals", "2", "3", "4"};
     run();
@@ -419,7 +410,7 @@ TEST_F(TApp, RequiredOptsDouble) {
 
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
 
-    app.reset();
+    app.clear();
     args = {"--str", "one", "two"};
 
     run();
@@ -435,8 +426,7 @@ TEST_F(TApp, RequiredOptsDoubleShort) {
     args = {"-s", "one"};
 
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-
-    app.reset();
+    app.clear();
 
     args = {"-s", "one", "-s", "one", "-s", "one"};
 
@@ -450,20 +440,15 @@ TEST_F(TApp, RequiredOptsDoubleNeg) {
     args = {"-s", "one"};
 
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-
-    app.reset();
+    app.clear();
 
     args = {"-s", "one", "two", "-s", "three"};
 
-    EXPECT_NO_THROW(run());
-
+    ASSERT_NO_THROW(run());
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two", "three"}));
 
-    app.reset();
     args = {"-s", "one", "two"};
-
-    EXPECT_NO_THROW(run());
-
+    ASSERT_NO_THROW(run());
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
 }
 
@@ -483,7 +468,6 @@ TEST_F(TApp, PositionalNoSpace) {
     EXPECT_EQ(options.size(), (size_t)1);
     EXPECT_EQ(options.at(0), "Test");
 
-    app.reset();
     args = {"-OTest", "param1", "param2"};
     run();
 
@@ -505,7 +489,6 @@ TEST_F(TApp, PositionalNoSpaceLong) {
     EXPECT_EQ(options.size(), (size_t)1);
     EXPECT_EQ(options.at(0), "Test");
 
-    app.reset();
     args = {"--option=Test", "param1", "param2"};
     run();
 
@@ -520,25 +503,22 @@ TEST_F(TApp, RequiredOptsUnlimited) {
 
     args = {"--str"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
+    app.clear();
 
-    app.reset();
     args = {"--str", "one", "--str", "two"};
     run();
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
 
-    app.reset();
     args = {"--str", "one", "two"};
     run();
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
 
     // It's better to feed a hungry option than to feed allow_extras
-    app.reset();
     app.allow_extras();
     run();
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
     EXPECT_EQ(app.remaining(), std::vector<std::string>({}));
 
-    app.reset();
     app.allow_extras(false);
     std::vector<std::string> remain;
     app.add_option("positional", remain);
@@ -546,14 +526,12 @@ TEST_F(TApp, RequiredOptsUnlimited) {
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
     EXPECT_EQ(remain, std::vector<std::string>());
 
-    app.reset();
     args = {"--str", "one", "--", "two"};
 
     run();
     EXPECT_EQ(strs, std::vector<std::string>({"one"}));
     EXPECT_EQ(remain, std::vector<std::string>({"two"}));
 
-    app.reset();
     args = {"one", "--str", "two"};
 
     run();
@@ -568,25 +546,22 @@ TEST_F(TApp, RequiredOptsUnlimitedShort) {
 
     args = {"-s"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
+    app.clear();
 
-    app.reset();
     args = {"-s", "one", "-s", "two"};
     run();
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
 
-    app.reset();
     args = {"-s", "one", "two"};
     run();
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
 
     // It's better to feed a hungry option than to feed allow_extras
-    app.reset();
     app.allow_extras();
     run();
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
     EXPECT_EQ(app.remaining(), std::vector<std::string>({}));
 
-    app.reset();
     app.allow_extras(false);
     std::vector<std::string> remain;
     app.add_option("positional", remain);
@@ -594,14 +569,12 @@ TEST_F(TApp, RequiredOptsUnlimitedShort) {
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
     EXPECT_EQ(remain, std::vector<std::string>());
 
-    app.reset();
     args = {"-s", "one", "--", "two"};
 
     run();
     EXPECT_EQ(strs, std::vector<std::string>({"one"}));
     EXPECT_EQ(remain, std::vector<std::string>({"two"}));
 
-    app.reset();
     args = {"one", "-s", "two"};
 
     run();
@@ -635,7 +608,6 @@ TEST_F(TApp, RequireOptPriority) {
     EXPECT_EQ(strs, std::vector<std::string>({"one"}));
     EXPECT_EQ(remain, std::vector<std::string>({"two", "three"}));
 
-    app.reset();
     args = {"two", "three", "--str", "one", "four"};
     run();
 
@@ -656,7 +628,6 @@ TEST_F(TApp, RequireOptPriorityShort) {
     EXPECT_EQ(strs, std::vector<std::string>({"one"}));
     EXPECT_EQ(remain, std::vector<std::string>({"two", "three"}));
 
-    app.reset();
     args = {"two", "three", "-s", "one", "four"};
     run();
 
@@ -689,17 +660,16 @@ TEST_F(TApp, RequiredFlags) {
     app.add_flag("-b")->mandatory(); // Alternate term
 
     EXPECT_THROW(run(), CLI::RequiredError);
-
-    app.reset();
+    app.clear();
 
     args = {"-a"};
     EXPECT_THROW(run(), CLI::RequiredError);
+    app.clear();
 
-    app.reset();
     args = {"-b"};
     EXPECT_THROW(run(), CLI::RequiredError);
+    app.clear();
 
-    app.reset();
     args = {"-a", "-b"};
     run();
 }
@@ -715,12 +685,10 @@ TEST_F(TApp, CallbackFlags) {
     run();
     EXPECT_EQ(value, (size_t)0);
 
-    app.reset();
     args = {"-v"};
     run();
     EXPECT_EQ(value, (size_t)1);
 
-    app.reset();
     args = {"-vv"};
     run();
     EXPECT_EQ(value, (size_t)2);
@@ -740,12 +708,10 @@ TEST_F(TApp, CallbackFlagsAuto) {
     run();
     EXPECT_EQ(value, (size_t)0);
 
-    app.reset();
     args = {"-v"};
     run();
     EXPECT_EQ(value, (size_t)1);
 
-    app.reset();
     args = {"-vv"};
     run();
     EXPECT_EQ(value, (size_t)2);
@@ -782,8 +748,6 @@ TEST_F(TApp, ForcedPositional) {
     EXPECT_TRUE(one->count());
     EXPECT_EQ(answers1, posit);
 
-    app.reset();
-
     args = {"--", "--one", "two", "three"};
     std::vector<std::string> answers2 = {"--one", "two", "three"};
     run();
@@ -818,8 +782,6 @@ TEST_F(TApp, BigPositional) {
     run();
     EXPECT_EQ(args, vec);
 
-    app.reset();
-
     args = {"one", "two"};
     run();
 
@@ -840,7 +802,7 @@ TEST_F(TApp, Reset) {
     EXPECT_EQ((size_t)1, app.count("-d"));
     EXPECT_DOUBLE_EQ(1.2, doub);
 
-    app.reset();
+    app.clear();
 
     EXPECT_EQ((size_t)0, app.count("--simple"));
     EXPECT_EQ((size_t)0, app.count("-d"));
@@ -866,7 +828,7 @@ TEST_F(TApp, RemoveOption) {
 
 TEST_F(TApp, FileNotExists) {
     std::string myfile{"TestNonFileNotUsed.txt"};
-    EXPECT_NO_THROW(CLI::NonexistentPath(myfile));
+    ASSERT_NO_THROW(CLI::NonexistentPath(myfile));
 
     std::string filename;
     app.add_option("--file", filename)->check(CLI::NonexistentPath);
@@ -874,8 +836,6 @@ TEST_F(TApp, FileNotExists) {
 
     run();
     EXPECT_EQ(myfile, filename);
-
-    app.reset();
 
     bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a')); // create file
     EXPECT_TRUE(ok);
@@ -894,8 +854,7 @@ TEST_F(TApp, FileExists) {
     args = {"--file", myfile};
 
     EXPECT_THROW(run(), CLI::ValidationError);
-
-    app.reset();
+    app.clear();
 
     bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a')); // create file
     EXPECT_TRUE(ok);
@@ -916,8 +875,6 @@ TEST_F(TApp, InSet) {
     run();
     EXPECT_EQ("two", choice);
 
-    app.reset();
-
     args = {"--quick", "four"};
     EXPECT_THROW(run(), CLI::ConversionError);
 }
@@ -929,14 +886,11 @@ TEST_F(TApp, InSetWithDefault) {
 
     run();
     EXPECT_EQ("one", choice);
-    app.reset();
 
     args = {"--quick", "two"};
 
     run();
     EXPECT_EQ("two", choice);
-
-    app.reset();
 
     args = {"--quick", "four"};
     EXPECT_THROW(run(), CLI::ConversionError);
@@ -949,14 +903,11 @@ TEST_F(TApp, InCaselessSetWithDefault) {
 
     run();
     EXPECT_EQ("one", choice);
-    app.reset();
 
     args = {"--quick", "tWo"};
 
     run();
     EXPECT_EQ("two", choice);
-
-    app.reset();
 
     args = {"--quick", "four"};
     EXPECT_THROW(run(), CLI::ConversionError);
@@ -972,8 +923,6 @@ TEST_F(TApp, InIntSet) {
     run();
     EXPECT_EQ(2, choice);
 
-    app.reset();
-
     args = {"--quick", "4"};
     EXPECT_THROW(run(), CLI::ConversionError);
 }
@@ -985,8 +934,7 @@ TEST_F(TApp, FailSet) {
 
     args = {"--quick", "3", "--quick=2"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
-
-    app.reset();
+    app.clear();
 
     args = {"--quick=hello"};
     EXPECT_THROW(run(), CLI::ConversionError);
@@ -1001,8 +949,8 @@ TEST_F(TApp, FailLValueSet) {
 
     args = {"--quick=hello"};
     EXPECT_THROW(run(), CLI::ConversionError);
+    app.clear();
 
-    app.reset();
     args = {"--slow=hello"};
     EXPECT_THROW(run(), CLI::ConversionError);
 }
@@ -1016,21 +964,18 @@ TEST_F(TApp, InSetIgnoreCase) {
     run();
     EXPECT_EQ("one", choice);
 
-    app.reset();
     args = {"--quick", "two"};
     run();
     EXPECT_EQ("Two", choice); // Keeps caps from set
 
-    app.reset();
     args = {"--quick", "ThrEE"};
     run();
     EXPECT_EQ("THREE", choice); // Keeps caps from set
 
-    app.reset();
     args = {"--quick", "four"};
     EXPECT_THROW(run(), CLI::ConversionError);
+    app.clear();
 
-    app.reset();
     args = {"--quick=one", "--quick=two"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
@@ -1073,7 +1018,6 @@ TEST_F(TApp, VectorUnlimString) {
     EXPECT_EQ((size_t)3, app.count("--string"));
     EXPECT_EQ(answer, strvec);
 
-    app.reset();
     args = {"-s", "mystring", "mystring2", "mystring3"};
     run();
     EXPECT_EQ((size_t)3, app.count("--string"));
@@ -1092,11 +1036,10 @@ TEST_F(TApp, VectorFancyOpts) {
     EXPECT_EQ((size_t)3, app.count("--string"));
     EXPECT_EQ(answer, strvec);
 
-    app.reset();
     args = {"one", "two"};
     EXPECT_THROW(run(), CLI::RequiredError);
+    app.clear();
 
-    app.reset();
     EXPECT_THROW(run(), CLI::ParseError);
 }
 
@@ -1122,15 +1065,12 @@ TEST_F(TApp, NeedsFlags) {
 
     run();
 
-    app.reset();
     args = {"-s"};
     run();
 
-    app.reset();
     args = {"-s", "--both"};
     run();
 
-    app.reset();
     args = {"--both"};
     EXPECT_THROW(run(), CLI::RequiresError);
 }
@@ -1141,19 +1081,16 @@ TEST_F(TApp, ExcludesFlags) {
 
     run();
 
-    app.reset();
     args = {"-s"};
     run();
 
-    app.reset();
     args = {"--nostr"};
     run();
 
-    app.reset();
     args = {"--nostr", "-s"};
     EXPECT_THROW(run(), CLI::ExcludesError);
+    app.clear();
 
-    app.reset();
     args = {"--string", "--nostr"};
     EXPECT_THROW(run(), CLI::ExcludesError);
 }
@@ -1166,19 +1103,16 @@ TEST_F(TApp, ExcludesMixedFlags) {
 
     run();
 
-    app.reset();
     args = {"--no"};
     run();
 
-    app.reset();
     args = {"--opt2"};
     run();
 
-    app.reset();
     args = {"--no", "--opt1"};
     EXPECT_THROW(run(), CLI::ExcludesError);
+    app.clear();
 
-    app.reset();
     args = {"--no", "--opt2"};
     EXPECT_THROW(run(), CLI::ExcludesError);
 }
@@ -1191,27 +1125,24 @@ TEST_F(TApp, NeedsMultiFlags) {
 
     run();
 
-    app.reset();
     args = {"--opt1"};
     run();
 
-    app.reset();
     args = {"--opt2"};
     run();
 
-    app.reset();
     args = {"--optall"};
     EXPECT_THROW(run(), CLI::RequiresError);
+    app.clear();
 
-    app.reset();
     args = {"--optall", "--opt1"};
     EXPECT_THROW(run(), CLI::RequiresError);
+    app.clear();
 
-    app.reset();
     args = {"--optall", "--opt2", "--opt1"};
     EXPECT_THROW(run(), CLI::RequiresError);
+    app.clear();
 
-    app.reset();
     args = {"--optall", "--opt1", "--opt2", "--opt3"};
     run();
 }
@@ -1224,27 +1155,24 @@ TEST_F(TApp, NeedsMixedFlags) {
 
     run();
 
-    app.reset();
     args = {"--opt1"};
     run();
 
-    app.reset();
     args = {"--opt2"};
     run();
 
-    app.reset();
     args = {"--optall"};
     EXPECT_THROW(run(), CLI::RequiresError);
+    app.clear();
 
-    app.reset();
     args = {"--optall", "--opt1"};
     EXPECT_THROW(run(), CLI::RequiresError);
+    app.clear();
 
-    app.reset();
     args = {"--optall", "--opt2", "--opt1"};
     EXPECT_THROW(run(), CLI::RequiresError);
+    app.clear();
 
-    app.reset();
     args = {"--optall", "--opt1", "--opt2", "--opt3"};
     run();
 }
@@ -1256,31 +1184,28 @@ TEST_F(TApp, NeedsChainedFlags) {
 
     run();
 
-    app.reset();
     args = {"--opt1"};
     run();
 
-    app.reset();
     args = {"--opt2"};
     EXPECT_THROW(run(), CLI::RequiresError);
+    app.clear();
 
-    app.reset();
     args = {"--opt3"};
     EXPECT_THROW(run(), CLI::RequiresError);
+    app.clear();
 
-    app.reset();
     args = {"--opt3", "--opt2"};
     EXPECT_THROW(run(), CLI::RequiresError);
+    app.clear();
 
-    app.reset();
     args = {"--opt3", "--opt1"};
     EXPECT_THROW(run(), CLI::RequiresError);
+    app.clear();
 
-    app.reset();
     args = {"--opt2", "--opt1"};
     run();
 
-    app.reset();
     args = {"--opt1", "--opt2", "--opt3"};
     run();
 }
@@ -1297,11 +1222,9 @@ TEST_F(TApp, Env) {
     EXPECT_EQ(2, val);
     EXPECT_EQ((size_t)1, vopt->count());
 
-    app.reset();
     vopt->required();
     run();
 
-    app.reset();
     unset_env("CLI11_TEST_ENV_TMP");
     EXPECT_THROW(run(), CLI::RequiredError);
 }
@@ -1312,20 +1235,18 @@ TEST_F(TApp, RangeInt) {
 
     args = {"--one=1"};
     EXPECT_THROW(run(), CLI::ValidationError);
+    app.clear();
 
-    app.reset();
     args = {"--one=7"};
     EXPECT_THROW(run(), CLI::ValidationError);
+    app.clear();
 
-    app.reset();
     args = {"--one=3"};
     run();
 
-    app.reset();
     args = {"--one=5"};
     run();
 
-    app.reset();
     args = {"--one=6"};
     run();
 }
@@ -1338,20 +1259,18 @@ TEST_F(TApp, RangeDouble) {
 
     args = {"--one=1"};
     EXPECT_THROW(run(), CLI::ValidationError);
+    app.clear();
 
-    app.reset();
     args = {"--one=7"};
     EXPECT_THROW(run(), CLI::ValidationError);
+    app.clear();
 
-    app.reset();
     args = {"--one=3"};
     run();
 
-    app.reset();
     args = {"--one=5"};
     run();
 
-    app.reset();
     args = {"--one=6"};
     run();
 }
@@ -1367,7 +1286,7 @@ TEST_F(TApp, AllowExtras) {
 
     args = {"-x", "-f"};
 
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_TRUE(val);
     EXPECT_EQ(app.remaining(), std::vector<std::string>({"-x"}));
 }
@@ -1377,9 +1296,8 @@ TEST_F(TApp, AllowExtrasOrder) {
     app.allow_extras();
 
     args = {"-x", "-f"};
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_EQ(app.remaining(), std::vector<std::string>({"-x", "-f"}));
-    app.reset();
 
     std::vector<std::string> left_over = app.remaining();
     app.parse(left_over);
@@ -1462,14 +1380,12 @@ TEST_F(TApp, ThrowingTransform) {
     auto m = app.add_option("-m,--mess", val);
     m->transform([](std::string) -> std::string { throw CLI::ValidationError("My Message"); });
 
-    EXPECT_NO_THROW(run());
-    app.reset();
+    ASSERT_NO_THROW(run());
 
     args = {"-mone"};
 
     ASSERT_THROW(run(), CLI::ValidationError);
-
-    app.reset();
+    app.clear();
 
     try {
         run();
@@ -1533,17 +1449,15 @@ TEST_F(TApp, AddRemoveSetItems) {
     items.erase("TYPE1");
     items.erase("TYPE2");
 
-    app.reset();
     args = {"--type1", "TYPE6", "--type2", "TYPE7"};
     run();
     EXPECT_EQ(type1, "TYPE6");
     EXPECT_EQ(type2, "TYPE7");
 
-    app.reset();
     args = {"--type1", "TYPE1"};
     EXPECT_THROW(run(), CLI::ConversionError);
+    app.clear();
 
-    app.reset();
     args = {"--type2", "TYPE2"};
     EXPECT_THROW(run(), CLI::ConversionError);
 }
@@ -1567,17 +1481,15 @@ TEST_F(TApp, AddRemoveSetItemsNoCase) {
     items.erase("TYPE1");
     items.erase("TYPE2");
 
-    app.reset();
     args = {"--type1", "TyPE6", "--type2", "tYPE7"};
     run();
     EXPECT_EQ(type1, "TYPE6");
     EXPECT_EQ(type2, "TYPE7");
 
-    app.reset();
     args = {"--type1", "TYPe1"};
     EXPECT_THROW(run(), CLI::ConversionError);
+    app.clear();
 
-    app.reset();
     args = {"--type2", "TYpE2"};
     EXPECT_THROW(run(), CLI::ConversionError);
 }
@@ -1588,10 +1500,9 @@ TEST_F(TApp, RepeatingMultiArgumentOptions) {
     app.add_option("--entry", entries, "set a key and value")->type_name("KEY VALUE")->type_size(-2);
 
     args = {"--entry", "key1", "value1", "--entry", "key2", "value2"};
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_EQ(entries, std::vector<std::string>({"key1", "value1", "key2", "value2"}));
 
-    app.reset();
     args.pop_back();
     ASSERT_THROW(run(), CLI::ArgumentMismatch);
 }

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -326,11 +326,9 @@ TEST(THelp, OnlyOneAllHelp) {
 
     std::vector<std::string> input{"--help-all"};
     EXPECT_THROW(app.parse(input), CLI::ExtrasError);
-    app.clear();
 
     std::vector<std::string> input2{"--yelp"};
     EXPECT_THROW(app.parse(input2), CLI::CallForAllHelp);
-    app.clear();
 
     // Remove the flag
     app.set_help_all_flag();

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -326,14 +326,14 @@ TEST(THelp, OnlyOneAllHelp) {
 
     std::vector<std::string> input{"--help-all"};
     EXPECT_THROW(app.parse(input), CLI::ExtrasError);
+    app.clear();
 
-    app.reset();
     std::vector<std::string> input2{"--yelp"};
     EXPECT_THROW(app.parse(input2), CLI::CallForAllHelp);
+    app.clear();
 
     // Remove the flag
     app.set_help_all_flag();
-    app.reset();
     std::vector<std::string> input3{"--yelp"};
     EXPECT_THROW(app.parse(input3), CLI::ExtrasError);
 }

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -193,7 +193,6 @@ TEST_F(TApp, IniNotRequired) {
     EXPECT_EQ(99, two);
     EXPECT_EQ(3, three);
 
-    app.reset();
     one = two = three = 0;
     args = {"--one=1", "--two=2"};
 
@@ -238,7 +237,7 @@ TEST_F(TApp, IniGetRemainingOption) {
 
     int two = 0;
     app.add_option("--two", two);
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     std::vector<std::string> ExpectedRemaining = {ExtraOption};
     EXPECT_EQ(app.remaining(), ExpectedRemaining);
 }
@@ -256,7 +255,7 @@ TEST_F(TApp, IniGetNoRemaining) {
 
     int two = 0;
     app.add_option("--two", two);
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_EQ(app.remaining().size(), (size_t)0);
 }
 
@@ -291,7 +290,6 @@ TEST_F(TApp, IniNotRequiredNotDefault) {
     EXPECT_EQ(99, two);
     EXPECT_EQ(3, three);
 
-    app.reset();
     args = {"--config", tmpini2};
     run();
 
@@ -360,18 +358,16 @@ TEST_F(TApp, IniRequired) {
 
     run();
 
-    app.reset();
     one = two = three = 0;
     args = {"--one=1", "--two=2"};
 
     run();
 
-    app.reset();
     args = {};
 
     EXPECT_THROW(run(), CLI::RequiredError);
+    app.clear();
 
-    app.reset();
     args = {"--two=2"};
 
     EXPECT_THROW(run(), CLI::RequiredError);
@@ -458,7 +454,7 @@ TEST_F(TApp, IniConfigurable) {
         out << "val=1" << std::endl;
     }
 
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_TRUE(value);
 }
 
@@ -538,7 +534,7 @@ TEST_F(TApp, IniFlagNumbers) {
         out << "flag=3" << std::endl;
     }
 
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_TRUE(boo);
 }
 

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -366,7 +366,6 @@ TEST_F(TApp, IniRequired) {
     args = {};
 
     EXPECT_THROW(run(), CLI::RequiredError);
-    app.clear();
 
     args = {"--two=2"};
 

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -11,13 +11,11 @@ TEST_F(TApp, StdOptionalTest) {
     run();
     EXPECT_FALSE(opt);
 
-    app.reset();
     args = {"-c", "1"};
     run();
     EXPECT_TRUE(opt);
     EXPECT_EQ(*opt, 1);
 
-    app.reset();
     args = {"--count", "3"};
     run();
     EXPECT_TRUE(opt);
@@ -33,13 +31,11 @@ TEST_F(TApp, ExperimentalOptionalTest) {
     run();
     EXPECT_FALSE(opt);
 
-    app.reset();
     args = {"-c", "1"};
     run();
     EXPECT_TRUE(opt);
     EXPECT_EQ(*opt, 1);
 
-    app.reset();
     args = {"--count", "3"};
     run();
     EXPECT_TRUE(opt);
@@ -55,13 +51,11 @@ TEST_F(TApp, BoostOptionalTest) {
     run();
     EXPECT_FALSE(opt);
 
-    app.reset();
     args = {"-c", "1"};
     run();
     EXPECT_TRUE(opt);
     EXPECT_EQ(*opt, 1);
 
-    app.reset();
     args = {"--count", "3"};
     run();
     EXPECT_TRUE(opt);

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -36,7 +36,6 @@ TEST_F(TApp, BasicSubcommands) {
 
     args = {"SUb2"};
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.clear();
 
     args = {"SUb2"};
     try {
@@ -44,7 +43,6 @@ TEST_F(TApp, BasicSubcommands) {
     } catch(const CLI::ExtrasError &e) {
         EXPECT_THAT(e.what(), HasSubstr("SUb2"));
     }
-    app.clear();
 
     args = {"sub1", "extra"};
     try {
@@ -82,7 +80,6 @@ TEST_F(TApp, MultiSubFallthrough) {
     app.require_subcommand(1);
 
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.clear();
 
     args = {"sub1"};
     run();
@@ -195,11 +192,9 @@ TEST_F(TApp, RuntimeErrorInCallback) {
     } catch(const CLI::RuntimeError &e) {
         EXPECT_EQ(1, e.get_exit_code());
     }
-    app.clear();
 
     args = {"sub2"};
     EXPECT_THROW(run(), CLI::RuntimeError);
-    app.clear();
 
     args = {"sub2"};
     try {
@@ -319,7 +314,6 @@ TEST_F(TApp, RequiredSubCom) {
     app.require_subcommand();
 
     EXPECT_THROW(run(), CLI::RequiredError);
-    app.clear();
 
     args = {"sub1"};
     run();
@@ -358,7 +352,6 @@ TEST_F(TApp, Required1SubCom) {
     app.add_subcommand("sub3");
 
     EXPECT_THROW(run(), CLI::RequiredError);
-    app.clear();
 
     args = {"sub1"};
     run();
@@ -502,7 +495,6 @@ TEST_F(SubcommandProgram, MultipleArgs) {
 TEST_F(SubcommandProgram, CaseCheck) {
     args = {"Start"};
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.clear();
 
     args = {"start"};
     run();
@@ -582,15 +574,12 @@ TEST_F(SubcommandProgram, ExtrasErrors) {
 
     args = {"one", "two", "start", "three", "four"};
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.clear();
 
     args = {"start", "three", "four"};
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.clear();
 
     args = {"one", "two"};
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.clear();
 }
 
 TEST_F(SubcommandProgram, OrderedExtras) {
@@ -598,7 +587,6 @@ TEST_F(SubcommandProgram, OrderedExtras) {
     app.allow_extras();
     args = {"one", "two", "start", "three", "four"};
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.clear();
 
     start->allow_extras();
 

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -21,12 +21,12 @@ TEST_F(TApp, BasicSubcommands) {
     run();
     EXPECT_EQ((size_t)0, app.get_subcommands().size());
 
-    app.reset();
     args = {"sub1"};
     run();
     EXPECT_EQ(sub1, app.get_subcommands().at(0));
+    EXPECT_EQ((size_t)1, app.get_subcommands().size());
 
-    app.reset();
+    app.clear();
     EXPECT_EQ((size_t)0, app.get_subcommands().size());
 
     args = {"sub2"};
@@ -34,19 +34,18 @@ TEST_F(TApp, BasicSubcommands) {
     EXPECT_EQ((size_t)1, app.get_subcommands().size());
     EXPECT_EQ(sub2, app.get_subcommands().at(0));
 
-    app.reset();
     args = {"SUb2"};
     EXPECT_THROW(run(), CLI::ExtrasError);
+    app.clear();
 
-    app.reset();
     args = {"SUb2"};
     try {
         run();
     } catch(const CLI::ExtrasError &e) {
         EXPECT_THAT(e.what(), HasSubstr("SUb2"));
     }
+    app.clear();
 
-    app.reset();
     args = {"sub1", "extra"};
     try {
         run();
@@ -72,22 +71,19 @@ TEST_F(TApp, MultiSubFallthrough) {
     EXPECT_TRUE(app.got_subcommand(sub2));
     EXPECT_TRUE(*sub2);
 
-    app.reset();
     app.require_subcommand();
 
     run();
 
-    app.reset();
     app.require_subcommand(2);
 
     run();
 
-    app.reset();
     app.require_subcommand(1);
 
     EXPECT_THROW(run(), CLI::ExtrasError);
+    app.clear();
 
-    app.reset();
     args = {"sub1"};
     run();
 
@@ -109,24 +105,21 @@ TEST_F(TApp, RequiredAndSubcoms) { // #23
     auto bar = app.add_subcommand("bar");
 
     args = {"bar", "foo"};
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_TRUE(*foo);
     EXPECT_FALSE(*bar);
     EXPECT_EQ(baz, "bar");
 
-    app.reset();
     args = {"foo"};
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_FALSE(*foo);
     EXPECT_EQ(baz, "foo");
 
-    app.reset();
     args = {"foo", "foo"};
-    EXPECT_NO_THROW(run());
+    ASSERT_NO_THROW(run());
     EXPECT_TRUE(*foo);
     EXPECT_EQ(baz, "foo");
 
-    app.reset();
     args = {"foo", "other"};
     EXPECT_THROW(run(), CLI::ExtrasError);
 }
@@ -144,7 +137,6 @@ TEST_F(TApp, RequiredAndSubcomFallthrough) {
     EXPECT_TRUE(bar);
     EXPECT_EQ(baz, "other");
 
-    app.reset();
     args = {"bar", "other2"};
     EXPECT_THROW(run(), CLI::ExtrasError);
 }
@@ -164,7 +156,6 @@ TEST_F(TApp, FooFooProblem) {
     EXPECT_EQ(baz_str, "");
     EXPECT_EQ(other_str, "foo");
 
-    app.reset();
     baz_str = "";
     other_str = "";
     baz->required();
@@ -198,19 +189,18 @@ TEST_F(TApp, RuntimeErrorInCallback) {
     args = {"sub1"};
     EXPECT_THROW(run(), CLI::RuntimeError);
 
-    app.reset();
     args = {"sub1"};
     try {
         run();
     } catch(const CLI::RuntimeError &e) {
         EXPECT_EQ(1, e.get_exit_code());
     }
+    app.clear();
 
-    app.reset();
     args = {"sub2"};
     EXPECT_THROW(run(), CLI::RuntimeError);
+    app.clear();
 
-    app.reset();
     args = {"sub2"};
     try {
         run();
@@ -316,7 +306,6 @@ TEST_F(TApp, CallbackOrdering) {
     EXPECT_EQ(2, val);
     EXPECT_EQ(2, sub_val);
 
-    app.reset();
     args = {"--val=2", "sub"};
     run();
     EXPECT_EQ(2, val);
@@ -330,11 +319,9 @@ TEST_F(TApp, RequiredSubCom) {
     app.require_subcommand();
 
     EXPECT_THROW(run(), CLI::RequiredError);
-
-    app.reset();
+    app.clear();
 
     args = {"sub1"};
-
     run();
 }
 
@@ -347,21 +334,15 @@ TEST_F(TApp, SubComExtras) {
     EXPECT_EQ(app.remaining(), std::vector<std::string>({"extra"}));
     EXPECT_EQ(sub->remaining(), std::vector<std::string>());
 
-    app.reset();
-
     args = {"extra1", "extra2", "sub"};
     run();
     EXPECT_EQ(app.remaining(), std::vector<std::string>({"extra1", "extra2"}));
     EXPECT_EQ(sub->remaining(), std::vector<std::string>());
 
-    app.reset();
-
     args = {"sub", "extra1", "extra2"};
     run();
     EXPECT_EQ(app.remaining(), std::vector<std::string>());
     EXPECT_EQ(sub->remaining(), std::vector<std::string>({"extra1", "extra2"}));
-
-    app.reset();
 
     args = {"extra1", "extra2", "sub", "extra3", "extra4"};
     run();
@@ -377,12 +358,11 @@ TEST_F(TApp, Required1SubCom) {
     app.add_subcommand("sub3");
 
     EXPECT_THROW(run(), CLI::RequiredError);
+    app.clear();
 
-    app.reset();
     args = {"sub1"};
     run();
 
-    app.reset();
     args = {"sub1", "sub2"};
     EXPECT_THROW(run(), CLI::ExtrasError);
 }
@@ -522,16 +502,14 @@ TEST_F(SubcommandProgram, MultipleArgs) {
 TEST_F(SubcommandProgram, CaseCheck) {
     args = {"Start"};
     EXPECT_THROW(run(), CLI::ExtrasError);
+    app.clear();
 
-    app.reset();
     args = {"start"};
     run();
 
-    app.reset();
     start->ignore_case();
     run();
 
-    app.reset();
     args = {"Start"};
     run();
 }
@@ -546,12 +524,12 @@ TEST_F(TApp, SubcomInheritCaseCheck) {
     EXPECT_EQ((size_t)2, app.get_subcommands({}).size());
     EXPECT_EQ((size_t)1, app.get_subcommands([](const CLI::App *s) { return s->get_name() == "sub1"; }).size());
 
-    app.reset();
     args = {"SuB1"};
     run();
     EXPECT_EQ(sub1, app.get_subcommands().at(0));
+    EXPECT_EQ((size_t)1, app.get_subcommands().size());
 
-    app.reset();
+    app.clear();
     EXPECT_EQ((size_t)0, app.get_subcommands().size());
 
     args = {"sUb2"};
@@ -576,8 +554,6 @@ TEST_F(SubcommandProgram, Callbacks) {
     start->callback([]() { throw CLI::Success(); });
 
     run();
-
-    app.reset();
 
     args = {"start"};
 
@@ -606,15 +582,15 @@ TEST_F(SubcommandProgram, ExtrasErrors) {
 
     args = {"one", "two", "start", "three", "four"};
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.reset();
+    app.clear();
 
     args = {"start", "three", "four"};
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.reset();
+    app.clear();
 
     args = {"one", "two"};
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.reset();
+    app.clear();
 }
 
 TEST_F(SubcommandProgram, OrderedExtras) {
@@ -622,7 +598,7 @@ TEST_F(SubcommandProgram, OrderedExtras) {
     app.allow_extras();
     args = {"one", "two", "start", "three", "four"};
     EXPECT_THROW(run(), CLI::ExtrasError);
-    app.reset();
+    app.clear();
 
     start->allow_extras();
 
@@ -632,7 +608,6 @@ TEST_F(SubcommandProgram, OrderedExtras) {
     EXPECT_EQ(start->remaining(), std::vector<std::string>({"three", "four"}));
     EXPECT_EQ(app.remaining(true), std::vector<std::string>({"one", "two", "three", "four"}));
 
-    app.reset();
     args = {"one", "two", "start", "three", "--", "four"};
 
     run();
@@ -656,7 +631,6 @@ TEST_F(SubcommandProgram, MixedOrderExtras) {
     EXPECT_EQ(stop->remaining(), std::vector<std::string>({"five", "six"}));
     EXPECT_EQ(app.remaining(true), std::vector<std::string>({"one", "two", "three", "four", "five", "six"}));
 
-    app.reset();
     args = {"one", "two", "stop", "three", "four", "start", "five", "six"};
     run();
 
@@ -675,7 +649,6 @@ TEST_F(SubcommandProgram, CallbackOrder) {
     run();
     EXPECT_EQ(callback_order, std::vector<int>({1, 2}));
 
-    app.reset();
     callback_order.clear();
 
     args = {"stop", "start"};
@@ -728,7 +701,6 @@ TEST_F(ManySubcommands, Required1Fuzzy) {
     run();
     EXPECT_EQ(sub1->remaining(), vs_t({"sub2", "sub3"}));
 
-    app.reset();
     app.require_subcommand(-1);
 
     run();
@@ -742,7 +714,6 @@ TEST_F(ManySubcommands, Required2Fuzzy) {
     EXPECT_EQ(sub2->remaining(), vs_t({"sub3"}));
     EXPECT_EQ(app.remaining(true), vs_t({"sub3"}));
 
-    app.reset();
     app.require_subcommand(-2);
 
     run();
@@ -753,13 +724,11 @@ TEST_F(ManySubcommands, Unlimited) {
     run();
     EXPECT_EQ(app.remaining(true), vs_t());
 
-    app.reset();
     app.require_subcommand();
 
     run();
     EXPECT_EQ(app.remaining(true), vs_t());
 
-    app.reset();
     app.require_subcommand(2, 0); // 2 or more
 
     run();


### PR DESCRIPTION
Drops `app.reset()` in favor of automatic clearing if needed (`parse()` can now be used multiple times natively without extra work, even if an error is thrown and caught). A bug with the arg setting and ordering has been fixed; it was hidden in the tests due to a wrong placement of `app.reset()`. If you need to manually clear an app, `app.clear()` will do exactly what `app.reset()` used to do (consistent name with `opt->clear()`).

`app.reset()` was only intended for use in tests, so no DEPRECATED form provided.