### PR TITLE
Touchup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Changes to the help system (most normal users will not notice this):
 * Removed `help_*` functions.
 * Protected function `_has_help_positional` removed.
 * `format_help` can now be chained.
+* Added getters for the missing parts of options (help no longer uses any private parts).
+* Help flags now use new `short_circuit` property to simplify parsing. [#121]
 
 
 New for Config file reading and writing [#121]:
@@ -38,7 +40,6 @@ Validators are now much more powerful [#118], all built in validators upgraded t
 Other changes:
 
 * Fixing `parse(args)`'s `args` setting and ordering after parse. [#141]
-* Cleaner tests without `app.reset()` (and `reset` is now `clear`). [#141]
 * Replaced `set_custom_option` with `type_name` and `type_size` instead of `set_custom_option`. Methods return `this`. [#136]
 * Dropped `set_` on Option's `type_name`, `default_str`, and `default_val`. [#136]
 * Removed `set_` from App's `failure_message`, `footer`, `callback`, and `name`. [#136]
@@ -46,18 +47,20 @@ Other changes:
 * Added `->each()` to make adding custom callbacks easier. [#126]
 * Added filter argument to `get_subcommands`, `get_options`; use empty filter `{}` to avoid filtering.
 * Added `get_groups()` to get groups.
-* Added getters for the missing parts of options (help no longer uses any private parts).
 * Better support for manual options with `get_option`, `set_results`, and `empty`. [#119]
 * `lname` and `sname` have getters, added `const get_parent`. [#120]
 * Using `add_set` will now capture L-values for sets, allowing further modification. [#113]
-* Internally, `type_name` is now a lambda function; for sets, this reads the set live. [#116] 
 * Dropped duplicate way to run `get_type_name` (`get_typeval`).
-* Testing (only) now uses submodules. [#111]
 * Removed `requires` in favor of `needs` (deprecated in last version). [#112]
+* Const added to argv. [#126]
+
+Backend and testing changes:
+
+* Internally, `type_name` is now a lambda function; for sets, this reads the set live. [#116] 
+* Cleaner tests without `app.reset()` (and `reset` is now `clear`). [#141]
 * Better CMake policy handling. [#110]
 * Includes are properly sorted. [#120]
-* Help flags now use new `short_circuit` property to simplify parsing. [#121]
-* Const added to argv. [#126]
+* Testing (only) now uses submodules. [#111]
 
 [#109]: https://github.com/CLIUtils/CLI11/pull/109
 [#110]: https://github.com/CLIUtils/CLI11/pull/110

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Other changes:
 * Removed `set_` from App's `failure_message`, `footer`, `callback`, and `name`. [#136]
 * Fixed support `N<-1` for `type_size`. [#140]
 * Added `->each()` to make adding custom callbacks easier. [#126]
+* Allow empty options `add_option("-n",{})` to be edited later with `each` [#142]
 * Added filter argument to `get_subcommands`, `get_options`; use empty filter `{}` to avoid filtering.
 * Added `get_groups()` to get groups.
 * Better support for manual options with `get_option`, `set_results`, and `empty`. [#119]
@@ -77,6 +78,7 @@ Backend and testing changes:
 [#138]: https://github.com/CLIUtils/CLI11/pull/138
 [#140]: https://github.com/CLIUtils/CLI11/pull/140
 [#141]: https://github.com/CLIUtils/CLI11/pull/141
+[#142]: https://github.com/CLIUtils/CLI11/pull/142
 
 [nlohmann/json]: https://github.com/nlohmann/json
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -60,6 +60,20 @@ set_property(TEST subcommands_all PROPERTY PASS_REGULAR_EXPRESSION
     "Subcommand: start"
     "Subcommand: stop")
 
+add_cli_exe(validators validators.cpp)
+add_test(NAME validators_help COMMAND validators --help)
+set_property(TEST validators_help PROPERTY PASS_REGULAR_EXPRESSION
+    "  -f,--file FILE              File name"
+    "  -v,--value INT in [3 - 6]   Value in range")
+add_test(NAME validators_file COMMAND validators --file nonex.xxx)
+set_property(TEST validators_file PROPERTY PASS_REGULAR_EXPRESSION
+    "--file: File does not exist: nonex.xxx"
+    "Run with --help for more information.")
+add_test(NAME validators_plain COMMAND validators --value 9)
+set_property(TEST validators_plain PROPERTY PASS_REGULAR_EXPRESSION
+    "--value: Value 9 not in range 3 to 6"
+    "Run with --help for more information.")
+
 add_cli_exe(groups groups.cpp)
 add_test(NAME groups_none COMMAND groups)
 set_property(TEST groups_none PROPERTY PASS_REGULAR_EXPRESSION

--- a/examples/validators.cpp
+++ b/examples/validators.cpp
@@ -1,0 +1,17 @@
+#include "CLI/CLI.hpp"
+
+int main(int argc, char **argv) {
+
+    CLI::App app("Validator checker");
+
+    std::string file;
+    app.add_option("-f,--file,file", file, "File name")->check(CLI::ExistingFile);
+
+    int count;
+    app.add_option("-v,--value", count, "Value in range")->check(CLI::Range(3, 6));
+    CLI11_PARSE(app, argc, argv);
+
+    std::cout << "Try printing help or failing the validator" << std::endl;
+
+    return 0;
+}

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -226,12 +226,10 @@ class Option : public OptionBase<Option> {
     ///@}
 
     /// Making an option by hand is not defined, it must be made by the App class
-    Option(std::string name,
-           std::string description = "",
-           std::function<bool(results_t)> callback = [](results_t) { return true; },
-           bool default_ = true,
-           App *parent = nullptr)
-        : description_(std::move(description)), default_(default_), parent_(parent), callback_(std::move(callback)) {
+    Option(
+        std::string name, std::string description, std::function<bool(results_t)> callback, bool default_, App *parent)
+        : description_(std::move(description)), default_(default_), parent_(parent),
+          callback_(callback ? std::move(callback) : [](results_t) { return true; }) {
         std::tie(snames_, lnames_, pname_) = detail::get_names(detail::split_names(name));
     }
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -227,8 +227,8 @@ class Option : public OptionBase<Option> {
 
     /// Making an option by hand is not defined, it must be made by the App class
     Option(
-        std::string name, std::string description, std::function<bool(results_t)> callback, bool default_, App *parent)
-        : description_(std::move(description)), default_(default_), parent_(parent),
+        std::string name, std::string description, std::function<bool(results_t)> callback, bool defaulted, App *parent)
+        : description_(std::move(description)), default_(defaulted), parent_(parent),
           callback_(callback ? std::move(callback) : [](results_t) { return true; }) {
         std::tie(snames_, lnames_, pname_) = detail::get_names(detail::split_names(name));
     }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1472,3 +1472,23 @@ TEST_F(TApp, RepeatingMultiArgumentOptions) {
     args.pop_back();
     ASSERT_THROW(run(), CLI::ArgumentMismatch);
 }
+
+// #122
+TEST_F(TApp, EmptyOptionEach) {
+    std::string q;
+    app.add_option("--each", {})->each([&q](std::string s) { q = s; });
+
+    args = {"--each", "that"};
+    run();
+
+    EXPECT_EQ(q, "that");
+}
+
+// #122
+TEST_F(TApp, EmptyOptionFail) {
+    std::string q;
+    app.add_option("--each", {});
+
+    args = {"--each", "that"};
+    run();
+}


### PR DESCRIPTION
Allow empty options as requested in ( and closes #122). Use `{}` in `add_option`.

Also adds a Validators example and check.

Better changelog.