### PR TITLE
Work around Windows min/max macro problem

### DIFF
--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -546,7 +546,8 @@ class Option : public OptionBase<Option> {
 
         // Num items expected or length of vector, always at least 1
         // Only valid for a trimming policy
-        int trim_size = std::min(std::max(std::abs(get_items_expected()), 1), static_cast<int>(results_.size()));
+        int trim_size =
+            std::min<int>(std::max<int>(std::abs(get_items_expected()), 1), static_cast<int>(results_.size()));
 
         // Operation depends on the policy setting
         if(multi_option_policy_ == MultiOptionPolicy::TakeLast) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,10 @@ set(CLI11_TESTS
     DeprecatedTest
     )
 
+if(WIN32)
+    list(APPEND CLI11_TESTS WindowsTest)
+endif()
+
 set(CLI11_MULTIONLY_TESTS
     TimerTest
     )

--- a/tests/WindowsTest.cpp
+++ b/tests/WindowsTest.cpp
@@ -1,0 +1,13 @@
+#include "app_helper.hpp"
+#include <Windows.h>
+
+// This test verifies that CLI11 still works if
+// Windows.h is included. #145
+
+TEST_F(TApp, WindowsTestSimple) {
+    app.add_flag("-c,--count");
+    args = {"-c"};
+    run();
+    EXPECT_EQ((size_t)1, app.count("-c"));
+    EXPECT_EQ((size_t)1, app.count("--count"));
+}

--- a/tests/link_test_2.cpp
+++ b/tests/link_test_2.cpp
@@ -4,7 +4,7 @@
 
 int do_nothing();
 
-// Verifies there are no ungarded inlines
+// Verifies there are no unguarded inlines
 TEST(Link, DoNothing) {
     int a = do_nothing();
     EXPECT_EQ(7, a);


### PR DESCRIPTION
This small change works around the very problematic default feature of `windows.h` declaring macros for `min` and `max`.  See https://stackoverflow.com/questions/5004858/stdmin-gives-error

There are other solutions to this problem (Such as defining `#NOMINMAX` on the project developer's side), but this change keeps the code in CLI11 unambiguous.

This would mean that any further invocations of `std::min` or `std::max` in this project would also need to use the explicit template type version for this change to be useful. I would understand if you do not wish to do that. If you *do* think it is worthwhile, a test could also be created that includes `windows.h` such that the macros would be defined and cause errors when building on Windows if min or max is used ambiguously in the future.

