### PR TITLE
Py26

### DIFF
--- a/.ci/make_and_test.sh
+++ b/.ci/make_and_test.sh
@@ -8,7 +8,7 @@ set -evx
 
 mkdir -p build
 cd build
-cmake .. -DCLI11_CXX_STD=$STD -DCLI11_SINGLE_FILE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache $@
+cmake .. -DCLI11_SINGLE_FILE=ON -DCLI11_CXX_STD=$STD -DCLI11_SINGLE_FILE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache $@
 cmake --build . -- -j2
 
 set +evx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
-## Since last version
+## Version 1.6.1: Platform fixes
+This version provides a few fixes for special cases, such as mixing with `Windows.h` and better defaults
+for systems like Hunter. The one new feature is the ability to produce "branded" single file output for
+providing custom namespaces or custom macro names.
+
 * Added fix and test for including Windows.h [#145]
+* No longer build single file by default if main project, supports systems stuck on Python 2.6 [#149], [#151]
+* Branding support for single file output [#150]
 
 [#145]: https://github.com/CLIUtils/CLI11/pull/145
+[#149]: https://github.com/CLIUtils/CLI11/pull/149
+[#150]: https://github.com/CLIUtils/CLI11/pull/150
+[#151]: https://github.com/CLIUtils/CLI11/pull/151
 
 ## Version 1.6: Formatting help
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,33 +112,16 @@ export(TARGETS CLI11
 # Register in the user cmake package registry
 export(PACKAGE CLI11)
 
-# Single file test
-if(CMAKE_VERSION VERSION_LESS 3.12)
-    set(Python_ADDITIONAL_VERSIONS 2.7 3.4 3.5 3.6 3.7 3.8)
-    find_package(PythonInterp)
-    set(Python_VERSION ${PYTHON_VERSION_STRING})
-    set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
-else()
-    find_package(Python)
-endif()
-
-if(Python_Interpreter_FOUND OR PYTHONINTERP_FOUND)
-    if(Python_VERSION VERSION_LESS 2.7)
-        set(CLI11_PYTHON_FOUND FALSE)
-    else()
-        set(CLI11_PYTHON_FOUND TRUE)
-    endif()
-else()
-    set(CLI11_PYTHON_FOUND FALSE)
-endif()
-
-cmake_dependent_option(CLI11_SINGLE_FILE "Generate a single header file" ON "CUR_PROJ;CLI11_PYTHON_FOUND" OFF)
+option(CLI11_SINGLE_FILE "Generate a single header file" OFF)
 
 if(CLI11_SINGLE_FILE)
-    if(NOT CLI11_PYTHON_FOUND)
-        message(FATAL_ERROR "CLI11_SINGLE_FILE requires Python 2.7 or 3 (not found)")
+# Single file test
+    if(CMAKE_VERSION VERSION_LESS 3.12)
+        find_package(PythonInterp REQUIRED)
+        set(Python_VERSION ${PYTHON_VERSION_STRING})
+        set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
     else()
-        message(STATUS "Building single file include using Python ${Python_VERSION} at ${Python_EXECUTABLE}")
+        find_package(Python REQUIRED)
     endif()
 
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-CLI11 1.5 Copyright (c) 2017-2018 University of Cincinnati, developed by Henry
+CLI11 1.6 Copyright (c) 2017-2018 University of Cincinnati, developed by Henry
 Schreiner under NSF AWARD 1414736. All rights reserved.
 
 Redistribution and use in source and binary forms of CLI11, with or without

--- a/scripts/MakeSingleHeader.py
+++ b/scripts/MakeSingleHeader.py
@@ -9,7 +9,7 @@ import operator
 from copy import copy
 from functools import reduce
 
-import subprocess
+from subprocess import Popen, PIPE
 
 includes_local = re.compile(r"""^#include "(.*)"$""", re.MULTILINE)
 includes_system = re.compile(r"""^#include \<(.*)\>$""", re.MULTILINE)
@@ -112,12 +112,13 @@ class HeaderFile(object):
 def MakeHeader(output, main_header, include_dir = '../include', namespace=None, macro=None):
     # Set tag if possible to class variable
     try:
-        proc = subprocess.Popen(['git', 'describe', '--tags', '--always'], cwd=str(DIR), stdout=subprocess.PIPE)
+        proc = Popen(['git', 'describe', '--tags', '--always'], cwd=str(DIR), stdout=PIPE)
         out, _ = proc.communicate()
-        if proc.returncode == 0:
-            HeaderFile.TAG = out.decode("utf-8").strip()
     except OSError:
         pass
+    else:
+        if proc.returncode == 0:
+            HeaderFile.TAG = out.decode("utf-8").strip()
 
     base_dir = os.path.abspath(os.path.join(DIR, include_dir))
     main_header = os.path.join(base_dir, main_header)

--- a/scripts/MakeSingleHeader.py
+++ b/scripts/MakeSingleHeader.py
@@ -4,11 +4,10 @@ from __future__ import print_function, unicode_literals
 
 import os
 import re
-import argparse
-import operator
+from argparse import ArgumentParser
+from operator import add
 from copy import copy
 from functools import reduce
-
 from subprocess import Popen, PIPE
 
 includes_local = re.compile(r"""^#include "(.*)"$""", re.MULTILINE)
@@ -79,7 +78,6 @@ class HeaderFile(object):
         self.verbatim = [x.replace(before, after) for x in self.verbatim]
         self.body = self.body.replace(before, after)
 
-
     def __str__(self):
         result = '''\
 #pragma once
@@ -133,12 +131,12 @@ def MakeHeader(output, main_header, include_dir = '../include', namespace=None, 
     include_files = includes_local.findall(header)
 
     headers = [HeaderFile(base_dir, inc) for inc in include_files]
-    single_header = reduce(operator.add, headers)
+    single_header = reduce(add, headers)
 
-    if macro:
-        before, after = macro
-        print("Converting macros", before, "->", after)
-        single_header.macro_replacement(before, after)
+    if macro is not None:
+        before = 'CLI11_'
+        print("Converting macros", before, "->", macro)
+        single_header.macro_replacement(before, macro)
 
     if namespace:
         print("Adding namespace", namespace)
@@ -150,14 +148,13 @@ def MakeHeader(output, main_header, include_dir = '../include', namespace=None, 
     print("Created", output)
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(usage='Convert source to single header include. Can optionally add namespace and search-replace replacements (for macros).')
+    parser = ArgumentParser(usage='Convert source to single header include. Can optionally add namespace and search-replace replacements (for macros).')
     parser.add_argument("output", help="Single header file output")
     parser.add_argument("--main", default='CLI/CLI.hpp', help="The main include file that defines the other files")
     parser.add_argument("--include", default='../include', help="The include directory")
     parser.add_argument("--namespace", help="Add an optional namespace")
-    parser.add_argument("--macro", nargs=2, help="Macro replacement: CLI11_ NEW_PREFIX_")
+    parser.add_argument("--macro", help="Replaces CLI11_ with NEW_PREFIX_")
     args = parser.parse_args()
-
 
     MakeHeader(args.output, args.main, args.include, args.namespace, args.macro)
 


### PR DESCRIPTION
Adding Python 2.6 support because CMake doesn’t seem to have great support for checking python versions. Also making single file version an option you must enable if you want it. Follow up to #149. 