### PR TITLE
Minor build system improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
-cmake_minimum_required(VERSION 3.4...3.11)
+cmake_minimum_required(VERSION 3.4)
+# Note: this is a header only library. If you have an older CMake than 3.4,
+# just add the CLI11/include directory and that's all you need to do.
 
+# Make sure users don't get warnings on a tested (3.4 to 3.12) version
+# of CMake. For most of the policies, the new version is better (hence the change).
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
-    cmake_policy(VERSION ${CMAKE_VERSION})
+    cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+else()
+    cmake_policy(VERSION 3.12)
 endif()
 
 set(VERSION_REGEX "#define CLI11_VERSION[ \t]+\"(.+)\"")
@@ -13,9 +19,8 @@ file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/include/CLI/Version.hpp"
 # Pick out just the version
 string(REGEX REPLACE ${VERSION_REGEX} "\\1" VERSION_STRING "${VERSION_STRING}")
 
+# Add the project
 project(CLI11 LANGUAGES CXX VERSION ${VERSION_STRING})
-
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 # Only if built as the main project
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,10 +3,12 @@ if(NOT EXISTS "${CLI11_SOURCE_DIR}/extern/googletest/CMakeLists.txt")
     git submodule update --init")
 endif()
 
+list(APPEND CMAKE_MODULE_PATH "${CLI11_SOURCE_DIR}/cmake")
+
 # If submodule is available, add sanitizers
 # Set SANITIZE_ADDRESS, SANITIZE_MEMORY, SANITIZE_THREAD or SANITIZE_UNDEFINED
 if(EXISTS "${CLI11_SOURCE_DIR}/extern/sanitizers/cmake/FindSanitizers.cmake")
-    set(CMAKE_MODULE_PATH "${CLI11_SOURCE_DIR}/extern/sanitizers/cmake" ${CMAKE_MODULE_PATH})
+    list(APPEND CMAKE_MODULE_PATH "${CLI11_SOURCE_DIR}/extern/sanitizers/cmake")
     find_package(Sanitizers)
     if(SANITIZE_ADDRESS)
         message(STATUS "You might want to use \"${ASan_WRAPPER}\" to run your program")


### PR DESCRIPTION
Inspired by #153.

No longer change the CMake module path (not really needed), and change the minimum required statement to work around a bug in MSVC's server mode with CMake 3.11. See the [Modern CMake book](https://cliutils.gitlab.io/modern-cmake/chapters/basics.html).