### PR TITLE
Warning fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
+## Version 1.6.2: More special case fixes
+
+This version adds fixes for several warnings, including an experimental optional error on Clang 7.
+
+* Fixed CMake install as subproject with `CLI11_INSTALL` flag. [#156]
+* Fixed warning about local variable hiding class member with MSVC [#157]
+* Fixed compile error with default settings on Clang 7 and libc++ [#158]
+
+[#156]: https://github.com/CLIUtils/CLI11/issues/156
+[#157]: https://github.com/CLIUtils/CLI11/issues/157
+[#158]: https://github.com/CLIUtils/CLI11/issues/158
+
 ## Version 1.6.1: Platform fixes
+
 This version provides a few fixes for special cases, such as mixing with `Windows.h` and better defaults
 for systems like Hunter. The one new feature is the ability to produce "branded" single file output for
 providing custom namespaces or custom macro names.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,16 @@ target_include_directories(CLI11 INTERFACE
 # Make add_subdirectory work like find_package
 add_library(CLI11::CLI11 ALIAS CLI11)
 
+option(CLI11_INSTALL "Install the CLI11 folder to include during install process" ${CUR_PROJ})
+
 # This folder should be installed
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CLI DESTINATION include)
+if(CLI11_INSTALL)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CLI DESTINATION include)
+
+    # Make an export target
+    install(TARGETS CLI11
+            EXPORT CLI11Targets)
+endif()
 
 # Use find_package on the installed package
 # Since we have no custom code, we can directly write this
@@ -95,27 +103,26 @@ write_basic_package_version_file(
     COMPATIBILITY AnyNewerVersion
     )
 
-# Make version available in the install
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/CLI11ConfigVersion.cmake"
-        DESTINATION lib/cmake/CLI11)
+# These installs only make sense for a local project
+if(CUR_PROJ)
+    # Make version available in the install
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/CLI11ConfigVersion.cmake"
+            DESTINATION lib/cmake/CLI11)
 
-# Make an export target
-install(TARGETS CLI11
-        EXPORT CLI11Targets)
+    # Install the export target as a file
+    install(EXPORT CLI11Targets
+            FILE CLI11Config.cmake
+            NAMESPACE CLI11::
+            DESTINATION lib/cmake/CLI11)
 
-# Install the export target as a file
-install(EXPORT CLI11Targets
-        FILE CLI11Config.cmake
-        NAMESPACE CLI11::
-        DESTINATION lib/cmake/CLI11)
+    # Use find_package on the installed package
+    export(TARGETS CLI11
+           NAMESPACE CLI11::
+           FILE CLI11Targets.cmake)
 
-# Use find_package on the installed package
-export(TARGETS CLI11
-       NAMESPACE CLI11::
-       FILE CLI11Targets.cmake)
-
-# Register in the user cmake package registry
-export(PACKAGE CLI11)
+    # Register in the user cmake package registry
+    export(PACKAGE CLI11)
+endif()
 
 option(CLI11_SINGLE_FILE "Generate a single header file" OFF)
 

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -117,7 +117,7 @@ class ConfigINI : public Config {
         std::vector<ConfigItem> output;
 
         while(getline(input, line)) {
-            std::vector<std::string> items;
+            std::vector<std::string> items_buffer;
 
             detail::trim(line);
             size_t len = line.length();
@@ -132,10 +132,10 @@ class ConfigINI : public Config {
                 if(pos != std::string::npos) {
                     out.name = detail::trim_copy(line.substr(0, pos));
                     std::string item = detail::trim_copy(line.substr(pos + 1));
-                    items = detail::split_up(item);
+                    items_buffer = detail::split_up(item);
                 } else {
                     out.name = detail::trim_copy(line);
-                    items = {"ON"};
+                    items_buffer = {"ON"};
                 }
 
                 if(detail::to_lower(section) != "default") {
@@ -149,7 +149,7 @@ class ConfigINI : public Config {
                     out.parents.insert(out.parents.end(), plist.begin(), plist.end());
                 }
 
-                out.inputs.insert(std::end(out.inputs), std::begin(items), std::end(items));
+                out.inputs.insert(std::end(out.inputs), std::begin(items_buffer), std::end(items_buffer));
             }
         }
         return output;

--- a/include/CLI/Optional.hpp
+++ b/include/CLI/Optional.hpp
@@ -10,13 +10,16 @@
 // [CLI11:verbatim]
 #ifdef __has_include
 
+// You can explicitly enable or disable support
+// by defining these to 1 or 0.
 #if defined(CLI11_CPP17) && __has_include(<optional>) && \
      !defined(CLI11_STD_OPTIONAL)
 #define CLI11_STD_OPTIONAL 1
 #endif
 
 #if defined(CLI11_CPP14) && __has_include(<experimental/optional>) && \
-    !defined(CLI11_EXPERIMENTAL_OPTIONAL)
+    !defined(CLI11_EXPERIMENTAL_OPTIONAL) \
+    && (!defined(CLI11_STD_OPTIONAL) || CLI11_STD_OPTIONAL != 0)
 #define CLI11_EXPERIMENTAL_OPTIONAL 1
 #endif
 


### PR DESCRIPTION
This fixes several warnings and auto-config errors. Also upgrading to GoogleTest 1.8.1, removing several warning fixes that were accepted into GoogleTest master and included in 1.8.1.