### PR TITLE
Upgrade googletest and drop GCC 4.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,17 +70,17 @@ matrix:
     - .ci/make_and_test.sh 14 -DCLI11_EXAMPLE_JSON=ON
     - .ci/make_and_test.sh 17 -DCLI11_EXAMPLE_JSON=ON
 
-    # GCC 4.7 and Conan
+    # GCC 4.8 and Conan
   - compiler: gcc
     env:
-    - GCC_VER=4.7
+    - GCC_VER=4.8
     addons:
       apt:
         packages:
-        - g++-4.7
+        - g++-4.8
     install:
-    - export CC=gcc-4.7
-    - export CXX=g++-4.7
+    - export CC=gcc-4.8
+    - export CXX=g++-4.8
     - python -m pip install --user conan
     - conan user
     script:
@@ -95,19 +95,6 @@ matrix:
         conan upload "*" -c -r origin --all
       fi
 
-    # GCC 4.8
-  - compiler: gcc
-    env:
-    - GCC_VER=4.8
-    addons:
-      apt:
-        packages:
-        - g++-4.8
-    install:
-    - export CC=gcc-4.8
-    - export CXX=g++-4.8
-    script:
-    - .ci/make_and_test.sh 11
 
 install: skip
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.9: IN PROGRESS
+
+* GCC 4.7 is no longer supported, due mostly to GoogleTest. GCC 4.8+ is now required.
+
 ## Version 1.8: Transformers, default strings, and flags
 
 Set handling has been completely replaced by a new backend that works as a Validator or Transformer. This provides a single interface instead of the 16 different functions in App. It also allows ordered collections to be used, custom functions for filtering, and better help and error messages. You can also use a collection of pairs (like `std::map`) to transform the match into an output. Also new are inverted flags, which can cancel or reduce the count of flags, and can also support general flag types. A new `add_option_fn` lets you more easily program CLI11 options with the types you choose. Vector options now support a custom separator. Apps can now be composed with unnamed subcommand support. The final bool "defaults" flag when creating options has been replaced by `->capture_default_str()` (ending an old limitation in construction made this possible); the old method is still available but may be removed in future versions.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,8 +58,8 @@ jobs:
       gcc9:
         containerImage: gcc:9
         cli11.std: 17
-      gcc4.7:
-        containerImage: gcc:4.7
+      gcc4.8:
+        containerImage: gcc:4.8
         cli11.std: 11
       clang3.4:
         containerImage: silkeh/clang:3.4

--- a/cmake/AddGoogletest.cmake
+++ b/cmake/AddGoogletest.cmake
@@ -1,16 +1,12 @@
 #
 #
-# Downloads GTest and provides a helper macro to add tests. Add make check, as well, which
+# Includes GTest and provides a helper macro to add tests. Add make check, as well, which
 # gives output on failed tests without having to set an environment variable.
 #
 #
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 set(BUILD_SHARED_LIBS OFF)
-# older version of google tests doesn't support MSYS so needs this flag to compile
-if (MSYS)
-	set(gtest_disable_pthreads ON CACHE BOOL "" FORCE)
-endif()
-set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "")
+
 add_subdirectory("${CLI11_SOURCE_DIR}/extern/googletest" "${CLI11_BINARY_DIR}/extern/googletest" EXCLUDE_FROM_ALL)
 
 
@@ -45,32 +41,5 @@ macro(add_gtest TESTNAME)
 
 endmacro()
 
-mark_as_advanced(
-gmock_build_tests
-gtest_build_samples
-gtest_build_tests
-gtest_disable_pthreads
-gtest_force_shared_crt
-gtest_hide_internal_symbols
-BUILD_GMOCK
-BUILD_GTEST
-)
-
 set_target_properties(gtest gtest_main gmock gmock_main
     PROPERTIES FOLDER "Extern")
-
-foreach(TGT IN ITEMS gtest gtest_main gmock gmock_main)
-    get_property(DIR_LIST TARGET ${TGT} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-    foreach(ITEM IN LISTS DIR_LIST)
-        set_property(TARGET ${TGT} APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${ITEM}")
-    endforeach()
-endforeach()
-
-if(MSVC)
-    if (MSVC_VERSION GREATER_EQUAL 1900)
-        target_compile_definitions(gtest PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-        target_compile_definitions(gtest_main PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-        target_compile_definitions(gmock PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-        target_compile_definitions(gmock_main PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-    endif()
-endif()


### PR DESCRIPTION
This seems to be hitting a bug in GoogleMock 1.8.1 that causes GCC 4.7 to fail. See Google/GoogleTest#1804 .