### PR TITLE
Add the is_assignable to a string condition to return 'TEXT' as type name of a type

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -76,6 +76,11 @@ constexpr const char *type_name() {
     return "TEXT";
 }
 
+template <typename T, enable_if_t<std::is_enum<T>::value, detail::enabler> = detail::dummy>
+constexpr const char *type_name() {
+    return "ENUM";
+}
+
 // Lexical cast
 
 /// Signed integers / enums

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -32,6 +32,14 @@ template <typename T> struct is_bool { static const bool value = false; };
 /// Check to see if something is bool (true if actually a bool)
 template <> struct is_bool<bool> { static bool const value = true; };
 
+/// Check to see if something is a string (fail check by default)
+template <typename T> struct is_string { static const bool value = false; };
+
+/// Check to see if something is string (true if actually a std::string or const char*)
+template <> struct is_string<std::string> { static bool const value = true; };
+template <> struct is_string<const char*> { static bool const value = true; };
+template <> struct is_string<      char*> { static bool const value = true; };
+
 namespace detail {
 // Based generally on https://rmf.io/cxx11/almost-static-if
 /// Simple empty scoped class
@@ -70,8 +78,8 @@ constexpr const char *type_name() {
 }
 
 template <typename T,
-          enable_if_t<!std::is_floating_point<T>::value && !std::is_integral<T>::value && !is_vector<T>::value && std::is_assignable<T &, std::string>::value,
-                      detail::enabler> = detail::dummy>
+          enable_if_t<!std::is_floating_point<T>::value && !std::is_integral<T>::value && !is_vector<T>::value
+                      && is_string<T>::value, detail::enabler> = detail::dummy>
 constexpr const char *type_name() {
     return "TEXT";
 }

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -70,7 +70,7 @@ constexpr const char *type_name() {
 }
 
 template <typename T,
-          enable_if_t<!std::is_floating_point<T>::value && !std::is_integral<T>::value && !is_vector<T>::value,
+          enable_if_t<!std::is_floating_point<T>::value && !std::is_integral<T>::value && !is_vector<T>::value && std::is_assignable<T &, std::string>::value,
                       detail::enabler> = detail::dummy>
 constexpr const char *type_name() {
     return "TEXT";

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -403,6 +403,10 @@ TEST(Types, TypeName) {
 
     std::string text2_name = CLI::detail::type_name<char *>();
     EXPECT_EQ("TEXT", text2_name);
+
+    enum test_enum {E1, E2, E3};
+    std::string enum_name = CLI::detail::type_name<test_enum>();
+    EXPECT_EQ("ENUM", enum_name);
 }
 
 TEST(Types, OverflowSmall) {


### PR DESCRIPTION
This fixes an overload ambiguity when adding a user new type_name function.