### PR TITLE
add options to handle windows style command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,14 @@ On the command line, options can be given as:
 -   `--file filename` (space)
 -   `--file=filename` (equals)
 
+If allow_windows_style_options() is specified in the application or subcommand options can also be given as:
+-   `/a` (flag)
+-   `/f filename` (option)
+-   `/long` (long flag)
+-   `/file filename` (space)
+-   `/file:filename` (colon)
+=  Windows style options do not allow combining short options or values not separated from the short option like with `-` options
+
 Extra positional arguments will cause the program to exit, so at least one positional option with a vector is recommended if you want to allow extraneous arguments.
 If you set `.allow_extras()` on the main `App`, you will not get an error. You can access the missing options using `remaining` (if you have subcommands, `app.remaining(true)` will get all remaining options, subcommands included).
 
@@ -285,7 +293,7 @@ There are several options that are supported on the main app and subcommands. Th
 
 -   `.ignore_case()`: Ignore the case of this subcommand. Inherited by added subcommands, so is usually used on the main `App`.
 -   `.ignore_underscore()`: Ignore any underscores in the subcommand name. Inherited by added subcommands, so is usually used on the main `App`.
-
+-   `.allow_windows_style_options()`:  Allow command line options to be parsed in the form of `/s /long /file:file_name.ext`  This option does not change how options are specified in the `add_option` calls or the ability to process options in the form of `-s --long --file=file_name.ext`
 -   `.fallthrough()`: Allow extra unmatched options and positionals to "fall through" and be matched on a parent command. Subcommands always are allowed to fall through.
 -   `.require_subcommand()`: Require 1 or more subcommands.
 -   `.require_subcommand(N)`: Require `N` subcommands if `N>0`, or up to `N` if `N<0`. `N=0` resets to the default 0 or more.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1943,16 +1943,12 @@ class App {
         }
 
         auto op_ptr = std::find_if(std::begin(options_), std::end(options_), [name, current_type](const Option_p &opt) {
-            switch(current_type) {
-            case detail::Classifier::LONG:
+            if(current_type == detail::Classifier::LONG)
                 return opt->check_lname(name);
-            case detail::Classifier::SHORT:
+            if(current_type == detail::Classifier::SHORT)
                 return opt->check_sname(name);
-            case detail::Classifier::WINDOWS:
-                return opt->check_lname(name) || opt->check_sname(name);
-            default:
-                return false;
-            }
+            // this will only get called for detail::Classifier::WINDOWS
+            return opt->check_lname(name) || opt->check_sname(name);
         });
 
         // Option not found

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1189,27 +1189,25 @@ class App {
                 name_ = nstr.first;
             }
             commandline = std::move(nstr.second);
-        } else {
+        } else
             detail::trim(commandline);
-        }
-        // the first section of code is to deal with quoted arguments after an '='
+        // the next section of code is to deal with quoted arguments after an '=' or ':' for windows like operations
         if(!commandline.empty()) {
             auto escape_detect = [](std::string &str, size_t offset) {
                 auto next = str[offset + 1];
                 if((next == '\"') || (next == '\'') || (next == '`')) {
                     auto astart = str.find_last_of("-/ \"\'`", offset - 1);
                     if(astart != std::string::npos) {
-                        if(str[astart] == (str[offset] == '=') ? '-' : '/') {
-                            str[offset] = ' '; // interpret this a space so the split_up works properly
-                        }
+                        if(str[astart] == (str[offset] == '=') ? '-' : '/')
+                            str[offset] = ' '; // interpret this as a space so the split_up works properly
                     }
                 }
-                return offset + 1;
+                return (offset + 1);
             };
+
             commandline = detail::find_and_modify(commandline, "=", escape_detect);
-            if(allow_windows_style_options_) {
+            if(allow_windows_style_options_)
                 commandline = detail::find_and_modify(commandline, ":", escape_detect);
-            }
         }
 
         auto args = detail::split_up(std::move(commandline));

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -115,7 +115,7 @@ inline std::string Formatter::make_footer(const App *app) const {
 
 inline std::string Formatter::make_help(const App *app, std::string name, AppFormatMode mode) const {
 
-    // This immediatly forwards to the make_expanded method. This is done this way so that subcommands can
+    // This immediately forwards to the make_expanded method. This is done this way so that subcommands can
     // have overridden formatters
     if(mode == AppFormatMode::Sub)
         return make_expanded(app);

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -479,7 +479,7 @@ class Option : public OptionBase<Option> {
     int get_expected() const { return expected_; }
 
     /// \brief The total number of expected values (including the type)
-    /// This is positive if exactly this number is expected, and negitive for at least N values
+    /// This is positive if exactly this number is expected, and negative for at least N values
     ///
     /// v = fabs(size_type*expected)
     /// !MultiOptionPolicy::Throw
@@ -518,7 +518,7 @@ class Option : public OptionBase<Option> {
     /// @name Help tools
     ///@{
 
-    /// \brief Gets a comma seperated list of names.
+    /// \brief Gets a comma separated list of names.
     /// Will include / prefer the positional name if positional is true.
     /// If all_options is false, pick just the most descriptive name to show.
     /// Use `get_name(true)` to get the positional name (replaces `get_pname`)
@@ -530,7 +530,7 @@ class Option : public OptionBase<Option> {
 
             std::vector<std::string> name_list;
 
-            /// The all list wil never include a positional unless asked or that's the only name.
+            /// The all list will never include a positional unless asked or that's the only name.
             if((positional && pname_.length()) || (snames_.empty() && lnames_.empty()))
                 name_list.push_back(pname_);
 

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -26,12 +26,28 @@ inline bool split_short(const std::string &current, std::string &name, std::stri
 // Returns false if not a long option. Otherwise, sets opt name and other side of = and returns true
 inline bool split_long(const std::string &current, std::string &name, std::string &value) {
     if(current.size() > 2 && current.substr(0, 2) == "--" && valid_first_char(current[2])) {
-        auto loc = current.find("=");
+        auto loc = current.find_first_of('=');
         if(loc != std::string::npos) {
             name = current.substr(2, loc - 2);
             value = current.substr(loc + 1);
         } else {
             name = current.substr(2);
+            value = "";
+        }
+        return true;
+    } else
+        return false;
+}
+
+// Returns false if not a windows style option. Otherwise, sets opt name and value and returns true
+inline bool split_windows(const std::string &current, std::string &name, std::string &value) {
+    if(current.size() > 1 && current[0] == '/' && valid_first_char(current[1])) {
+        auto loc = current.find_first_of(':');
+        if(loc != std::string::npos) {
+            name = current.substr(1, loc - 1);
+            value = current.substr(loc + 1);
+        } else {
+            name = current.substr(1);
             value = "";
         }
         return true;

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -161,6 +161,16 @@ inline std::string find_and_replace(std::string str, std::string from, std::stri
     return str;
 }
 
+/// Find a trigger string and call a modify callable function that takes the current string and starting position of the
+/// trigger and returns the position in the string to search for the next trigger string
+template <typename Callable> inline std::string find_and_modify(std::string str, std::string trigger, Callable modify) {
+    size_t start_pos = 0;
+    while((start_pos = str.find(trigger, start_pos)) != std::string::npos) {
+        start_pos = modify(str, start_pos);
+    }
+    return str;
+}
+
 /// Split a string '"one two" "three"' into 'one two', 'three'
 /// Quote characters can be ` ' or "
 inline std::vector<std::string> split_up(std::string str) {

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -191,6 +191,33 @@ struct Range : public Validator {
     template <typename T> explicit Range(T max) : Range(static_cast<T>(0), max) {}
 };
 
+namespace detail {
+/// split a string into a program name and command line arguments
+/// the string is assumed to contain a file name followed by other arguments
+/// the return value contains is a pair with the first argument containing the program name and the second everything
+/// else
+inline std::pair<std::string, std::string> split_program_name(std::string commandline) {
+    // try to determine the programName
+    std::pair<std::string, std::string> vals;
+    trim(commandline);
+    auto esp = commandline.find_first_of(' ', 1);
+    while(!ExistingFile(commandline.substr(0, esp)).empty()) {
+        esp = commandline.find_first_of(' ', esp + 1);
+        if(esp == std::string::npos) {
+            // if we have reached the end and haven't found a valid file just assume the first argument is the
+            // program name
+            esp = commandline.find_first_of(' ', 1);
+            break;
+        }
+    }
+    vals.first = commandline.substr(0, esp);
+    rtrim(vals.first);
+    // strip the program name
+    vals.second = (esp != std::string::npos) ? commandline.substr(esp + 1) : std::string{};
+    ltrim(vals.second);
+    return vals;
+}
+} // namespace detail
 /// @}
 
 } // namespace CLI

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -10,6 +10,15 @@ TEST_F(TApp, OneFlagShort) {
     EXPECT_EQ((size_t)1, app.count("--count"));
 }
 
+TEST_F(TApp, OneFlagShortWindows) {
+    app.add_flag("-c,--count");
+    args = {"/c"};
+    app.allow_windows_style_options();
+    run();
+    EXPECT_EQ((size_t)1, app.count("-c"));
+    EXPECT_EQ((size_t)1, app.count("--count"));
+}
+
 TEST_F(TApp, CountNonExist) {
     app.add_flag("-c,--count");
     args = {"-c"};
@@ -70,6 +79,17 @@ TEST_F(TApp, OneString) {
     EXPECT_EQ(str, "mystring");
 }
 
+TEST_F(TApp, OneStringWindowsStyle) {
+    std::string str;
+    app.add_option("-s,--string", str);
+    args = {"/string", "mystring"};
+    app.allow_windows_style_options();
+    run();
+    EXPECT_EQ((size_t)1, app.count("-s"));
+    EXPECT_EQ((size_t)1, app.count("--string"));
+    EXPECT_EQ(str, "mystring");
+}
+
 TEST_F(TApp, OneStringSingleStringInput) {
     std::string str;
     app.add_option("-s,--string", str);
@@ -84,6 +104,17 @@ TEST_F(TApp, OneStringEqualVersion) {
     std::string str;
     app.add_option("-s,--string", str);
     args = {"--string=mystring"};
+    run();
+    EXPECT_EQ((size_t)1, app.count("-s"));
+    EXPECT_EQ((size_t)1, app.count("--string"));
+    EXPECT_EQ(str, "mystring");
+}
+
+TEST_F(TApp, OneStringEqualVersionWindowsStyle) {
+    std::string str;
+    app.add_option("-s,--string", str);
+    args = {"/string:mystring"};
+    app.allow_windows_style_options();
     run();
     EXPECT_EQ((size_t)1, app.count("-s"));
     EXPECT_EQ((size_t)1, app.count("--string"));
@@ -114,6 +145,18 @@ TEST_F(TApp, OneStringEqualVersionSingleStringQuotedMultiple) {
     app.add_option("-t,--tstr", str2);
     app.add_option("-m,--mstr", str3);
     app.parse("--string=\"this is my quoted string\" -t 'qstring 2' -m=`\"quoted string\"`");
+    EXPECT_EQ(str, "this is my quoted string");
+    EXPECT_EQ(str2, "qstring 2");
+    EXPECT_EQ(str3, "\"quoted string\"");
+}
+
+TEST_F(TApp, OneStringEqualVersionSingleStringQuotedMultipleMixedStyle) {
+    std::string str, str2, str3;
+    app.add_option("-s,--string", str);
+    app.add_option("-t,--tstr", str2);
+    app.add_option("-m,--mstr", str3);
+    app.allow_windows_style_options();
+    app.parse("/string:\"this is my quoted string\" /t 'qstring 2' -m=`\"quoted string\"`");
     EXPECT_EQ(str, "this is my quoted string");
     EXPECT_EQ(str2, "qstring 2");
     EXPECT_EQ(str3, "\"quoted string\"");
@@ -1547,14 +1590,28 @@ TEST_F(TApp, AllowExtrasOrder) {
 TEST_F(TApp, CheckShortFail) {
     args = {"--two"};
 
-    EXPECT_THROW(CLI::detail::AppFriend::parse_arg(&app, args, false), CLI::HorribleError);
+    EXPECT_THROW(CLI::detail::AppFriend::parse_arg(&app, args, CLI::detail::Classifier::SHORT), CLI::HorribleError);
 }
 
 // Test horrible error
 TEST_F(TApp, CheckLongFail) {
     args = {"-t"};
 
-    EXPECT_THROW(CLI::detail::AppFriend::parse_arg(&app, args, true), CLI::HorribleError);
+    EXPECT_THROW(CLI::detail::AppFriend::parse_arg(&app, args, CLI::detail::Classifier::LONG), CLI::HorribleError);
+}
+
+// Test horrible error
+TEST_F(TApp, CheckWindowsFail) {
+    args = {"-t"};
+
+    EXPECT_THROW(CLI::detail::AppFriend::parse_arg(&app, args, CLI::detail::Classifier::WINDOWS), CLI::HorribleError);
+}
+
+// Test horrible error
+TEST_F(TApp, CheckOtherFail) {
+    args = {"-t"};
+
+    EXPECT_THROW(CLI::detail::AppFriend::parse_arg(&app, args, CLI::detail::Classifier::NONE), CLI::HorribleError);
 }
 
 // Test horrible error

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1120,6 +1120,20 @@ TEST_F(TApp, InIntSet) {
     EXPECT_THROW(run(), CLI::ConversionError);
 }
 
+TEST_F(TApp, InIntSetWindows) {
+
+    int choice;
+    app.add_set("-q,--quick", choice, {1, 2, 3});
+    app.allow_windows_style_options();
+    args = {"/q", "2"};
+
+    run();
+    EXPECT_EQ(2, choice);
+
+    args = {"/q4"};
+    EXPECT_THROW(run(), CLI::ExtrasError);
+}
+
 TEST_F(TApp, FailSet) {
 
     int choice;

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -471,6 +471,7 @@ TEST_F(TApp, SubcommandDefaults) {
     EXPECT_FALSE(app.get_prefix_command());
     EXPECT_FALSE(app.get_ignore_case());
     EXPECT_FALSE(app.get_ignore_underscore());
+    EXPECT_FALSE(app.get_allow_windows_style_options());
     EXPECT_FALSE(app.get_fallthrough());
     EXPECT_EQ(app.get_footer(), "");
     EXPECT_EQ(app.get_group(), "Subcommands");
@@ -481,6 +482,7 @@ TEST_F(TApp, SubcommandDefaults) {
     app.prefix_command();
     app.ignore_case();
     app.ignore_underscore();
+    app.allow_windows_style_options();
     app.fallthrough();
     app.footer("footy");
     app.group("Stuff");
@@ -493,6 +495,7 @@ TEST_F(TApp, SubcommandDefaults) {
     EXPECT_TRUE(app2->get_prefix_command());
     EXPECT_TRUE(app2->get_ignore_case());
     EXPECT_TRUE(app2->get_ignore_underscore());
+    EXPECT_TRUE(app2->get_allow_windows_style_options());
     EXPECT_TRUE(app2->get_fallthrough());
     EXPECT_EQ(app2->get_footer(), "footy");
     EXPECT_EQ(app2->get_group(), "Stuff");

--- a/tests/StringParseTest.cpp
+++ b/tests/StringParseTest.cpp
@@ -26,30 +26,6 @@ TEST_F(TApp, ExistingExeCheck) {
     EXPECT_EQ(str3, "\"quoted string\"");
 }
 
-TEST_F(TApp, ExistingExeCheckWithSpace) {
-
-    TempFile tmpexe{"Space File.out"};
-
-    std::string str, str2, str3;
-    app.add_option("-s,--string", str);
-    app.add_option("-t,--tstr", str2);
-    app.add_option("-m,--mstr", str3);
-
-    {
-        std::ofstream out{tmpexe};
-        out << "useless string doesn't matter" << std::endl;
-    }
-
-    app.parse(std::string("./") + std::string(tmpexe) +
-                  " --string=\"this is my quoted string\" -t 'qstring 2' -m=`\"quoted string\"`",
-              true);
-    EXPECT_EQ(str, "this is my quoted string");
-    EXPECT_EQ(str2, "qstring 2");
-    EXPECT_EQ(str3, "\"quoted string\"");
-
-    EXPECT_EQ(app.get_name(), std::string("./") + std::string(tmpexe));
-}
-
 TEST_F(TApp, ExistingExeCheckWithLotsOfSpace) {
 
     TempFile tmpexe{"this is a weird file.exe"};


### PR DESCRIPTION
If merged this pull request will add an option for CLI11 to handle windows style options 
such as /d /D /file:some_file.ext  

This is enabled through a new app `function allow_windows_style_options()`

The modifications include some refactoring of the parse_arg function to take a Classifier enum instead of a boolean and the addition of a parse_windows helper function.  

The Classifer enum was renamed to Classifier  (not entirely sure if that was a misspelling or on purpose?)  If it was on purpose I can change it back.  

