### PR TITLE
Adding Windows style options default on Windows

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -145,8 +145,14 @@ class App {
     /// Allow subcommand fallthrough, so that parent commands can collect commands after subcommand.  INHERITABLE
     bool fallthrough_{false};
 
-    /// Allow '/' for options for windows like options INHERITABLE
-    bool allow_windows_style_options_{false};
+    /// Allow '/' for options for Windows like options. Defaults to true on Windows, false otherwise. INHERITABLE
+    bool allow_windows_style_options_{
+#ifdef _WIN32
+        true
+#else
+        false
+#endif
+    };
 
     /// A pointer to the parent if this is a subcommand
     App *parent_{nullptr};

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -471,7 +471,11 @@ TEST_F(TApp, SubcommandDefaults) {
     EXPECT_FALSE(app.get_prefix_command());
     EXPECT_FALSE(app.get_ignore_case());
     EXPECT_FALSE(app.get_ignore_underscore());
+#ifdef _WIN32
+    EXPECT_TRUE(app.get_allow_windows_style_options());
+#else
     EXPECT_FALSE(app.get_allow_windows_style_options());
+#endif
     EXPECT_FALSE(app.get_fallthrough());
     EXPECT_EQ(app.get_footer(), "");
     EXPECT_EQ(app.get_group(), "Subcommands");
@@ -482,7 +486,12 @@ TEST_F(TApp, SubcommandDefaults) {
     app.prefix_command();
     app.ignore_case();
     app.ignore_underscore();
+#ifdef _WIN32
+    app.allow_windows_style_options(false);
+#else
     app.allow_windows_style_options();
+#endif
+
     app.fallthrough();
     app.footer("footy");
     app.group("Stuff");
@@ -495,7 +504,11 @@ TEST_F(TApp, SubcommandDefaults) {
     EXPECT_TRUE(app2->get_prefix_command());
     EXPECT_TRUE(app2->get_ignore_case());
     EXPECT_TRUE(app2->get_ignore_underscore());
+#ifdef _WIN32
+    EXPECT_FALSE(app2->get_allow_windows_style_options());
+#else
     EXPECT_TRUE(app2->get_allow_windows_style_options());
+#endif
     EXPECT_TRUE(app2->get_fallthrough());
     EXPECT_EQ(app2->get_footer(), "footy");
     EXPECT_EQ(app2->get_group(), "Stuff");


### PR DESCRIPTION
This would add true as the default for Windows style options if building on Windows. Probably will need to make a few tests more specific to help AppVeyor pass.