### PR TITLE
Help delete

### DIFF
--- a/.ci/build_doxygen.sh
+++ b/.ci/build_doxygen.sh
@@ -3,7 +3,7 @@
 
 set -evx
 
-DOXYGEN_URL="http://doxygen.nl/files/doxygen-1.8.14.src.tar.gz"
+DOXYGEN_URL="http://doxygen.nl/files/doxygen-1.8.15.src.tar.gz"
 cd "${DEPS_DIR}"
 
 if [[ ! -f "${DEPS_DIR}/doxygen/build/bin/doxygen" ]] ; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## Version 1.7.0: Parse breakup (in progress)
+## Version 1.7.0: Parse breakup
 
 The parsing procedure now maps much more sensibly to complex, nested subcommand structures. Each phase of the parsing happens on all subcommands before moving on with the next phase of the parse. This allows several features, like required environment variables, to work properly even through subcommand boundaries.
-Passing the same subcommand multiple times is better supported. A few new features were added as well, including Windows style option support, parsing strings directly, and ignoring underscores in names.
+Passing the same subcommand multiple times is better supported. Several new features were added as well, including Windows style option support, parsing strings directly, and ignoring underscores in names.
 
 * Support Windows style options with `->allow_windows_style_options`. [#187] On by default on Windows. [#190]
 * Added `parse(string)` to split up and parse a command-line style string directly. [#186]

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-CLI11 1.6 Copyright (c) 2017-2018 University of Cincinnati, developed by Henry
+CLI11 1.7 Copyright (c) 2017-2018 University of Cincinnati, developed by Henry
 Schreiner under NSF AWARD 1414736. All rights reserved.
 
 Redistribution and use in source and binary forms of CLI11, with or without

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1055,6 +1055,11 @@ class App {
             op->remove_excludes(opt);
         }
 
+        if(help_ptr_ == opt)
+            help_ptr_ = nullptr;
+        if(help_all_ptr_ == opt)
+            help_all_ptr_ = nullptr;
+
         auto iterator =
             std::find_if(std::begin(options_), std::end(options_), [opt](const Option_p &v) { return v.get() == opt; });
         if(iterator != std::end(options_)) {

--- a/include/CLI/Version.hpp
+++ b/include/CLI/Version.hpp
@@ -6,8 +6,8 @@
 // [CLI11:verbatim]
 
 #define CLI11_VERSION_MAJOR 1
-#define CLI11_VERSION_MINOR 6
-#define CLI11_VERSION_PATCH 2
-#define CLI11_VERSION "1.6.2"
+#define CLI11_VERSION_MINOR 7
+#define CLI11_VERSION_PATCH 0
+#define CLI11_VERSION "1.7.0"
 
 // [CLI11:verbatim]

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -355,6 +355,49 @@ TEST(THelp, RemoveHelp) {
     }
 }
 
+TEST(THelp, RemoveOtherMethodHelp) {
+    CLI::App app{"My prog"};
+
+    // Don't do this. Just in case, let's make sure it works.
+    app.remove_option(const_cast<CLI::Option *>(app.get_help_ptr()));
+
+    std::string help = app.help();
+
+    EXPECT_THAT(help, HasSubstr("My prog"));
+    EXPECT_THAT(help, Not(HasSubstr("-h,--help")));
+    EXPECT_THAT(help, Not(HasSubstr("Options:")));
+    EXPECT_THAT(help, HasSubstr("Usage:"));
+
+    std::vector<std::string> input{"--help"};
+    try {
+        app.parse(input);
+    } catch(const CLI::ParseError &e) {
+        EXPECT_EQ(static_cast<int>(CLI::ExitCodes::ExtrasError), e.get_exit_code());
+    }
+}
+
+TEST(THelp, RemoveOtherMethodHelpAll) {
+    CLI::App app{"My prog"};
+
+    app.set_help_all_flag("--help-all");
+    // Don't do this. Just in case, let's make sure it works.
+    app.remove_option(const_cast<CLI::Option *>(app.get_help_all_ptr()));
+
+    std::string help = app.help();
+
+    EXPECT_THAT(help, HasSubstr("My prog"));
+    EXPECT_THAT(help, Not(HasSubstr("--help-all")));
+    EXPECT_THAT(help, HasSubstr("Options:"));
+    EXPECT_THAT(help, HasSubstr("Usage:"));
+
+    std::vector<std::string> input{"--help-all"};
+    try {
+        app.parse(input);
+    } catch(const CLI::ParseError &e) {
+        EXPECT_EQ(static_cast<int>(CLI::ExitCodes::ExtrasError), e.get_exit_code());
+    }
+}
+
 TEST(THelp, NoHelp) {
     CLI::App app{"My prog"};
     app.set_help_flag();


### PR DESCRIPTION
This shouldn't happen much, but just in case, if a user removes an option that also was a help option, the pointer could still be referenced. This checks for that and removed the help (and help all) pointers if that happens.