### PR TITLE
Fix for GCC 8 warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 [![Conan.io][conan-badge]][conan-link]
 [![Try CLI11 1.6 online][wandbox-badge]][wandbox-link]
 
+[What's new](./CHANGELOG.md) •
 [Documentation][gitbook] •
-[API Reference][api-docs] •
-[What's new](./CHANGELOG.md)
+[API Reference][api-docs]
 
 CLI11 is a command line parser for C++11 and beyond that provides a rich feature set with a simple and intuitive interface.
 

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -243,7 +243,7 @@ inline size_t escape_detect(std::string &str, size_t offset) {
     if((next == '\"') || (next == '\'') || (next == '`')) {
         auto astart = str.find_last_of("-/ \"\'`", offset - 1);
         if(astart != std::string::npos) {
-            if(str[astart] == (str[offset] == '=') ? '-' : '/')
+            if(str[astart] == ((str[offset] == '=') ? '-' : '/'))
                 str[offset] = ' '; // interpret this as a space so the split_up works properly
         }
     }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -172,6 +172,39 @@ TEST_F(TApp, OneStringEqualVersionSingleStringQuotedMultiple) {
     EXPECT_EQ(str3, "\"quoted string\"");
 }
 
+TEST_F(TApp, OneStringEqualVersionSingleStringEmbeddedEqual) {
+    std::string str, str2, str3;
+    app.add_option("-s,--string", str);
+    app.add_option("-t,--tstr", str2);
+    app.add_option("-m,--mstr", str3);
+    app.parse("--string=\"app=\\\"test1 b\\\" test2=\\\"frogs\\\"\" -t 'qstring 2' -m=`\"quoted string\"`");
+    EXPECT_EQ(str, "app=\"test1 b\" test2=\"frogs\"");
+    EXPECT_EQ(str2, "qstring 2");
+    EXPECT_EQ(str3, "\"quoted string\"");
+
+    app.parse("--string=\"app='test1 b' test2='frogs'\" -t 'qstring 2' -m=`\"quoted string\"`");
+    EXPECT_EQ(str, "app='test1 b' test2='frogs'");
+    EXPECT_EQ(str2, "qstring 2");
+    EXPECT_EQ(str3, "\"quoted string\"");
+}
+
+TEST_F(TApp, OneStringEqualVersionSingleStringEmbeddedEqualWindowsStyle) {
+    std::string str, str2, str3;
+    app.add_option("-s,--string", str);
+    app.add_option("-t,--tstr", str2);
+    app.add_option("--mstr", str3);
+    app.allow_windows_style_options();
+    app.parse("/string:\"app:\\\"test1 b\\\" test2:\\\"frogs\\\"\" /t 'qstring 2' /mstr:`\"quoted string\"`");
+    EXPECT_EQ(str, "app:\"test1 b\" test2:\"frogs\"");
+    EXPECT_EQ(str2, "qstring 2");
+    EXPECT_EQ(str3, "\"quoted string\"");
+
+    app.parse("/string:\"app:'test1 b' test2:'frogs'\" /t 'qstring 2' /mstr:`\"quoted string\"`");
+    EXPECT_EQ(str, "app:'test1 b' test2:'frogs'");
+    EXPECT_EQ(str2, "qstring 2");
+    EXPECT_EQ(str3, "\"quoted string\"");
+}
+
 TEST_F(TApp, OneStringEqualVersionSingleStringQuotedMultipleMixedStyle) {
     std::string str, str2, str3;
     app.add_option("-s,--string", str);


### PR DESCRIPTION
This seems to be a bug in 1.7.0 introduced in #187; the `==` evaluates before the `?`. GCC notices this and gives a warning.