### PR TITLE
Fixes some cmake issues when using earlier cmake versions 

### DIFF
--- a/cmake/AddGoogletest.cmake
+++ b/cmake/AddGoogletest.cmake
@@ -56,9 +56,11 @@ BUILD_GTEST
 set_target_properties(gtest gtest_main gmock gmock_main
     PROPERTIES FOLDER "Extern")
 
-if(MSVC AND MSVC_VERSION GREATER_EQUAL 1900)
-    target_compile_definitions(gtest PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-    target_compile_definitions(gtest_main PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-    target_compile_definitions(gmock PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-    target_compile_definitions(gmock_main PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+if(MSVC)
+    if (MSVC_VERSION GREATER_EQUAL 1900)
+        target_compile_definitions(gtest PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+        target_compile_definitions(gtest_main PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+        target_compile_definitions(gmock PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+        target_compile_definitions(gmock_main PUBLIC _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+    endif()
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,9 +110,13 @@ file(WRITE "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
 # Add boost to test boost::optional if available
 find_package(Boost 1.58)
 if(Boost_FOUND)
-    target_link_libraries(informational PUBLIC Boost::boost)
-    target_link_libraries(OptionalTest PUBLIC Boost::boost)
-
+    if (TARGET Boost::boost)
+        target_link_libraries(informational PUBLIC Boost::boost)
+        target_link_libraries(OptionalTest PUBLIC Boost::boost)
+    else()
+        target_link_libraries(informational PUBLIC ${Boost_INCLUDE_DIR})
+        target_link_libraries(OptionalTest PUBLIC ${BOOST_INCLUDE_DIR})
+    endif()
     # Enforce Boost::Optional even if __has_include is missing on your compiler
     target_compile_definitions(informational PUBLIC CLI11_BOOST_OPTIONAL)
     target_compile_definitions(OptionalTest PUBLIC CLI11_BOOST_OPTIONAL)


### PR DESCRIPTION
specifically Boost::boost is not defined before boost 3.5.2 so 3.4 doesn't work.  Also the AND condition for MSVC didn't work on older cmakes for addGoogleTest file.  