### PR TITLE
Support user defined delimiter when parsing list

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -413,14 +413,19 @@ class App {
     template <typename T>
     Option *add_option(std::string option_name,
                        std::vector<T> &variable, ///< The variable vector to set
-                       std::string description = "") {
+                       std::string description = "",
+                       char delimiter = ' ') {
 
-        CLI::callback_t fun = [&variable](CLI::results_t res) {
+        CLI::callback_t fun = [&variable, delimiter](CLI::results_t res) {
             bool retval = true;
             variable.clear();
-            for(const auto &a : res) {
-                variable.emplace_back();
-                retval &= detail::lexical_cast(a, variable.back());
+            for(const auto &elem : res) {
+                for(const auto &var : CLI::detail::split(elem, delimiter)) {
+                    if(!var.empty()) {
+                        variable.emplace_back();
+                        retval &= detail::lexical_cast(var, variable.back());
+                    }
+                }
             }
             return (!variable.empty()) && retval;
         };
@@ -435,14 +440,19 @@ class App {
     Option *add_option(std::string option_name,
                        std::vector<T> &variable, ///< The variable vector to set
                        std::string description,
-                       bool defaulted) {
+                       bool defaulted,
+                       char delimiter = ' ') {
 
-        CLI::callback_t fun = [&variable](CLI::results_t res) {
+        CLI::callback_t fun = [&variable, delimiter](CLI::results_t res) {
             bool retval = true;
             variable.clear();
             for(const auto &a : res) {
-                variable.emplace_back();
-                retval &= detail::lexical_cast(a, variable.back());
+                for(const auto &var : CLI::detail::split(a, delimiter)) {
+                    if(!var.empty()) {
+                        variable.emplace_back();
+                        retval &= detail::lexical_cast(var, variable.back());
+                    }
+                }
             }
             return (!variable.empty()) && retval;
         };

--- a/scripts/check_style_docker.sh
+++ b/scripts/check_style_docker.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Also good but untagged: CLANG_FORMAT=unibeautify/clang-format
+CLANG_FORMAT=saschpe/clang-format:5.0.1
+
+set -evx
+
+docker run -it ${CLANG_FORMAT} --version
+docker run -it -v "$(pwd)":/workdir -w /workdir ${CLANG_FORMAT} -style=file -sort-includes -i $(git ls-files -- '*.cpp' '*.hpp')
+
+git diff --exit-code --color
+
+set +evx

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1961,3 +1961,94 @@ TEST_F(TApp, BeforeRequirements) {
     // args = {"-b", "-a", "extra"};
     // EXPECT_THROW(run(), CLI::CallForHelp);
 }
+
+// #209
+TEST_F(TApp, CustomUserSepParse) {
+
+    std::vector<int> vals = {1, 2, 3};
+    args = {"--idx", "1,2,3"};
+    auto opt = app.add_option("--idx", vals, "", ',');
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+
+    app.remove_option(opt);
+
+    app.add_option("--idx", vals, "", true, ',');
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+}
+
+// #209
+TEST_F(TApp, DefaultUserSepParse) {
+
+    std::vector<int> vals = {1, 2, 3};
+    args = {"--idx", "1 2 3"};
+    auto opt = app.add_option("--idx", vals, "");
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+    app.remove_option(opt);
+    app.add_option("--idx", vals, "", true);
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+}
+
+// #209
+TEST_F(TApp, BadUserSepParse) {
+
+    std::vector<int> vals;
+    app.add_option("--idx", vals, "");
+
+    args = {"--idx", "1,2,3"};
+
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
+// #209
+TEST_F(TApp, CustomUserSepParse2) {
+
+    std::vector<int> vals = {1, 2, 3};
+    args = {"--idx", "1,2,"};
+    auto opt = app.add_option("--idx", vals, "", ',');
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2}));
+
+    app.remove_option(opt);
+
+    app.add_option("--idx", vals, "", true, ',');
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2}));
+}
+
+// #209
+TEST_F(TApp, CustomUserSepParse3) {
+
+    std::vector<int> vals = {1, 2, 3};
+    args = {"--idx",
+            "1",
+            ","
+            "2"};
+    auto opt = app.add_option("--idx", vals, "", ',');
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2}));
+    app.remove_option(opt);
+
+    app.add_option("--idx", vals, "", false, ',');
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2}));
+}
+
+// #209
+TEST_F(TApp, CustomUserSepParse4) {
+
+    std::vector<int> vals;
+    args = {"--idx", "1,    2"};
+    auto opt = app.add_option("--idx", vals, "", ',');
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2}));
+
+    app.remove_option(opt);
+
+    app.add_option("--idx", vals, "", true, ',');
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2}));
+}


### PR DESCRIPTION
Currently user can only parse list with spaces
E.g app -o 1 2 3
now use can define his own one char delimiter e.g comma