### PR TITLE
Add unnamed subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ An acceptable CLI parser library should be all of the following:
 -   Usable subcommand syntax, with support for multiple subcommands, nested subcommands, and optional fallthrough (explained later).
 -   Ability to add a configuration file (`ini` format), and produce it as well.
 -   Produce real values that can be used directly in code, not something you have pay compute time to look up, for HPC applications.
--   Work with standard types, simple custom types, and extendible to exotic types.
+-   Work with standard types, simple custom types, and extensible to exotic types.
 -   Permissively licensed.
 
 ### Other parsers
@@ -92,7 +92,7 @@ After I wrote this, I also found the following libraries:
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [GFlags][]              | The Google Commandline Flags library. Uses macros heavily, and is limited in scope, missing things like subcommands. It provides a simple syntax and supports config files/env vars. |
 | [GetOpt][]              | Very limited C solution with long, convoluted syntax. Does not support much of anything, like help generation. Always available on UNIX, though (but in different flavors).          |
-| [ProgramOptions.hxx][]  | Intresting library, less powerful and no subcommands. Nice callback system.                                                                                                          |
+| [ProgramOptions.hxx][]  | Interesting library, less powerful and no subcommands. Nice callback system.                                                                                                          |
 | [Args][]                | Also interesting, and supports subcommands. I like the optional-like design, but CLI11 is cleaner and provides direct value access, and is less verbose.                             |
 | [Argument Aggregator][] | I'm a big fan of the [fmt][] library, and the try-catch statement looks familiar.  :thumbsup: Doesn't seem to support subcommands.                                                   |
 | [Clara][]               | Simple library built for the excellent [Catch][] testing framework. Unique syntax, limited scope.                                                                                    |
@@ -239,7 +239,7 @@ Before parsing, you can set the following options:
 -   `->envname(name)`: Gets the value from the environment if present and not passed on the command line.
 -   `->group(name)`: The help group to put the option in. No effect for positional options. Defaults to `"Options"`. `""` will not show up in the help print (hidden).
 -   `->ignore_case()`: Ignore the case on the command line (also works on subcommands, does not affect arguments).
--   `->ignore_underscore()`: Ignore any underscores in the options names (also works on subcommands, does not affect arguments). For example "option_one" will match with optionone.  This does not apply to short form options since they only have one character
+-   `->ignore_underscore()`: Ignore any underscores in the options names (also works on subcommands, does not affect arguments). For example "option_one" will match with "optionone".  This does not apply to short form options since they only have one character
 -   `->description(str)`: Set/change the description.
 -   `->multi_option_policy(CLI::MultiOptionPolicy::Throw)`: Set the multi-option policy. Shortcuts available: `->take_last()`, `->take_first()`, and `->join()`. This will only affect options expecting 1 argument or bool flags (which always default to take last).
 -   `->check(CLI::ExistingFile)`: Requires that the file exists if given.
@@ -285,7 +285,7 @@ Subcommands are supported, and can be nested infinitely. To add a subcommand, ca
 case).
 
 If you want to require that at least one subcommand is given, use `.require_subcommand()` on the parent app. You can optionally give an exact number of subcommands to require, as well. If you give two arguments, that sets the min and max number allowed.
-0 for the max number allowed will allow an unlimited number of subcommands. As a handy shortcut, a single negative value N will set "up to N" values. Limiting the maximimum number allows you to keep arguments that match a previous
+0 for the max number allowed will allow an unlimited number of subcommands. As a handy shortcut, a single negative value N will set "up to N" values. Limiting the maximum number allows you to keep arguments that match a previous
 subcommand name from matching.
 
 If an `App` (main or subcommand) has been parsed on the command line, `->parsed` will be true (or convert directly to bool).
@@ -295,6 +295,9 @@ For many cases, however, using an app's callback may be easier. Every app execut
 even exit the program through the callback. The main `App` has a callback slot, as well, but it is generally not as useful.
 You are allowed to throw `CLI::Success` in the callbacks.
 Multiple subcommands are allowed, to allow [`Click`][click] like series of commands (order is preserved).
+
+Subcommands may also have an empty name either by calling `add_subcommand` with an empty string for the name or with no arguments.
+Nameless subcommands function a little like groups in the main `App`.  If an option is not defined in the main App, all nameless subcommands are checked as well.  This allows for the options to be defined in a composable group.  The `add_subcommand` function has an overload for adding a `shared_ptr<App>` so the subcommand(s) could be defined in different components and merged into a main `App`, or possibly multiple `Apps`.  Multiple nameless subcommands are allowed.
 
 #### Subcommand options
 
@@ -307,7 +310,8 @@ There are several options that are supported on the main app and subcommands. Th
 -   `.require_subcommand()`: Require 1 or more subcommands.
 -   `.require_subcommand(N)`: Require `N` subcommands if `N>0`, or up to `N` if `N<0`. `N=0` resets to the default 0 or more.
 -   `.require_subcommand(min, max)`: Explicitly set min and max allowed subcommands. Setting `max` to 0 is unlimited.
--   `.add_subcommand(name, description="")` Add a subcommand, returns a pointer to the internally stored subcommand.
+-   `.add_subcommand(name="", description="")` Add a subcommand, returns a pointer to the internally stored subcommand.
+-   `.add_subcommand(shared_ptr<App>)` Add a subcommand by shared_ptr, returns a pointer to the internally stored subcommand.
 -   `.got_subcommand(App_or_name)`: Check to see if a subcommand was received on the command line.
 -   `.get_subcommands(filter)`: The list of subcommands given on the command line.
 -   `.get_parent()`: Get the parent App or nullptr if called on master App.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -63,6 +63,24 @@ set_property(TEST subcommands_all PROPERTY PASS_REGULAR_EXPRESSION
     "Subcommand: start"
     "Subcommand: stop")
 
+add_cli_exe(subcom_partitioned subcom_partitioned.cpp)
+add_test(NAME subcom_partitioned_none COMMAND subcom_partitioned)
+set_property(TEST subcom_partitioned_none PROPERTY PASS_REGULAR_EXPRESSION
+    "This is a timer:"
+    "--file is required"
+    "Run with --help for more information.")
+add_test(NAME subcom_partitioned_all COMMAND subcom_partitioned --file this --count --count -d 1.2)
+set_property(TEST subcom_partitioned_all PROPERTY PASS_REGULAR_EXPRESSION
+    "This is a timer:"
+    "Working on file: this, direct count: 1, opt count: 1"
+    "Working on count: 2, direct count: 2, opt count: 2"
+    "Some value: 1.2")
+    # test shows that the help prints out for unnamed subcommands
+add_test(NAME subcom_partitioned_help COMMAND subcom_partitioned --help)
+set_property(TEST subcom_partitioned_help PROPERTY PASS_REGULAR_EXPRESSION
+    "-f,--file TEXT REQUIRED"
+    "-d,--double FLOAT")
+
 add_cli_exe(validators validators.cpp)
 add_test(NAME validators_help COMMAND validators --help)
 set_property(TEST validators_help PROPERTY PASS_REGULAR_EXPRESSION

--- a/examples/subcom_partitioned.cpp
+++ b/examples/subcom_partitioned.cpp
@@ -1,0 +1,37 @@
+#include "CLI/CLI.hpp"
+#include "CLI/Timer.hpp"
+
+int main(int argc, char **argv) {
+    CLI::AutoTimer("This is a timer");
+
+    CLI::App app("K3Pi goofit fitter");
+
+    CLI::App_p impOpt = std::make_shared<CLI::App>("Important");
+    std::string file;
+    CLI::Option *opt = impOpt->add_option("-f,--file,file", file, "File name")->required();
+
+    int count;
+    CLI::Option *copt = impOpt->add_flag("-c,--count", count, "Counter")->required();
+
+    CLI::App_p otherOpt = std::make_shared<CLI::App>("Other");
+    double value; // = 3.14;
+    otherOpt->add_option("-d,--double", value, "Some Value");
+
+    // add the subapps to the main one
+    app.add_subcommand(impOpt);
+    app.add_subcommand(otherOpt);
+
+    try {
+        app.parse(argc, argv);
+    } catch(const CLI::ParseError &e) {
+        return app.exit(e);
+    }
+
+    std::cout << "Working on file: " << file << ", direct count: " << impOpt->count("--file")
+              << ", opt count: " << opt->count() << std::endl;
+    std::cout << "Working on count: " << count << ", direct count: " << impOpt->count("--count")
+              << ", opt count: " << copt->count() << std::endl;
+    std::cout << "Some value: " << value << std::endl;
+
+    return 0;
+}

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -140,6 +140,10 @@ inline std::string Formatter::make_subcommands(const App *app, AppFormatMode mod
     // Make a list in definition order of the groups seen
     std::vector<std::string> subcmd_groups_seen;
     for(const App *com : subcommands) {
+        if(com->get_name().empty()) {
+            out << make_expanded(com);
+            continue;
+        }
         std::string group_key = com->get_group();
         if(!group_key.empty() &&
            std::find_if(subcmd_groups_seen.begin(), subcmd_groups_seen.end(), [&group_key](std::string a) {
@@ -154,6 +158,8 @@ inline std::string Formatter::make_subcommands(const App *app, AppFormatMode mod
         std::vector<const App *> subcommands_group = app->get_subcommands(
             [&group](const App *sub_app) { return detail::to_lower(sub_app->get_group()) == detail::to_lower(group); });
         for(const App *new_com : subcommands_group) {
+            if(new_com->get_name().empty())
+                continue;
             if(mode != AppFormatMode::All) {
                 out << make_subcommand(new_com);
             } else {

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -134,3 +134,30 @@ TEST(Formatter, AllSub) {
     EXPECT_THAT(help, HasSubstr("--insub"));
     EXPECT_THAT(help, HasSubstr("subcom"));
 }
+
+TEST(Formatter, NamelessSub) {
+    CLI::App app{"My prog"};
+    CLI::App *sub = app.add_subcommand("", "This subcommand");
+    sub->add_flag("--insub", "MyFlag");
+
+    std::string help = app.help("", CLI::AppFormatMode::Normal);
+    EXPECT_THAT(help, HasSubstr("--insub"));
+    EXPECT_THAT(help, HasSubstr("This subcommand"));
+}
+
+TEST(Formatter, NamelessSubInGroup) {
+    CLI::App app{"My prog"};
+    CLI::App *sub = app.add_subcommand("", "This subcommand");
+    CLI::App *sub2 = app.add_subcommand("sub2", "subcommand2");
+    sub->add_flag("--insub", "MyFlag");
+    int val;
+    sub2->add_option("pos", val, "positional");
+    sub->group("group1");
+    sub2->group("group1");
+    std::string help = app.help("", CLI::AppFormatMode::Normal);
+    EXPECT_THAT(help, HasSubstr("--insub"));
+    EXPECT_THAT(help, HasSubstr("This subcommand"));
+    EXPECT_THAT(help, HasSubstr("group1"));
+    EXPECT_THAT(help, HasSubstr("sub2"));
+    EXPECT_TRUE(help.find("pos") == std::string::npos);
+}


### PR DESCRIPTION
If merged this pull request will allow unnamed subcommands that get checked for options if no matches occur in the main App.  it also allows the extraction and insertion of subcommands via shared_ptr.  

See issue #215. 