### PR TITLE
Change default delimiter to '\0' instead of space

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -418,17 +418,22 @@ class App {
     Option *add_option(std::string option_name,
                        std::vector<T> &variable, ///< The variable vector to set
                        std::string description = "",
-                       char delimiter = ' ') {
+                       char delimiter = '\0') {
 
         CLI::callback_t fun = [&variable, delimiter](CLI::results_t res) {
             bool retval = true;
             variable.clear();
             for(const auto &elem : res) {
-                for(const auto &var : CLI::detail::split(elem, delimiter)) {
-                    if(!var.empty()) {
-                        variable.emplace_back();
-                        retval &= detail::lexical_cast(var, variable.back());
+                if(delimiter != '\0') {
+                    for(const auto &var : CLI::detail::split(elem, delimiter)) {
+                        if(!var.empty()) {
+                            variable.emplace_back();
+                            retval &= detail::lexical_cast(var, variable.back());
+                        }
                     }
+                } else {
+                    variable.emplace_back();
+                    retval &= detail::lexical_cast(elem, variable.back());
                 }
             }
             return (!variable.empty()) && retval;
@@ -445,17 +450,22 @@ class App {
                        std::vector<T> &variable, ///< The variable vector to set
                        std::string description,
                        bool defaulted,
-                       char delimiter = ' ') {
+                       char delimiter = '\0') {
 
         CLI::callback_t fun = [&variable, delimiter](CLI::results_t res) {
             bool retval = true;
             variable.clear();
-            for(const auto &a : res) {
-                for(const auto &var : CLI::detail::split(a, delimiter)) {
-                    if(!var.empty()) {
-                        variable.emplace_back();
-                        retval &= detail::lexical_cast(var, variable.back());
+            for(const auto &elem : res) {
+                if(delimiter != '\0') {
+                    for(const auto &var : CLI::detail::split(elem, delimiter)) {
+                        if(!var.empty()) {
+                            variable.emplace_back();
+                            retval &= detail::lexical_cast(var, variable.back());
+                        }
                     }
+                } else {
+                    variable.emplace_back();
+                    retval &= detail::lexical_cast(elem, variable.back());
                 }
             }
             return (!variable.empty()) && retval;

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1981,15 +1981,15 @@ TEST_F(TApp, CustomUserSepParse) {
 // #209
 TEST_F(TApp, DefaultUserSepParse) {
 
-    std::vector<int> vals = {1, 2, 3};
-    args = {"--idx", "1 2 3"};
+    std::vector<std::string> vals;
+    args = {"--idx", "1 2 3", "4 5 6"};
     auto opt = app.add_option("--idx", vals, "");
     run();
-    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+    EXPECT_EQ(vals, std::vector<std::string>({"1 2 3", "4 5 6"}));
     app.remove_option(opt);
     app.add_option("--idx", vals, "", true);
     run();
-    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+    EXPECT_EQ(vals, std::vector<std::string>({"1 2 3", "4 5 6"}));
 }
 
 // #209
@@ -2051,4 +2051,20 @@ TEST_F(TApp, CustomUserSepParse4) {
     app.add_option("--idx", vals, "", true, ',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2}));
+}
+
+// #218
+TEST_F(TApp, CustomUserSepParse5) {
+
+    std::vector<std::string> bar;
+    args = {"this", "is", "a", "test"};
+    auto opt = app.add_option("bar", bar, "bar");
+    run();
+    EXPECT_EQ(bar, std::vector<std::string>({"this", "is", "a", "test"}));
+
+    app.remove_option(opt);
+    args = {"this", "is", "a", "test"};
+    app.add_option("bar", bar, "bar", true);
+    run();
+    EXPECT_EQ(bar, std::vector<std::string>({"this", "is", "a", "test"}));
 }


### PR DESCRIPTION
This maintains CLI11 previous way of work.
This  fixes #218 

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>