### PR TITLE
CLI::IsMember

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - .ci/make_and_test.sh 17
 
     # Check style/tidy
-  - compiler: clang 
+  - compiler: clang
     env:
     - CHECK_STYLE=yes
     script:
@@ -103,6 +103,20 @@ matrix:
         conan user -p ${BINFROG_API_KEY} -r origin henryiii
         conan upload "*" -c -r origin --all
       fi
+
+    # GCC 4.8
+  - compiler: gcc
+    env:
+    - GCC_VER=4.8
+    addons:
+      apt:
+        packages:
+        - g++-4.8
+    install:
+    - export CC=gcc-4.8
+    - export CXX=g++-4.8
+    script:
+    - .ci/make_and_test.sh 11
 
     # macOS and clang
   - os: osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,28 @@
-## Version 1.8: Flags and Sets
+## Version 1.8: Sets and Flags
 
-This version adds inverted flags, which can cancel or reduce the count of flags, and can also support basic number assignment. A new `add_option_fn` lets you more easily program CLI11 options with the types you choose. Vector options now support a custom separator. Apps can now be composed with unnamed subcommand support.
+Set handling has been completely replaced by a new backend that works as a Validator. This provides a single interface instead of the 16 different functions in App. It also allows ordered collections to be used, custom functions for filtering, and better help and error messages. Also new are inverted flags, which can cancel or reduce the count of flags, and can also support basic number assignment. A new `add_option_fn` lets you more easily program CLI11 options with the types you choose. Vector options now support a custom separator. Apps can now be composed with unnamed subcommand support.
 
+* New `CL::IsMember` validator replaces set validation [#222]
 * Much more powerful flags with different values [#211]
 * Support for composable unnamed subcommands [#216]
 * Custom vector separator [#209], [#221]
 * Validators added for IP4 addresses and positive numbers [#210]
+
+> ### Converting from CLI11 1.7:
+>
+> * `app.add_set("--name", value, {"choice1", "choice2"})` should become `app.add_option("--name", value)->check(CLI::IsMember({"choice1", "choice2"}))`
+> * The `_mutable` versions of this can be replaced by passing a pointer or shared pointer into `IsMember`
+> * The `_ignore_case` version of this can be replaced by adding `CLI::ignore_case` to the argument list in `IsMember`
+> * The `_ignore_underscore` version of this can be replaced by adding `CLI::ignore_underscore` to the argument list in `IsMember`
+> * The `_ignore_case_underscore` version of this can be replaced by adding both functions listed above to the argument list in `IsMember`
+> * An error with sets now produces a `ValidationError` instead of a `ConversionError`
 
 [#209]: https://github.com/CLIUtils/CLI11/pull/209
 [#210]: https://github.com/CLIUtils/CLI11/pull/210
 [#211]: https://github.com/CLIUtils/CLI11/pull/211
 [#216]: https://github.com/CLIUtils/CLI11/pull/216
 [#221]: https://github.com/CLIUtils/CLI11/pull/221
+[#222]: https://github.com/CLIUtils/CLI11/pull/222
 
 
 ## Version 1.7.1: Quick patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Set handling has been completely replaced by a new backend that works as a Valid
 
 * New `CL::IsMember` validator replaces set validation [#222]
 * Much more powerful flags with different values [#211]
+* `add_option` now supports bool due to unified bool handling [#211]
 * Support for composable unnamed subcommands [#216]
 * Custom vector separator [#209], [#221]
 * Validators added for IP4 addresses and positive numbers [#210]

--- a/README.md
+++ b/README.md
@@ -144,12 +144,15 @@ GTEST_COLOR=1 CTEST_OUTPUT_ON_FAILURE=1 make test
 To set up, add options, and run, your main function will look something like this:
 
 ```cpp
-CLI::App app{"App description"};
+int main(int charc, char** argv) {
+    CLI::App app{"App description"};
 
-std::string filename = "default";
-app.add_option("-f,--file", filename, "A help string");
+    std::string filename = "default";
+    app.add_option("-f,--file", filename, "A help string");
 
-CLI11_PARSE(app, argc, argv);
+    CLI11_PARSE(app, argc, argv);
+    return 0;
+}
 ```
 
 <details><summary>Note: If you don't like macros, this is what that macro expands to: (click to expand)</summary><p>
@@ -175,7 +178,7 @@ While all options internally are the same type, there are several ways to add an
 
 ```cpp
 app.add_option(option_name,
-               variable_to_bind_to, // int, float, vector, or string-like
+               variable_to_bind_to, // bool, int, float, vector, or string-like
                help_string="",
                default=false)
 
@@ -272,15 +275,15 @@ Before parsing, you can set the following options:
 
 These options return the `Option` pointer, so you can chain them together, and even skip storing the pointer entirely. Check takes any function that has the signature `void(const std::string&)`; it should throw a `ValidationError` when validation fails. The help message will have the name of the parent option prepended. Since `check` and `transform` use the same underlying mechanism, you can chain as many as you want, and they will be executed in order. If you just want to see the unconverted values, use `.results()` to get the `std::vector<std::string>` of results. Validate can also be a subclass of `CLI::Validator`, in which case it can also set the type name and can be combined with `&` and `|` (all built-in validators are this sort).
 
-The IsMember validator lets you specify a set of predefined options. You can pass any container or copiable pointer (including `std::shared_ptr`) to a container to this validator; the container just needs to be iterable and have a `::value_type`. The type should be convertable from a string (`const char*` is not, for example). You can use an initializer list of strings directly if you like. If you need to modify the set later, the pointer form lets you do that; the type message and check will correctly refer to the current version of the set.
+The `IsMember` validator lets you specify a set of predefined options. You can pass any container or copyable pointer (including `std::shared_ptr`) to a container to this validator; the container just needs to be iterable and have a `::value_type`. The type should be convertible from a string. You can use an initializer list directly if you like. If you need to modify the set later, the pointer form lets you do that; the type message and check will correctly refer to the current version of the set.
 After specifying a set of options, you can also specify "filter" functions of the form `T(T)`, where `T` is the type of the values. The most common choices probably will be `CLI::ignore_case` an `CLI::ignore_underscore`.
 Here are some examples
-of IsMember:
+of `IsMember`:
 
--   `CLI::IsMember({"choice1", "choice2"})`: Select from exact match to choices
+-   `CLI::IsMember({"choice1", "choice2"})`: Select from exact match to choices.
 -   `CLI::IsMember({"choice1", "choice2"}, CLI::ignore_case, CLI::ignore_underscore)`: Match things like `Choice_1`, too.
--   `CLI::IsMember(std::set<int>({2,3,4}))`: Most containers and types work
--   `auto p = std::make_shared<std::vector<std::string>>("one", "two"); CLI::IsMember(p)`: You can modify `p` later.
+-   `CLI::IsMember(std::set<int>({2,3,4}))`: Most containers and types work; you just need `std::begin`, `std::end`, and `::value_type`.
+-   `auto p = std::make_shared<std::vector<std::string>>(std::initializer_list<std::string>("one", "two")); CLI::IsMember(p)`: You can modify `p` later.
 
 On the command line, options can be given as:
 
@@ -294,7 +297,7 @@ On the command line, options can be given as:
 -   `--file filename` (space)
 -   `--file=filename` (equals)
 
-If allow_windows_style_options() is specified in the application or subcommand options can also be given as:
+If `allow_windows_style_options()` is specified in the application or subcommand options can also be given as:
 -   `/a` (flag)
 -   `/f filename` (option)
 -   `/long` (long flag)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -130,7 +130,7 @@ add_cli_exe(enum enum.cpp)
 add_test(NAME enum_pass COMMAND enum -l 1)
 add_test(NAME enum_fail COMMAND enum -l 4)
 set_property(TEST enum_fail PROPERTY PASS_REGULAR_EXPRESSION
-    "Could not convert: --level = 4")
+    "--level: 4 not in {0,1,2}")
 
 add_cli_exe(modhelp modhelp.cpp)
 add_test(NAME modhelp COMMAND modhelp -a test -h)

--- a/examples/enum.cpp
+++ b/examples/enum.cpp
@@ -16,7 +16,8 @@ int main(int argc, char **argv) {
     CLI::App app;
 
     Level level;
-    app.add_set("-l,--level", level, {Level::High, Level::Medium, Level::Low}, "Level settings")
+    app.add_option("-l,--level", level, "Level settings")
+        ->check(CLI::IsMember({Level::High, Level::Medium, Level::Low}))
         ->type_name("enum/Level in {High=0, Medium=1, Low=2}");
 
     CLI11_PARSE(app, argc, argv);

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -644,7 +644,7 @@ class App {
     }
 #endif
 
-    /// Add set of options (No default, temp reference, such as an inline set)
+    /// Add set of options (No default, temp reference, such as an inline set) DEPRECATED
     template <typename T>
     Option *add_set(std::string option_name,
                     T &member,           ///< The selected member of the set
@@ -656,7 +656,7 @@ class App {
         return opt;
     }
 
-    /// Add set of options (No default, set can be changed afterwords - do not destroy the set)
+    /// Add set of options (No default, set can be changed afterwords - do not destroy the set) DEPRECATED
     template <typename T>
     Option *add_mutable_set(std::string option_name,
                             T &member,                  ///< The selected member of the set
@@ -668,7 +668,7 @@ class App {
         return opt;
     }
 
-    /// Add set of options (with default, static set, such as an inline set)
+    /// Add set of options (with default, static set, such as an inline set) DEPRECATED
     template <typename T>
     Option *add_set(std::string option_name,
                     T &member,           ///< The selected member of the set
@@ -681,7 +681,7 @@ class App {
         return opt;
     }
 
-    /// Add set of options (with default, set can be changed afterwards - do not destroy the set)
+    /// Add set of options (with default, set can be changed afterwards - do not destroy the set) DEPRECATED
     template <typename T>
     Option *add_mutable_set(std::string option_name,
                             T &member,                  ///< The selected member of the set
@@ -694,7 +694,8 @@ class App {
         return opt;
     }
 
-    /// Add set of options, string only, ignore case (no default, static set)
+    /// Add set of options, string only, ignore case (no default, static set) DEPRECATED
+    CLI11_DEPRECATED("Use ->check(CLI::IsMember(..., CLI::ignore_case)) instead")
     Option *add_set_ignore_case(std::string option_name,
                                 std::string &member,           ///< The selected member of the set
                                 std::set<std::string> options, ///< The set of possibilities
@@ -706,7 +707,8 @@ class App {
     }
 
     /// Add set of options, string only, ignore case (no default, set can be changed afterwards - do not destroy the
-    /// set)
+    /// set) DEPRECATED
+    CLI11_DEPRECATED("Use ->check(CLI::IsMember(..., CLI::ignore_case)) with a (shared) pointer instead")
     Option *add_mutable_set_ignore_case(std::string option_name,
                                         std::string &member,                  ///< The selected member of the set
                                         const std::set<std::string> &options, ///< The set of possibilities
@@ -717,7 +719,8 @@ class App {
         return opt;
     }
 
-    /// Add set of options, string only, ignore case (default, static set)
+    /// Add set of options, string only, ignore case (default, static set) DEPRECATED
+    CLI11_DEPRECATED("Use ->check(CLI::IsMember(..., CLI::ignore_case)) instead")
     Option *add_set_ignore_case(std::string option_name,
                                 std::string &member,           ///< The selected member of the set
                                 std::set<std::string> options, ///< The set of possibilities
@@ -730,6 +733,8 @@ class App {
     }
 
     /// Add set of options, string only, ignore case (default, set can be changed afterwards - do not destroy the set)
+    /// DEPRECATED
+    CLI11_DEPRECATED("Use ->check(CLI::IsMember(...)) with a (shared) pointer instead")
     Option *add_mutable_set_ignore_case(std::string option_name,
                                         std::string &member,                  ///< The selected member of the set
                                         const std::set<std::string> &options, ///< The set of possibilities
@@ -741,7 +746,8 @@ class App {
         return opt;
     }
 
-    /// Add set of options, string only, ignore underscore (no default, static set)
+    /// Add set of options, string only, ignore underscore (no default, static set) DEPRECATED
+    CLI11_DEPRECATED("Use ->check(CLI::IsMember(..., CLI::ignore_underscore)) instead")
     Option *add_set_ignore_underscore(std::string option_name,
                                       std::string &member,           ///< The selected member of the set
                                       std::set<std::string> options, ///< The set of possibilities
@@ -753,7 +759,8 @@ class App {
     }
 
     /// Add set of options, string only, ignore underscore (no default, set can be changed afterwards - do not destroy
-    /// the set)
+    /// the set) DEPRECATED
+    CLI11_DEPRECATED("Use ->check(CLI::IsMember(..., CLI::ignore_underscore)) with a (shared) pointer instead")
     Option *add_mutable_set_ignore_underscore(std::string option_name,
                                               std::string &member,                  ///< The selected member of the set
                                               const std::set<std::string> &options, ///< The set of possibilities
@@ -764,7 +771,8 @@ class App {
         return opt;
     }
 
-    /// Add set of options, string only, ignore underscore (default, static set)
+    /// Add set of options, string only, ignore underscore (default, static set) DEPRECATED
+    CLI11_DEPRECATED("Use ->check(CLI::IsMember(..., CLI::ignore_underscore)) instead")
     Option *add_set_ignore_underscore(std::string option_name,
                                       std::string &member,           ///< The selected member of the set
                                       std::set<std::string> options, ///< The set of possibilities
@@ -777,7 +785,8 @@ class App {
     }
 
     /// Add set of options, string only, ignore underscore (default, set can be changed afterwards - do not destroy the
-    /// set)
+    /// set) DEPRECATED
+    CLI11_DEPRECATED("Use ->check(CLI::IsMember(..., CLI::ignore_underscore)) with a (shared) pointer instead")
     Option *add_mutable_set_ignore_underscore(std::string option_name,
                                               std::string &member,                  ///< The selected member of the set
                                               const std::set<std::string> &options, ///< The set of possibilities
@@ -789,7 +798,8 @@ class App {
         return opt;
     }
 
-    /// Add set of options, string only, ignore underscore and case (no default, static set)
+    /// Add set of options, string only, ignore underscore and case (no default, static set) DEPRECATED
+    CLI11_DEPRECATED("Use ->check(CLI::IsMember(..., CLI::ignore_case, CLI::ignore_underscore)) instead")
     Option *add_set_ignore_case_underscore(std::string option_name,
                                            std::string &member,           ///< The selected member of the set
                                            std::set<std::string> options, ///< The set of possibilities
@@ -801,7 +811,9 @@ class App {
     }
 
     /// Add set of options, string only, ignore underscore and case (no default, set can be changed afterwards - do not
-    /// destroy the set)
+    /// destroy the set) DEPRECATED
+    CLI11_DEPRECATED(
+        "Use ->check(CLI::IsMember(..., CLI::ignore_case, CLI::ignore_underscore)) with a (shared) pointer instead")
     Option *add_mutable_set_ignore_case_underscore(std::string option_name,
                                                    std::string &member, ///< The selected member of the set
                                                    const std::set<std::string> &options, ///< The set of possibilities
@@ -812,7 +824,8 @@ class App {
         return opt;
     }
 
-    /// Add set of options, string only, ignore underscore and case (default, static set)
+    /// Add set of options, string only, ignore underscore and case (default, static set) DEPRECATED
+    CLI11_DEPRECATED("Use ->check(CLI::IsMember(..., CLI::ignore_case, CLI::ignore_underscore)) instead")
     Option *add_set_ignore_case_underscore(std::string option_name,
                                            std::string &member,           ///< The selected member of the set
                                            std::set<std::string> options, ///< The set of possibilities
@@ -825,7 +838,9 @@ class App {
     }
 
     /// Add set of options, string only, ignore underscore and case (default, set can be changed afterwards - do not
-    /// destroy the set)
+    /// destroy the set) DEPRECATED
+    CLI11_DEPRECATED(
+        "Use ->check(CLI::IsMember(..., CLI::ignore_case, CLI::ignore_underscore)) with a (shared) pointer instead")
     Option *add_mutable_set_ignore_case_underscore(std::string option_name,
                                                    std::string &member, ///< The selected member of the set
                                                    const std::set<std::string> &options, ///< The set of possibilities

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -651,18 +651,8 @@ class App {
                     std::set<T> options, ///< The set of possibilities
                     std::string description = "") {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            bool retval = detail::lexical_cast(res[0], member);
-            if(!retval)
-                throw ConversionError(res[0], simple_name);
-            return std::find(std::begin(options), std::end(options), member) != std::end(options);
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), false);
-        std::string typeval = detail::type_name<T>();
-        typeval += " in {" + detail::join(options) + "}";
-        opt->type_name(typeval);
+        Option *opt = add_option(option_name, member, std::move(description));
+        opt->check(IsMember{options});
         return opt;
     }
 
@@ -673,18 +663,8 @@ class App {
                             const std::set<T> &options, ///< The set of possibilities
                             std::string description = "") {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, &options, simple_name](CLI::results_t res) {
-            bool retval = detail::lexical_cast(res[0], member);
-            if(!retval)
-                throw ConversionError(res[0], simple_name);
-            return std::find(std::begin(options), std::end(options), member) != std::end(options);
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), false);
-        opt->type_name_fn(
-            [&options]() { return std::string(detail::type_name<T>()) + " in {" + detail::join(options) + "}"; });
-
+        Option *opt = add_option(option_name, member, std::move(description));
+        opt->check(IsMember{&options});
         return opt;
     }
 
@@ -696,23 +676,8 @@ class App {
                     std::string description,
                     bool defaulted) {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            bool retval = detail::lexical_cast(res[0], member);
-            if(!retval)
-                throw ConversionError(res[0], simple_name);
-            return std::find(std::begin(options), std::end(options), member) != std::end(options);
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), defaulted);
-        std::string typeval = detail::type_name<T>();
-        typeval += " in {" + detail::join(options) + "}";
-        opt->type_name(typeval);
-        if(defaulted) {
-            std::stringstream out;
-            out << member;
-            opt->default_str(out.str());
-        }
+        Option *opt = add_option(option_name, member, std::move(description), defaulted);
+        opt->check(IsMember{options});
         return opt;
     }
 
@@ -724,22 +689,8 @@ class App {
                             std::string description,
                             bool defaulted) {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, &options, simple_name](CLI::results_t res) {
-            bool retval = detail::lexical_cast(res[0], member);
-            if(!retval)
-                throw ConversionError(res[0], simple_name);
-            return std::find(std::begin(options), std::end(options), member) != std::end(options);
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), defaulted);
-        opt->type_name_fn(
-            [&options]() { return std::string(detail::type_name<T>()) + " in {" + detail::join(options) + "}"; });
-        if(defaulted) {
-            std::stringstream out;
-            out << member;
-            opt->default_str(out.str());
-        }
+        Option *opt = add_option(option_name, member, std::move(description), defaulted);
+        opt->check(IsMember{&options});
         return opt;
     }
 
@@ -749,25 +700,8 @@ class App {
                                 std::set<std::string> options, ///< The set of possibilities
                                 std::string description = "") {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            member = detail::to_lower(res[0]);
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::to_lower(val) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), false);
-        std::string typeval = detail::type_name<std::string>();
-        typeval += " in {" + detail::join(options) + "}";
-        opt->type_name(typeval);
-
+        Option *opt = add_option(option_name, member, std::move(description));
+        opt->check(IsMember{options, CLI::ignore_case});
         return opt;
     }
 
@@ -778,25 +712,8 @@ class App {
                                         const std::set<std::string> &options, ///< The set of possibilities
                                         std::string description = "") {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, &options, simple_name](CLI::results_t res) {
-            member = detail::to_lower(res[0]);
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::to_lower(val) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), false);
-        opt->type_name_fn([&options]() {
-            return std::string(detail::type_name<std::string>()) + " in {" + detail::join(options) + "}";
-        });
-
+        Option *opt = add_option(option_name, member, std::move(description));
+        opt->check(IsMember{&options, CLI::ignore_case});
         return opt;
     }
 
@@ -807,27 +724,8 @@ class App {
                                 std::string description,
                                 bool defaulted) {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            member = detail::to_lower(res[0]);
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::to_lower(val) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), defaulted);
-        std::string typeval = detail::type_name<std::string>();
-        typeval += " in {" + detail::join(options) + "}";
-        opt->type_name(typeval);
-        if(defaulted) {
-            opt->default_str(member);
-        }
+        Option *opt = add_option(option_name, member, std::move(description), defaulted);
+        opt->check(IsMember{options, CLI::ignore_case});
         return opt;
     }
 
@@ -838,27 +736,8 @@ class App {
                                         std::string description,
                                         bool defaulted) {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, &options, simple_name](CLI::results_t res) {
-            member = detail::to_lower(res[0]);
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::to_lower(val) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), defaulted);
-        opt->type_name_fn([&options]() {
-            return std::string(detail::type_name<std::string>()) + " in {" + detail::join(options) + "}";
-        });
-        if(defaulted) {
-            opt->default_str(member);
-        }
+        Option *opt = add_option(option_name, member, std::move(description), defaulted);
+        opt->check(IsMember{&options, CLI::ignore_case});
         return opt;
     }
 
@@ -868,25 +747,8 @@ class App {
                                       std::set<std::string> options, ///< The set of possibilities
                                       std::string description = "") {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            member = detail::remove_underscore(res[0]);
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::remove_underscore(val) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), false);
-        std::string typeval = detail::type_name<std::string>();
-        typeval += " in {" + detail::join(options) + "}";
-        opt->type_name(typeval);
-
+        Option *opt = add_option(option_name, member, std::move(description));
+        opt->check(IsMember{options, CLI::ignore_underscore});
         return opt;
     }
 
@@ -897,25 +759,8 @@ class App {
                                               const std::set<std::string> &options, ///< The set of possibilities
                                               std::string description = "") {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, &options, simple_name](CLI::results_t res) {
-            member = detail::remove_underscore(res[0]);
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::remove_underscore(val) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), false);
-        opt->type_name_fn([&options]() {
-            return std::string(detail::type_name<std::string>()) + " in {" + detail::join(options) + "}";
-        });
-
+        Option *opt = add_option(option_name, member, std::move(description));
+        opt->check(IsMember{options, CLI::ignore_underscore});
         return opt;
     }
 
@@ -926,27 +771,8 @@ class App {
                                       std::string description,
                                       bool defaulted) {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            member = detail::remove_underscore(res[0]);
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::remove_underscore(val) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), defaulted);
-        std::string typeval = detail::type_name<std::string>();
-        typeval += " in {" + detail::join(options) + "}";
-        opt->type_name(typeval);
-        if(defaulted) {
-            opt->default_str(member);
-        }
+        Option *opt = add_option(option_name, member, std::move(description), defaulted);
+        opt->check(IsMember{options, CLI::ignore_underscore});
         return opt;
     }
 
@@ -958,27 +784,8 @@ class App {
                                               std::string description,
                                               bool defaulted) {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, &options, simple_name](CLI::results_t res) {
-            member = detail::remove_underscore(res[0]);
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::remove_underscore(val) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), defaulted);
-        opt->type_name_fn([&options]() {
-            return std::string(detail::type_name<std::string>()) + " in {" + detail::join(options) + "}";
-        });
-        if(defaulted) {
-            opt->default_str(member);
-        }
+        Option *opt = add_option(option_name, member, std::move(description), defaulted);
+        opt->check(IsMember{&options, CLI::ignore_underscore});
         return opt;
     }
 
@@ -988,25 +795,8 @@ class App {
                                            std::set<std::string> options, ///< The set of possibilities
                                            std::string description = "") {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            member = detail::to_lower(detail::remove_underscore(res[0]));
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::to_lower(detail::remove_underscore(val)) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), false);
-        std::string typeval = detail::type_name<std::string>();
-        typeval += " in {" + detail::join(options) + "}";
-        opt->type_name(typeval);
-
+        Option *opt = add_option(option_name, member, std::move(description));
+        opt->check(IsMember{options, CLI::ignore_underscore, CLI::ignore_case});
         return opt;
     }
 
@@ -1017,25 +807,8 @@ class App {
                                                    const std::set<std::string> &options, ///< The set of possibilities
                                                    std::string description = "") {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, &options, simple_name](CLI::results_t res) {
-            member = detail::to_lower(detail::remove_underscore(res[0]));
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::to_lower(detail::remove_underscore(val)) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), false);
-        opt->type_name_fn([&options]() {
-            return std::string(detail::type_name<std::string>()) + " in {" + detail::join(options) + "}";
-        });
-
+        Option *opt = add_option(option_name, member, std::move(description));
+        opt->check(IsMember{&options, CLI::ignore_underscore, CLI::ignore_case});
         return opt;
     }
 
@@ -1046,27 +819,8 @@ class App {
                                            std::string description,
                                            bool defaulted) {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, options, simple_name](CLI::results_t res) {
-            member = detail::to_lower(detail::remove_underscore(res[0]));
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::to_lower(detail::remove_underscore(val)) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), defaulted);
-        std::string typeval = detail::type_name<std::string>();
-        typeval += " in {" + detail::join(options) + "}";
-        opt->type_name(typeval);
-        if(defaulted) {
-            opt->default_str(member);
-        }
+        Option *opt = add_option(option_name, member, std::move(description), defaulted);
+        opt->check(IsMember{options, CLI::ignore_underscore, CLI::ignore_case});
         return opt;
     }
 
@@ -1078,27 +832,8 @@ class App {
                                                    std::string description,
                                                    bool defaulted) {
 
-        std::string simple_name = CLI::detail::split(option_name, ',').at(0);
-        CLI::callback_t fun = [&member, &options, simple_name](CLI::results_t res) {
-            member = detail::to_lower(detail::remove_underscore(res[0]));
-            auto iter = std::find_if(std::begin(options), std::end(options), [&member](std::string val) {
-                return detail::to_lower(detail::remove_underscore(val)) == member;
-            });
-            if(iter == std::end(options))
-                throw ConversionError(member, simple_name);
-            else {
-                member = *iter;
-                return true;
-            }
-        };
-
-        Option *opt = add_option(option_name, std::move(fun), std::move(description), defaulted);
-        opt->type_name_fn([&options]() {
-            return std::string(detail::type_name<std::string>()) + " in {" + detail::join(options) + "}";
-        });
-        if(defaulted) {
-            opt->default_str(member);
-        }
+        Option *opt = add_option(option_name, member, std::move(description), defaulted);
+        opt->check(IsMember{&options, CLI::ignore_underscore, CLI::ignore_case});
         return opt;
     }
 

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -49,7 +49,9 @@ class FormatterBase {
     FormatterBase() = default;
     FormatterBase(const FormatterBase &) = default;
     FormatterBase(FormatterBase &&) = default;
-    virtual ~FormatterBase() = default;
+
+    /// Adding a destructor in this form to work around bug in GCC 4.7
+    virtual ~FormatterBase() noexcept {} // NOLINT(modernize-use-equals-default)
 
     /// This is the key method that puts together help
     virtual std::string make_help(const App *, std::string, AppFormatMode) const = 0;
@@ -92,6 +94,9 @@ class FormatterLambda final : public FormatterBase {
   public:
     /// Create a FormatterLambda with a lambda function
     explicit FormatterLambda(funct_t funct) : lambda_(std::move(funct)) {}
+
+    /// Adding a destructor (mostly to make GCC 4.7 happy)
+    ~FormatterLambda() noexcept override {} // NOLINT(modernize-use-equals-default)
 
     /// This will simply call the lambda function
     std::string make_help(const App *app, std::string name, AppFormatMode mode) const override {

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -330,6 +330,27 @@ class Option : public OptionBase<Option> {
         return this;
     }
 
+    /// Allow a set to be quickly created in place
+    template <typename... Args> Option *set(std::string arg, Args... args) {
+        std::vector<std::string> vect = {arg, args...};
+        check(IsMember(vect));
+        return this;
+    }
+
+    /// Allow a set to be quickly created in place - modifier functions
+    template <typename... Args> Option *set(std::function<std::string(std::string)> fn, std::string arg, Args... args) {
+        std::vector<std::string> vect = {arg, args...};
+        check(IsMember(vect, fn));
+        return this;
+    }
+
+    /// Allow a set to be quickly created in place - combine functions
+    template <typename... Args>
+    Option *
+    set(std::function<std::string(std::string)> fn1, std::function<std::string(std::string)> fn2, Args... args) {
+        return set([fn1, fn2](std::string v) { return fn1(fn2(v)); }, args...);
+    }
+
     /// Adds a user supplied function to run on each item passed in (communicate though lambda capture)
     Option *each(std::function<void(std::string)> func) {
         validators_.emplace_back([func](std::string &inout) {

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -612,8 +612,8 @@ class Option : public OptionBase<Option> {
 
                     try {
                         err_msg = vali(result);
-                    } catch(const ConversionError &err) {
-                        throw ConversionError(err.what(), get_name());
+                    } catch(const ValidationError &err) {
+                        throw ValidationError(err.what(), get_name());
                     }
 
                     if(!err_msg.empty())

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -330,25 +330,17 @@ class Option : public OptionBase<Option> {
         return this;
     }
 
-    /// Allow a set to be quickly created in place
-    template <typename... Args> Option *set(std::string arg, Args... args) {
-        std::vector<std::string> vect = {arg, args...};
-        check(IsMember(vect));
+    /// Allow a set to be quickly created
+    template <typename... Args> Option *set(Args &&... args) {
+        check(IsMember(std::forward<Args>(args)...));
         return this;
     }
 
-    /// Allow a set to be quickly created in place - modifier functions
-    template <typename... Args> Option *set(std::function<std::string(std::string)> fn, std::string arg, Args... args) {
-        std::vector<std::string> vect = {arg, args...};
-        check(IsMember(vect, fn));
+    /// Allow a set to be quickly created
+    template <typename... Args> Option *set(std::initializer_list<std::string> tmpset, Args &&... args) {
+        std::vector<std::string> myset(tmpset);
+        check(IsMember(myset, std::forward<Args>(args)...));
         return this;
-    }
-
-    /// Allow a set to be quickly created in place - combine functions
-    template <typename... Args>
-    Option *
-    set(std::function<std::string(std::string)> fn1, std::function<std::string(std::string)> fn2, Args... args) {
-        return set([fn1, fn2](std::string v) { return fn1(fn2(v)); }, args...);
     }
 
     /// Adds a user supplied function to run on each item passed in (communicate though lambda capture)

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -330,51 +330,6 @@ class Option : public OptionBase<Option> {
         return this;
     }
 
-    /// Allow a set to be quickly created, strings followed optionally by functions.
-    ///
-    /// Start: Will always have std::string
-    template <typename... Args> Option *choices(std::string value, Args &&... args) {
-        std::vector<std::string> values = {value};
-        return choices(values, std::forward<Args>(args)...);
-    }
-
-  private:
-    /// Final function called - no function
-    Option *choices(std::vector<std::string> &values) {
-        check(IsMember(values));
-        return this;
-    }
-
-    /// Final function called - function present
-    template <typename T,
-              enable_if_t<std::is_assignable<std::function<std::string(std::string)>, T>::value &&
-                              !(std::is_same<T, const char *>::value || std::is_same<T, char *>::value),
-                          detail::enabler> = detail::dummy>
-    Option *choices(std::vector<std::string> &values, T fn) {
-        check(IsMember(values, fn));
-        return this;
-    }
-
-    /// Append a string
-    template <typename T,
-              typename... Args,
-              enable_if_t<std::is_assignable<std::string, T>::value, detail::enabler> = detail::dummy>
-    Option *choices(std::vector<std::string> &values, T value, Args &&... args) {
-        values.push_back(std::move(value));
-        return choices(values, std::forward<Args>(args)...);
-    }
-
-    /// Combine functions
-    template <typename... Args>
-    Option *choices(std::vector<std::string> &values,
-                    std::function<std::string(std::string)> fn1,
-                    std::function<std::string(std::string)> fn2,
-                    Args &&... args) {
-        std::function<std::string(std::string)> fn = [fn1, fn2](std::string val) { return fn1(fn2(val)); };
-        return choices(values, fn, std::forward<Args>(args)...);
-    }
-
-  public:
     /// Adds a user supplied function to run on each item passed in (communicate though lambda capture)
     Option *each(std::function<void(std::string)> func) {
         validators_.emplace_back([func](std::string &inout) {

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -340,7 +340,7 @@ class Option : public OptionBase<Option> {
 
   private:
     /// Final function called - no function
-    Option *choices(std::vector<std::string> values) {
+    Option *choices(std::vector<std::string> &values) {
         check(IsMember(values));
         return this;
     }
@@ -350,7 +350,7 @@ class Option : public OptionBase<Option> {
               enable_if_t<std::is_assignable<std::function<std::string(std::string)>, T>::value &&
                               !(std::is_same<T, const char *>::value || std::is_same<T, char *>::value),
                           detail::enabler> = detail::dummy>
-    Option *choices(std::vector<std::string> values, T fn) {
+    Option *choices(std::vector<std::string> &values, T fn) {
         check(IsMember(values, fn));
         return this;
     }
@@ -359,14 +359,14 @@ class Option : public OptionBase<Option> {
     template <typename T,
               typename... Args,
               enable_if_t<std::is_assignable<std::string, T>::value, detail::enabler> = detail::dummy>
-    Option *choices(std::vector<std::string> values, T value, Args &&... args) {
+    Option *choices(std::vector<std::string> &values, T value, Args &&... args) {
         values.push_back(std::move(value));
         return choices(values, std::forward<Args>(args)...);
     }
 
     /// Combine functions
     template <typename... Args>
-    Option *choices(std::vector<std::string> values,
+    Option *choices(std::vector<std::string> &values,
                     std::function<std::string(std::string)> fn1,
                     std::function<std::string(std::string)> fn2,
                     Args &&... args) {

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -343,4 +343,5 @@ inline std::string &add_quotes_if_needed(std::string &str) {
 }
 
 } // namespace detail
+
 } // namespace CLI

--- a/include/CLI/Timer.hpp
+++ b/include/CLI/Timer.hpp
@@ -119,7 +119,7 @@ class AutoTimer : public Timer {
     AutoTimer(std::string title = "Timer", time_print_t time_print = Simple) : Timer(title, time_print) {}
     // GCC 4.7 does not support using inheriting constructors.
 
-    /// This desctructor prints the string
+    /// This destructor prints the string
     ~AutoTimer() { std::cout << to_string() << std::endl; }
 };
 

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -4,6 +4,7 @@
 // file LICENSE or https://github.com/CLIUtils/CLI11 for details.
 
 #include <exception>
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -21,16 +22,27 @@ namespace CLI {
 template <bool B, class T = void> using enable_if_t = typename std::enable_if<B, T>::type;
 
 /// Check to see if something is a vector (fail check by default)
-template <typename T> struct is_vector { static const bool value = false; };
+template <typename T> struct is_vector : std::false_type {};
 
 /// Check to see if something is a vector (true if actually a vector)
-template <class T, class A> struct is_vector<std::vector<T, A>> { static bool const value = true; };
+template <class T, class A> struct is_vector<std::vector<T, A>> : std::true_type {};
 
 /// Check to see if something is bool (fail check by default)
-template <typename T> struct is_bool { static const bool value = false; };
+template <typename T> struct is_bool : std::false_type {};
 
 /// Check to see if something is bool (true if actually a bool)
-template <> struct is_bool<bool> { static bool const value = true; };
+template <> struct is_bool<bool> : std::true_type {};
+
+/// Check to see if something is a shared pointer
+template <typename T> struct is_shared_ptr : std::false_type {};
+
+/// Check to see if something is a shared pointer (True if really a shared pointer)
+template <typename T> struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
+
+/// Check to see if something is copyable pointer
+template <typename T> struct is_copyable_ptr {
+    static bool const value = is_shared_ptr<T>::value || std::is_pointer<T>::value;
+};
 
 namespace detail {
 // Based generally on https://rmf.io/cxx11/almost-static-if

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -277,13 +277,14 @@ class IsMember : public Validator {
     /// This checks to see if an item is in a set: pointer version. (Empty function)
     template <typename T, enable_if_t<is_copyable_ptr<T>::value, detail::enabler> = detail::dummy>
     explicit IsMember(T set)
-        : IsMember(set,
+        : IsMember(std::move(set),
                    std::function<typename std::pointer_traits<T>::element_type::value_type(
                        typename std::pointer_traits<T>::element_type::value_type)>{}) {}
 
     /// This checks to see if an item is in a set: copy version. (Empty function)
     template <typename T, enable_if_t<!is_copyable_ptr<T>::value, detail::enabler> = detail::dummy>
-    explicit IsMember(T set) : IsMember(set, std::function<typename T::value_type(typename T::value_type)>()) {}
+    explicit IsMember(T set)
+        : IsMember(std::move(set), std::function<typename T::value_type(typename T::value_type)>()) {}
 
     /// This checks to see if an item is in a set: pointer version. You can pass in a function that will filter
     /// both sides of the comparison before computing the comparison.
@@ -309,7 +310,7 @@ class IsMember : public Validator {
                 item_t a = v;
                 item_t b;
                 if(!detail::lexical_cast(input, b))
-                    throw ConversionError(input); // name is added later
+                    throw ValidationError(input); // name is added later
 
                 // The filter function might be empty, so don't filter if it is.
                 if(filter_fn) {
@@ -356,7 +357,7 @@ class IsMember : public Validator {
                 item_t a = v;
                 item_t b;
                 if(!detail::lexical_cast(input, b))
-                    throw ConversionError(input); // name is added later
+                    throw ValidationError(input); // name is added later
 
                 // The filter function might be empty, so don't filter if it is.
                 if(filter_fn) {
@@ -386,7 +387,9 @@ class IsMember : public Validator {
     /// You can pass in as many filter functions as you like, they nest
     template <typename T, typename... Args>
     IsMember(T set, filter_fn_t filter_fn_1, filter_fn_t filter_fn_2, Args &&... other)
-        : IsMember(set, [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); }, other...) {}
+        : IsMember(std::move(set),
+                   [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
+                   other...) {}
 };
 
 /// Helper function to allow ignore_case to be passed to IsMember

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -269,7 +269,7 @@ class IsMember : public Validator {
   public:
     using filter_fn_t = std::function<std::string(std::string)>;
 
-    /// This allows in-place construction
+    /// This allows in-place construction using an initializer list
     template <typename... Args>
     explicit IsMember(std::initializer_list<std::string> values, Args &&... args)
         : IsMember(std::vector<std::string>(values), std::forward<Args>(args)...) {}

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -18,6 +18,8 @@
 
 namespace CLI {
 
+class Option;
+
 /// @defgroup validator_group Validators
 
 /// @brief Some validators that are provided
@@ -28,7 +30,10 @@ namespace CLI {
 /// @{
 
 ///
-struct Validator {
+class Validator {
+    friend Option;
+
+  protected:
     /// This is the type name, if empty the type name will not be changed
     std::string tname;
 
@@ -98,7 +103,8 @@ struct Validator {
 namespace detail {
 
 /// Check for an existing file (returns error message if check fails)
-struct ExistingFileValidator : public Validator {
+class ExistingFileValidator : public Validator {
+  public:
     ExistingFileValidator() {
         tname = "FILE";
         func = [](std::string &filename) {
@@ -116,7 +122,8 @@ struct ExistingFileValidator : public Validator {
 };
 
 /// Check for an existing directory (returns error message if check fails)
-struct ExistingDirectoryValidator : public Validator {
+class ExistingDirectoryValidator : public Validator {
+  public:
     ExistingDirectoryValidator() {
         tname = "DIR";
         func = [](std::string &filename) {
@@ -134,7 +141,8 @@ struct ExistingDirectoryValidator : public Validator {
 };
 
 /// Check for an existing path
-struct ExistingPathValidator : public Validator {
+class ExistingPathValidator : public Validator {
+  public:
     ExistingPathValidator() {
         tname = "PATH";
         func = [](std::string &filename) {
@@ -149,7 +157,8 @@ struct ExistingPathValidator : public Validator {
 };
 
 /// Check for an non-existing path
-struct NonexistentPathValidator : public Validator {
+class NonexistentPathValidator : public Validator {
+  public:
     NonexistentPathValidator() {
         tname = "PATH";
         func = [](std::string &filename) {
@@ -164,7 +173,8 @@ struct NonexistentPathValidator : public Validator {
 };
 
 /// Validate the given string is a legal ipv4 address
-struct IPV4Validator : public Validator {
+class IPV4Validator : public Validator {
+  public:
     IPV4Validator() {
         tname = "IPV4";
         func = [](std::string &ip_addr) {
@@ -189,7 +199,8 @@ struct IPV4Validator : public Validator {
 };
 
 /// Validate the argument is a number and greater than or equal to 0
-struct PositiveNumber : public Validator {
+class PositiveNumber : public Validator {
+  public:
     PositiveNumber() {
         tname = "POSITIVE";
         func = [](std::string &number_str) {
@@ -228,7 +239,8 @@ const detail::IPV4Validator ValidIPV4;
 const detail::PositiveNumber PositiveNumber;
 
 /// Produce a range (factory). Min and max are inclusive.
-struct Range : public Validator {
+class Range : public Validator {
+  public:
     /// This produces a range with min and max inclusive.
     ///
     /// Note that the constructor is templated, but the struct is not, so C++17 is not
@@ -253,7 +265,8 @@ struct Range : public Validator {
 };
 
 /// Verify items are in a set
-struct IsMember : public Validator {
+class IsMember : public Validator {
+  public:
     using filter_fn_t = std::function<std::string(std::string)>;
 
     /// This checks to see if an item is in a set: pointer version. The pointer-like must be copyable. (Normal pointers
@@ -306,13 +319,6 @@ struct IsMember : public Validator {
     /// through the next constructor to avoid duplicating logic.
     template <typename T, enable_if_t<!is_copyable_ptr<T>::value, detail::enabler> = detail::dummy, typename... Args>
     explicit IsMember(T set, Args &&... other) : IsMember(std::make_shared<T>(set), other...) {}
-
-    /// Shortcut to allow inplace initilizer lists to be used as sets.
-    ///
-    /// Vector used internally to ensure order preservation.
-    template <typename... Args>
-    explicit IsMember(std::initializer_list<std::string> items, Args &&... other)
-        : IsMember(std::vector<std::string>(items), other...) {}
 
     /// You can pass in as many filter functions as you like, they nest
     template <typename T, typename... Args>

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -269,6 +269,11 @@ class IsMember : public Validator {
   public:
     using filter_fn_t = std::function<std::string(std::string)>;
 
+    /// This allows in-place construction
+    template <typename... Args>
+    explicit IsMember(std::initializer_list<std::string> values, Args &&... args)
+        : IsMember(std::vector<std::string>(values), std::forward<Args>(args)...) {}
+
     /// This checks to see if an item is in a set: shared_pointer version. (Empty function)
     template <typename T>
     explicit IsMember(std::shared_ptr<T> set)

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -274,17 +274,12 @@ class IsMember : public Validator {
     explicit IsMember(std::initializer_list<std::string> values, Args &&... args)
         : IsMember(std::vector<std::string>(values), std::forward<Args>(args)...) {}
 
-    /// This checks to see if an item is in a set: shared_pointer version. (Empty function)
-    template <typename T>
-    explicit IsMember(std::shared_ptr<T> set)
-        : IsMember(set, std::function<typename T::value_type(typename T::value_type)>{}) {}
-
     /// This checks to see if an item is in a set: pointer version. (Empty function)
-    template <typename T, enable_if_t<std::is_pointer<T>::value, detail::enabler> = detail::dummy>
+    template <typename T, enable_if_t<is_copyable_ptr<T>::value, detail::enabler> = detail::dummy>
     explicit IsMember(T set)
         : IsMember(set,
-                   std::function<typename std::remove_pointer<T>::type::value_type(
-                       typename std::remove_pointer<T>::type::value_type)>{}) {}
+                   std::function<typename std::pointer_traits<T>::element_type::value_type(
+                       typename std::pointer_traits<T>::element_type::value_type)>{}) {}
 
     /// This checks to see if an item is in a set: copy version. (Empty function)
     template <typename T, enable_if_t<!is_copyable_ptr<T>::value, detail::enabler> = detail::dummy>
@@ -293,8 +288,7 @@ class IsMember : public Validator {
     /// This checks to see if an item is in a set: pointer version.
     template <typename T, typename F, enable_if_t<is_copyable_ptr<T>::value, detail::enabler> = detail::dummy>
     explicit IsMember(T set, F filter_function) {
-        using set_t = typename std::pointer_traits<T>::element_type;
-        using item_t = typename set_t::value_type;
+        using item_t = typename std::pointer_traits<T>::element_type::value_type;
 
         std::function<item_t(item_t)> filter_fn = filter_function;
 

--- a/scripts/check_style_docker.sh
+++ b/scripts/check_style_docker.sh
@@ -5,8 +5,8 @@ CLANG_FORMAT=saschpe/clang-format:5.0.1
 
 set -evx
 
-docker run -it ${CLANG_FORMAT} --version
-docker run -it -v "$(pwd)":/workdir -w /workdir ${CLANG_FORMAT} -style=file -sort-includes -i $(git ls-files -- '*.cpp' '*.hpp')
+docker run --rm -it ${CLANG_FORMAT} --version
+docker run --rm -it -v "$(pwd)":/workdir -w /workdir ${CLANG_FORMAT} -style=file -sort-includes -i $(git ls-files -- '*.cpp' '*.hpp')
 
 git diff --exit-code --color
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1071,7 +1071,7 @@ TEST_F(TApp, CallbackFlagsFalse) {
     app.add_flag_function("-v,-f{false},--val,--fval{false}", func);
 
     run();
-    EXPECT_EQ(value, 0u);
+    EXPECT_EQ(value, 0);
 
     args = {"-f"};
     run();
@@ -1100,7 +1100,7 @@ TEST_F(TApp, CallbackFlagsFalseShortcut) {
     app.add_flag_function("-v,!-f,--val,!--fval", func);
 
     run();
-    EXPECT_EQ(value, 0u);
+    EXPECT_EQ(value, 0);
 
     args = {"-f"};
     run();
@@ -1315,233 +1315,6 @@ TEST_F(TApp, FileExists) {
 
     std::remove(myfile.c_str());
     EXPECT_FALSE(CLI::ExistingFile(myfile).empty());
-}
-
-TEST_F(TApp, InSet) {
-
-    std::string choice;
-    app.add_set("-q,--quick", choice, {"one", "two", "three"});
-
-    args = {"--quick", "two"};
-
-    run();
-    EXPECT_EQ("two", choice);
-
-    args = {"--quick", "four"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-}
-
-TEST_F(TApp, InSetWithDefault) {
-
-    std::string choice = "one";
-    app.add_set("-q,--quick", choice, {"one", "two", "three"}, "", true);
-
-    run();
-    EXPECT_EQ("one", choice);
-
-    args = {"--quick", "two"};
-
-    run();
-    EXPECT_EQ("two", choice);
-
-    args = {"--quick", "four"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-}
-
-TEST_F(TApp, InCaselessSetWithDefault) {
-
-    std::string choice = "one";
-    app.add_set_ignore_case("-q,--quick", choice, {"one", "two", "three"}, "", true);
-
-    run();
-    EXPECT_EQ("one", choice);
-
-    args = {"--quick", "tWo"};
-
-    run();
-    EXPECT_EQ("two", choice);
-
-    args = {"--quick", "four"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-}
-
-TEST_F(TApp, InIntSet) {
-
-    int choice;
-    app.add_set("-q,--quick", choice, {1, 2, 3});
-
-    args = {"--quick", "2"};
-
-    run();
-    EXPECT_EQ(2, choice);
-
-    args = {"--quick", "4"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-}
-
-TEST_F(TApp, InIntSetWindows) {
-
-    int choice;
-    app.add_set("-q,--quick", choice, {1, 2, 3});
-    app.allow_windows_style_options();
-    args = {"/q", "2"};
-
-    run();
-    EXPECT_EQ(2, choice);
-
-    args = {"/q4"};
-    EXPECT_THROW(run(), CLI::ExtrasError);
-}
-
-TEST_F(TApp, FailSet) {
-
-    int choice;
-    app.add_set("-q,--quick", choice, {1, 2, 3});
-
-    args = {"--quick", "3", "--quick=2"};
-    EXPECT_THROW(run(), CLI::ArgumentMismatch);
-
-    args = {"--quick=hello"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-}
-
-TEST_F(TApp, FailMutableSet) {
-
-    int choice;
-    std::set<int> vals{1, 2, 3};
-    app.add_mutable_set("-q,--quick", choice, vals);
-    app.add_mutable_set("-s,--slow", choice, vals, "", true);
-
-    args = {"--quick=hello"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-
-    args = {"--slow=hello"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-}
-
-TEST_F(TApp, InSetIgnoreCase) {
-
-    std::string choice;
-    app.add_set_ignore_case("-q,--quick", choice, {"one", "Two", "THREE"});
-
-    args = {"--quick", "One"};
-    run();
-    EXPECT_EQ("one", choice);
-
-    args = {"--quick", "two"};
-    run();
-    EXPECT_EQ("Two", choice); // Keeps caps from set
-
-    args = {"--quick", "ThrEE"};
-    run();
-    EXPECT_EQ("THREE", choice); // Keeps caps from set
-
-    args = {"--quick", "four"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-
-    args = {"--quick=one", "--quick=two"};
-    EXPECT_THROW(run(), CLI::ArgumentMismatch);
-}
-
-TEST_F(TApp, InSetIgnoreCaseMutableValue) {
-
-    std::set<std::string> options{"one", "Two", "THREE"};
-    std::string choice;
-    app.add_mutable_set_ignore_case("-q,--quick", choice, options);
-
-    args = {"--quick", "One"};
-    run();
-    EXPECT_EQ("one", choice);
-
-    args = {"--quick", "two"};
-    run();
-    EXPECT_EQ("Two", choice); // Keeps caps from set
-
-    args = {"--quick", "ThrEE"};
-    run();
-    EXPECT_EQ("THREE", choice); // Keeps caps from set
-
-    options.clear();
-    args = {"--quick", "ThrEE"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-}
-
-TEST_F(TApp, InSetIgnoreCasePointer) {
-
-    std::set<std::string> *options = new std::set<std::string>{"one", "Two", "THREE"};
-    std::string choice;
-    app.add_set_ignore_case("-q,--quick", choice, *options);
-
-    args = {"--quick", "One"};
-    run();
-    EXPECT_EQ("one", choice);
-
-    args = {"--quick", "two"};
-    run();
-    EXPECT_EQ("Two", choice); // Keeps caps from set
-
-    args = {"--quick", "ThrEE"};
-    run();
-    EXPECT_EQ("THREE", choice); // Keeps caps from set
-
-    delete options;
-    args = {"--quick", "ThrEE"};
-    run();
-    EXPECT_EQ("THREE", choice); // this does not throw a segfault
-
-    args = {"--quick", "four"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-
-    args = {"--quick=one", "--quick=two"};
-    EXPECT_THROW(run(), CLI::ArgumentMismatch);
-}
-
-TEST_F(TApp, InSetIgnoreUnderscore) {
-
-    std::string choice;
-    app.add_set_ignore_underscore("-q,--quick", choice, {"option_one", "option_two", "optionthree"});
-
-    args = {"--quick", "option_one"};
-    run();
-    EXPECT_EQ("option_one", choice);
-
-    args = {"--quick", "optiontwo"};
-    run();
-    EXPECT_EQ("option_two", choice); // Keeps underscore from set
-
-    args = {"--quick", "_option_thr_ee"};
-    run();
-    EXPECT_EQ("optionthree", choice); // no underscore
-
-    args = {"--quick", "Option4"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-
-    args = {"--quick=option_one", "--quick=option_two"};
-    EXPECT_THROW(run(), CLI::ArgumentMismatch);
-}
-
-TEST_F(TApp, InSetIgnoreCaseUnderscore) {
-
-    std::string choice;
-    app.add_set_ignore_case_underscore("-q,--quick", choice, {"Option_One", "option_two", "OptionThree"});
-
-    args = {"--quick", "option_one"};
-    run();
-    EXPECT_EQ("Option_One", choice);
-
-    args = {"--quick", "OptionTwo"};
-    run();
-    EXPECT_EQ("option_two", choice); // Keeps underscore and case from set
-
-    args = {"--quick", "_OPTION_thr_ee"};
-    run();
-    EXPECT_EQ("OptionThree", choice); // no underscore
-
-    args = {"--quick", "Option4"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-
-    args = {"--quick=option_one", "--quick=option_two"};
-    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
 TEST_F(TApp, VectorFixedString) {
@@ -1895,33 +1668,6 @@ TEST_F(TApp, OptionWithDefaults) {
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
-TEST_F(TApp, SetWithDefaults) {
-    int someint = 2;
-    app.add_set("-a", someint, {1, 2, 3, 4}, "", true);
-
-    args = {"-a1", "-a2"};
-
-    EXPECT_THROW(run(), CLI::ArgumentMismatch);
-}
-
-TEST_F(TApp, SetWithDefaultsConversion) {
-    int someint = 2;
-    app.add_set("-a", someint, {1, 2, 3, 4}, "", true);
-
-    args = {"-a", "hi"};
-
-    EXPECT_THROW(run(), CLI::ConversionError);
-}
-
-TEST_F(TApp, SetWithDefaultsIC) {
-    std::string someint = "ho";
-    app.add_set_ignore_case("-a", someint, {"Hi", "Ho"}, "", true);
-
-    args = {"-aHi", "-aHo"};
-
-    EXPECT_THROW(run(), CLI::ArgumentMismatch);
-}
-
 // Added to test ->transform
 TEST_F(TApp, OrderedModifingTransforms) {
     std::vector<std::string> val;
@@ -1987,69 +1733,6 @@ TEST_F(TApp, CustomDoubleOption) {
     run();
     EXPECT_EQ(custom_opt.first, 12);
     EXPECT_DOUBLE_EQ(custom_opt.second, 1.5);
-}
-
-// #113
-TEST_F(TApp, AddRemoveSetItems) {
-    std::set<std::string> items{"TYPE1", "TYPE2", "TYPE3", "TYPE4", "TYPE5"};
-
-    std::string type1, type2;
-    app.add_mutable_set("--type1", type1, items);
-    app.add_mutable_set("--type2", type2, items, "", true);
-
-    args = {"--type1", "TYPE1", "--type2", "TYPE2"};
-
-    run();
-    EXPECT_EQ(type1, "TYPE1");
-    EXPECT_EQ(type2, "TYPE2");
-
-    items.insert("TYPE6");
-    items.insert("TYPE7");
-
-    items.erase("TYPE1");
-    items.erase("TYPE2");
-
-    args = {"--type1", "TYPE6", "--type2", "TYPE7"};
-    run();
-    EXPECT_EQ(type1, "TYPE6");
-    EXPECT_EQ(type2, "TYPE7");
-
-    args = {"--type1", "TYPE1"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-
-    args = {"--type2", "TYPE2"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-}
-
-TEST_F(TApp, AddRemoveSetItemsNoCase) {
-    std::set<std::string> items{"TYPE1", "TYPE2", "TYPE3", "TYPE4", "TYPE5"};
-
-    std::string type1, type2;
-    app.add_mutable_set_ignore_case("--type1", type1, items);
-    app.add_mutable_set_ignore_case("--type2", type2, items, "", true);
-
-    args = {"--type1", "TYPe1", "--type2", "TyPE2"};
-
-    run();
-    EXPECT_EQ(type1, "TYPE1");
-    EXPECT_EQ(type2, "TYPE2");
-
-    items.insert("TYPE6");
-    items.insert("TYPE7");
-
-    items.erase("TYPE1");
-    items.erase("TYPE2");
-
-    args = {"--type1", "TyPE6", "--type2", "tYPE7"};
-    run();
-    EXPECT_EQ(type1, "TYPE6");
-    EXPECT_EQ(type2, "TYPE7");
-
-    args = {"--type1", "TYPe1"};
-    EXPECT_THROW(run(), CLI::ConversionError);
-
-    args = {"--type2", "TYpE2"};
-    EXPECT_THROW(run(), CLI::ConversionError);
 }
 
 // #128

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CLI11_TESTS
     IniTest
     SimpleTest
     AppTest
+    SetTest
     CreationTest
     SubcommandTest
     HelpTest

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(CLI11_TESTS
     OptionalTest
     DeprecatedTest
     StringParseTest
+    TrueFalseTest
     )
 
 if(WIN32)

--- a/tests/DeprecatedTest.cpp
+++ b/tests/DeprecatedTest.cpp
@@ -1,12 +1,328 @@
-#ifdef CLI11_SINGLE_FILE
-#include "CLI11.hpp"
-#else
-#include "CLI/CLI.hpp"
-#endif
-
-#include "gtest/gtest.h"
+#include "app_helper.hpp"
 
 TEST(Deprecated, Emtpy) {
     // No deprecated features at this time.
     EXPECT_TRUE(true);
+}
+
+// Classic sets
+
+TEST_F(TApp, SetWithDefaults) {
+    int someint = 2;
+    app.add_set("-a", someint, {1, 2, 3, 4}, "", true);
+
+    args = {"-a1", "-a2"};
+
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, SetWithDefaultsConversion) {
+    int someint = 2;
+    app.add_set("-a", someint, {1, 2, 3, 4}, "", true);
+
+    args = {"-a", "hi"};
+
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, SetWithDefaultsIC) {
+    std::string someint = "ho";
+    app.add_set_ignore_case("-a", someint, {"Hi", "Ho"}, "", true);
+
+    args = {"-aHi", "-aHo"};
+
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, InSet) {
+
+    std::string choice;
+    app.add_set("-q,--quick", choice, {"one", "two", "three"});
+
+    args = {"--quick", "two"};
+
+    run();
+    EXPECT_EQ("two", choice);
+
+    args = {"--quick", "four"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InSetWithDefault) {
+
+    std::string choice = "one";
+    app.add_set("-q,--quick", choice, {"one", "two", "three"}, "", true);
+
+    run();
+    EXPECT_EQ("one", choice);
+
+    args = {"--quick", "two"};
+
+    run();
+    EXPECT_EQ("two", choice);
+
+    args = {"--quick", "four"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InCaselessSetWithDefault) {
+
+    std::string choice = "one";
+    app.add_set_ignore_case("-q,--quick", choice, {"one", "two", "three"}, "", true);
+
+    run();
+    EXPECT_EQ("one", choice);
+
+    args = {"--quick", "tWo"};
+
+    run();
+    EXPECT_EQ("two", choice);
+
+    args = {"--quick", "four"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InIntSet) {
+
+    int choice;
+    app.add_set("-q,--quick", choice, {1, 2, 3});
+
+    args = {"--quick", "2"};
+
+    run();
+    EXPECT_EQ(2, choice);
+
+    args = {"--quick", "4"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InIntSetWindows) {
+
+    int choice;
+    app.add_set("-q,--quick", choice, {1, 2, 3});
+    app.allow_windows_style_options();
+    args = {"/q", "2"};
+
+    run();
+    EXPECT_EQ(2, choice);
+
+    args = {"/q", "4"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"/q4"};
+    EXPECT_THROW(run(), CLI::ExtrasError);
+}
+
+TEST_F(TApp, FailSet) {
+
+    int choice;
+    app.add_set("-q,--quick", choice, {1, 2, 3});
+
+    args = {"--quick", "3", "--quick=2"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+
+    args = {"--quick=hello"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, FailMutableSet) {
+
+    int choice;
+    std::set<int> vals{1, 2, 3};
+    app.add_mutable_set("-q,--quick", choice, vals);
+    app.add_mutable_set("-s,--slow", choice, vals, "", true);
+
+    args = {"--quick=hello"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--slow=hello"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InSetIgnoreCase) {
+
+    std::string choice;
+    app.add_set_ignore_case("-q,--quick", choice, {"one", "Two", "THREE"});
+
+    args = {"--quick", "One"};
+    run();
+    EXPECT_EQ("one", choice);
+
+    args = {"--quick", "two"};
+    run();
+    EXPECT_EQ("Two", choice); // Keeps caps from set
+
+    args = {"--quick", "ThrEE"};
+    run();
+    EXPECT_EQ("THREE", choice); // Keeps caps from set
+
+    args = {"--quick", "four"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--quick=one", "--quick=two"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, InSetIgnoreCaseMutableValue) {
+
+    std::set<std::string> options{"one", "Two", "THREE"};
+    std::string choice;
+    app.add_mutable_set_ignore_case("-q,--quick", choice, options);
+
+    args = {"--quick", "One"};
+    run();
+    EXPECT_EQ("one", choice);
+
+    args = {"--quick", "two"};
+    run();
+    EXPECT_EQ("Two", choice); // Keeps caps from set
+
+    args = {"--quick", "ThrEE"};
+    run();
+    EXPECT_EQ("THREE", choice); // Keeps caps from set
+
+    options.clear();
+    args = {"--quick", "ThrEE"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InSetIgnoreCasePointer) {
+
+    auto options = std::make_shared<std::set<std::string>>(std::initializer_list<std::string>{"one", "Two", "THREE"});
+    std::string choice;
+    app.add_set_ignore_case("-q,--quick", choice, *options);
+
+    args = {"--quick", "One"};
+    run();
+    EXPECT_EQ("one", choice);
+
+    args = {"--quick", "two"};
+    run();
+    EXPECT_EQ("Two", choice); // Keeps caps from set
+
+    args = {"--quick", "ThrEE"};
+    run();
+    EXPECT_EQ("THREE", choice); // Keeps caps from set
+
+    options.reset();
+    args = {"--quick", "ThrEE"};
+    run();
+    EXPECT_EQ("THREE", choice); // this does not throw a segfault
+
+    args = {"--quick", "four"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--quick=one", "--quick=two"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, InSetIgnoreUnderscore) {
+
+    std::string choice;
+    app.add_set_ignore_underscore("-q,--quick", choice, {"option_one", "option_two", "optionthree"});
+
+    args = {"--quick", "option_one"};
+    run();
+    EXPECT_EQ("option_one", choice);
+
+    args = {"--quick", "optiontwo"};
+    run();
+    EXPECT_EQ("option_two", choice); // Keeps underscore from set
+
+    args = {"--quick", "_option_thr_ee"};
+    run();
+    EXPECT_EQ("optionthree", choice); // no underscore
+
+    args = {"--quick", "Option4"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--quick=option_one", "--quick=option_two"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, InSetIgnoreCaseUnderscore) {
+
+    std::string choice;
+    app.add_set_ignore_case_underscore("-q,--quick", choice, {"Option_One", "option_two", "OptionThree"});
+
+    args = {"--quick", "option_one"};
+    run();
+    EXPECT_EQ("Option_One", choice);
+
+    args = {"--quick", "OptionTwo"};
+    run();
+    EXPECT_EQ("option_two", choice); // Keeps underscore and case from set
+
+    args = {"--quick", "_OPTION_thr_ee"};
+    run();
+    EXPECT_EQ("OptionThree", choice); // no underscore
+
+    args = {"--quick", "Option4"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--quick=option_one", "--quick=option_two"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+// #113
+TEST_F(TApp, AddRemoveSetItems) {
+    std::set<std::string> items{"TYPE1", "TYPE2", "TYPE3", "TYPE4", "TYPE5"};
+
+    std::string type1, type2;
+    app.add_mutable_set("--type1", type1, items);
+    app.add_mutable_set("--type2", type2, items, "", true);
+
+    args = {"--type1", "TYPE1", "--type2", "TYPE2"};
+
+    run();
+    EXPECT_EQ(type1, "TYPE1");
+    EXPECT_EQ(type2, "TYPE2");
+
+    items.insert("TYPE6");
+    items.insert("TYPE7");
+
+    items.erase("TYPE1");
+    items.erase("TYPE2");
+
+    args = {"--type1", "TYPE6", "--type2", "TYPE7"};
+    run();
+    EXPECT_EQ(type1, "TYPE6");
+    EXPECT_EQ(type2, "TYPE7");
+
+    args = {"--type1", "TYPE1"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--type2", "TYPE2"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, AddRemoveSetItemsNoCase) {
+    std::set<std::string> items{"TYPE1", "TYPE2", "TYPE3", "TYPE4", "TYPE5"};
+
+    std::string type1, type2;
+    app.add_mutable_set_ignore_case("--type1", type1, items);
+    app.add_mutable_set_ignore_case("--type2", type2, items, "", true);
+
+    args = {"--type1", "TYPe1", "--type2", "TyPE2"};
+
+    run();
+    EXPECT_EQ(type1, "TYPE1");
+    EXPECT_EQ(type2, "TYPE2");
+
+    items.insert("TYPE6");
+    items.insert("TYPE7");
+
+    items.erase("TYPE1");
+    items.erase("TYPE2");
+
+    args = {"--type1", "TyPE6", "--type2", "tYPE7"};
+    run();
+    EXPECT_EQ(type1, "TYPE6");
+    EXPECT_EQ(type2, "TYPE7");
+
+    args = {"--type1", "TYPe1"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--type2", "TYpE2"};
+    EXPECT_THROW(run(), CLI::ValidationError);
 }

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -280,7 +280,7 @@ TEST(THelp, IntDefaults) {
 
     int one{1}, two{2};
     app.add_option("--one", one, "Help for one", true);
-    app.add_set("--set", two, {2, 3, 4}, "Help for set", true);
+    app.add_option("--set", two, "Help for set", true)->check(CLI::IsMember({2, 3, 4}));
 
     std::string help = app.help();
 
@@ -295,7 +295,7 @@ TEST(THelp, SetLower) {
     CLI::App app{"My prog"};
 
     std::string def{"One"};
-    app.add_set_ignore_case("--set", def, {"oNe", "twO", "THREE"}, "Help for set", true);
+    app.add_option("--set", def, "Help for set", true)->check(CLI::IsMember({"oNe", "twO", "THREE"}));
 
     std::string help = app.help();
 
@@ -795,7 +795,7 @@ TEST(THelp, ChangingSet) {
 
     std::set<int> vals{1, 2, 3};
     int val;
-    app.add_mutable_set("--val", val, vals);
+    app.add_option("--val", val)->check(CLI::IsMember(&vals));
 
     std::string help = app.help();
 
@@ -816,7 +816,7 @@ TEST(THelp, ChangingSetDefaulted) {
 
     std::set<int> vals{1, 2, 3};
     int val = 2;
-    app.add_mutable_set("--val", val, vals, "", true);
+    app.add_option("--val", val, "", true)->check(CLI::IsMember(&vals));
 
     std::string help = app.help();
 
@@ -836,7 +836,7 @@ TEST(THelp, ChangingCaselessSet) {
 
     std::set<std::string> vals{"1", "2", "3"};
     std::string val;
-    app.add_mutable_set_ignore_case("--val", val, vals);
+    app.add_option("--val", val)->check(CLI::IsMember(&vals, CLI::ignore_case));
 
     std::string help = app.help();
 
@@ -857,7 +857,7 @@ TEST(THelp, ChangingCaselessSetDefaulted) {
 
     std::set<std::string> vals{"1", "2", "3"};
     std::string val = "2";
-    app.add_mutable_set_ignore_case("--val", val, vals, "", true);
+    app.add_option("--val", val, "", true)->check(CLI::IsMember(&vals, CLI::ignore_case));
 
     std::string help = app.help();
 

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -603,9 +603,9 @@ TEST_F(TApp, IniFlags) {
     run();
 
     EXPECT_EQ(2, two);
-    EXPECT_EQ(true, three);
-    EXPECT_EQ(true, four);
-    EXPECT_EQ(true, five);
+    EXPECT_TRUE(three);
+    EXPECT_TRUE(four);
+    EXPECT_TRUE(five);
 }
 
 TEST_F(TApp, IniFalseFlags) {
@@ -631,9 +631,9 @@ TEST_F(TApp, IniFalseFlags) {
     run();
 
     EXPECT_EQ(-2, two);
-    EXPECT_EQ(false, three);
-    EXPECT_EQ(true, four);
-    EXPECT_EQ(true, five);
+    EXPECT_FALSE(three);
+    EXPECT_TRUE(four);
+    EXPECT_TRUE(five);
 }
 
 TEST_F(TApp, IniFalseFlagsDef) {
@@ -659,9 +659,9 @@ TEST_F(TApp, IniFalseFlagsDef) {
     run();
 
     EXPECT_EQ(-2, two);
-    EXPECT_EQ(true, three);
-    EXPECT_EQ(false, four);
-    EXPECT_EQ(true, five);
+    EXPECT_TRUE(three);
+    EXPECT_FALSE(four);
+    EXPECT_TRUE(five);
 }
 
 TEST_F(TApp, IniOutputSimple) {

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -767,7 +767,7 @@ TEST_F(TApp, IniOutputFlag) {
 TEST_F(TApp, IniOutputSet) {
 
     int v;
-    app.add_set("--simple", v, {1, 2, 3});
+    app.add_option("--simple", v)->check(CLI::IsMember({1, 2, 3}));
 
     args = {"--simple=2"};
 

--- a/tests/SetTest.cpp
+++ b/tests/SetTest.cpp
@@ -162,7 +162,7 @@ TEST_F(TApp, SetWithDefaultsConversion) {
 
     args = {"-a", "hi"};
 
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ValidationError);
 }
 
 TEST_F(TApp, SetWithDefaultsIC) {
@@ -262,7 +262,7 @@ TEST_F(TApp, FailSet) {
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
 
     args = {"--quick=hello"};
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ValidationError);
 }
 
 TEST_F(TApp, FailMutableSet) {
@@ -273,10 +273,10 @@ TEST_F(TApp, FailMutableSet) {
     app.add_mutable_set("-s,--slow", choice, vals, "", true);
 
     args = {"--quick=hello"};
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ValidationError);
 
     args = {"--slow=hello"};
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ValidationError);
 }
 
 TEST_F(TApp, InSetIgnoreCase) {

--- a/tests/SetTest.cpp
+++ b/tests/SetTest.cpp
@@ -59,9 +59,29 @@ TEST_F(TApp, SimiShortcutSets) {
     EXPECT_EQ(value2, "One");
 }
 
-TEST_F(TApp, ShortcutSets) {
+/*
+
+ //template <typename T, enable_if_t<std::is_assignable<std::function<std::string(std::string)>, T>::value &&
+ !(std::is_same<T, const char *>::value || std::is_same<T, char *>::value), detail::enabler> = detail::dummy>
+ //int check_compile(T fn) const {return 2;}
+
+ //template <typename T, enable_if_t<std::is_assignable<std::string, T>::value, detail::enabler> = detail::dummy>
+ //int check_compile(T str) const {return 3;}
+
+ std::string value;
+ int a = app.add_option("--set", value)->check_compile("this");
+ int b = app.add_option("--set2", value)->check_compile(CLI::ignore_case);
+
+
+ EXPECT_EQ(a, 3);
+ EXPECT_EQ(b, 2);
+
+ */
+
+TEST_F(TApp, ShortCutSets) {
+
     std::string value;
-    auto opt = app.add_option("--set", value)->set({"one", "two", "three"});
+    auto opt = app.add_option("--set", value)->choices("one", "two", "three");
     args = {"--set", "one"};
     run();
     EXPECT_EQ(1u, app.count("--set"));
@@ -69,12 +89,21 @@ TEST_F(TApp, ShortcutSets) {
     EXPECT_EQ(value, "one");
 
     std::string value2;
-    auto opt2 = app.add_option("--set2", value2)->set({"One", "two", "three"}, CLI::ignore_case);
+    auto opt2 = app.add_option("--set2", value2)->choices("One", "two", "three", CLI::ignore_case);
     args = {"--set2", "onE"};
     run();
     EXPECT_EQ(1u, app.count("--set2"));
     EXPECT_EQ(1u, opt2->count());
     EXPECT_EQ(value2, "One");
+
+    std::string value3;
+    auto opt3 =
+        app.add_option("--set3", value3)->choices("O_ne", "two", "three", CLI::ignore_case, CLI::ignore_underscore);
+    args = {"--set3", "onE"};
+    run();
+    EXPECT_EQ(1u, app.count("--set3"));
+    EXPECT_EQ(1u, opt3->count());
+    EXPECT_EQ(value3, "O_ne");
 }
 
 TEST_F(TApp, NumericalSets) {

--- a/tests/SetTest.cpp
+++ b/tests/SetTest.cpp
@@ -68,7 +68,7 @@ TEST_F(TApp, SimiShortcutSets) {
     EXPECT_EQ(value3, "O_ne");
 }
 
-TEST_F(TApp, SetFromCharStarArray) {
+TEST_F(TApp, SetFromCharStarArrayVector) {
     constexpr const char *names[] = {"one", "two", "three"};
     std::string value;
     auto opt = app.add_option("-s,--set", value)
@@ -80,25 +80,6 @@ TEST_F(TApp, SetFromCharStarArray) {
     EXPECT_EQ(1u, opt->count());
     EXPECT_EQ(value, "one");
 }
-
-/*
-
- //template <typename T, enable_if_t<std::is_assignable<std::function<std::string(std::string)>, T>::value &&
- !(std::is_same<T, const char *>::value || std::is_same<T, char *>::value), detail::enabler> = detail::dummy>
- //int check_compile(T fn) const {return 2;}
-
- //template <typename T, enable_if_t<std::is_assignable<std::string, T>::value, detail::enabler> = detail::dummy>
- //int check_compile(T str) const {return 3;}
-
- std::string value;
- int a = app.add_option("--set", value)->check_compile("this");
- int b = app.add_option("--set2", value)->check_compile(CLI::ignore_case);
-
-
- EXPECT_EQ(a, 3);
- EXPECT_EQ(b, 2);
-
- */
 
 TEST_F(TApp, OtherTypeSets) {
     int value;

--- a/tests/SetTest.cpp
+++ b/tests/SetTest.cpp
@@ -41,6 +41,25 @@ TEST_F(TApp, SimpleSetsPtrs) {
     EXPECT_EQ(value, "four");
 }
 
+TEST_F(TApp, ShortcutSets) {
+    std::string value;
+    auto opt = app.add_option("-s,--set", value)->set("one", "two", "three");
+    args = {"-s", "one"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, app.count("--set"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, "one");
+
+    std::string value2;
+    auto opt2 = app.add_option("--set2", value2)->set(CLI::ignore_case, "One", "two", "three");
+    args = {"--set2", "onE"};
+    run();
+    EXPECT_EQ(1u, app.count("--set2"));
+    EXPECT_EQ(1u, opt2->count());
+    EXPECT_EQ(value2, "One");
+}
+
 // Classic sets
 
 TEST_F(TApp, SetWithDefaults) {

--- a/tests/SetTest.cpp
+++ b/tests/SetTest.cpp
@@ -41,23 +41,51 @@ TEST_F(TApp, SimpleSetsPtrs) {
     EXPECT_EQ(value, "four");
 }
 
-TEST_F(TApp, ShortcutSets) {
+TEST_F(TApp, SimiShortcutSets) {
     std::string value;
-    auto opt = app.add_option("-s,--set", value)->set("one", "two", "three");
-    args = {"-s", "one"};
+    auto opt = app.add_option("--set", value)->check(CLI::IsMember({"one", "two", "three"}));
+    args = {"--set", "one"};
     run();
-    EXPECT_EQ(1u, app.count("-s"));
     EXPECT_EQ(1u, app.count("--set"));
     EXPECT_EQ(1u, opt->count());
     EXPECT_EQ(value, "one");
 
     std::string value2;
-    auto opt2 = app.add_option("--set2", value2)->set(CLI::ignore_case, "One", "two", "three");
+    auto opt2 = app.add_option("--set2", value2)->check(CLI::IsMember({"One", "two", "three"}, CLI::ignore_case));
     args = {"--set2", "onE"};
     run();
     EXPECT_EQ(1u, app.count("--set2"));
     EXPECT_EQ(1u, opt2->count());
     EXPECT_EQ(value2, "One");
+}
+
+TEST_F(TApp, ShortcutSets) {
+    std::string value;
+    auto opt = app.add_option("--set", value)->set({"one", "two", "three"});
+    args = {"--set", "one"};
+    run();
+    EXPECT_EQ(1u, app.count("--set"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, "one");
+
+    std::string value2;
+    auto opt2 = app.add_option("--set2", value2)->set({"One", "two", "three"}, CLI::ignore_case);
+    args = {"--set2", "onE"};
+    run();
+    EXPECT_EQ(1u, app.count("--set2"));
+    EXPECT_EQ(1u, opt2->count());
+    EXPECT_EQ(value2, "One");
+}
+
+TEST_F(TApp, NumericalSets) {
+    int value;
+    auto opt = app.add_option("-s,--set", value)->check(CLI::IsMember{std::set<int>({1, 2, 3})});
+    args = {"-s", "1"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, app.count("--set"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, 1);
 }
 
 // Classic sets

--- a/tests/SetTest.cpp
+++ b/tests/SetTest.cpp
@@ -1,0 +1,364 @@
+#include "app_helper.hpp"
+
+static_assert(CLI::is_shared_ptr<std::shared_ptr<int>>::value == true, "is_shared_ptr should work on shared pointers");
+static_assert(CLI::is_shared_ptr<int *>::value == false, "is_shared_ptr should work on pointers");
+static_assert(CLI::is_shared_ptr<int>::value == false, "is_shared_ptr should work on non-pointers");
+
+static_assert(CLI::is_copyable_ptr<std::shared_ptr<int>>::value == true,
+              "is_copyable_ptr should work on shared pointers");
+static_assert(CLI::is_copyable_ptr<int *>::value == true, "is_copyable_ptr should work on pointers");
+static_assert(CLI::is_copyable_ptr<int>::value == false, "is_copyable_ptr should work on non-pointers");
+
+TEST_F(TApp, SimpleSets) {
+    std::string value;
+    auto opt = app.add_option("-s,--set", value)->check(CLI::IsMember{std::set<std::string>({"one", "two", "three"})});
+    args = {"-s", "one"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, app.count("--set"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, "one");
+}
+
+TEST_F(TApp, SimpleSetsPtrs) {
+    auto set = std::shared_ptr<std::set<std::string>>(new std::set<std::string>{"one", "two", "three"});
+    std::string value;
+    auto opt = app.add_option("-s,--set", value)->check(CLI::IsMember{set});
+    args = {"-s", "one"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, app.count("--set"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, "one");
+
+    set->insert("four");
+
+    args = {"-s", "four"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, app.count("--set"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, "four");
+}
+
+// Classic sets
+
+TEST_F(TApp, SetWithDefaults) {
+    int someint = 2;
+    app.add_set("-a", someint, {1, 2, 3, 4}, "", true);
+
+    args = {"-a1", "-a2"};
+
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, SetWithDefaultsConversion) {
+    int someint = 2;
+    app.add_set("-a", someint, {1, 2, 3, 4}, "", true);
+
+    args = {"-a", "hi"};
+
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
+TEST_F(TApp, SetWithDefaultsIC) {
+    std::string someint = "ho";
+    app.add_set_ignore_case("-a", someint, {"Hi", "Ho"}, "", true);
+
+    args = {"-aHi", "-aHo"};
+
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, InSet) {
+
+    std::string choice;
+    app.add_set("-q,--quick", choice, {"one", "two", "three"});
+
+    args = {"--quick", "two"};
+
+    run();
+    EXPECT_EQ("two", choice);
+
+    args = {"--quick", "four"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InSetWithDefault) {
+
+    std::string choice = "one";
+    app.add_set("-q,--quick", choice, {"one", "two", "three"}, "", true);
+
+    run();
+    EXPECT_EQ("one", choice);
+
+    args = {"--quick", "two"};
+
+    run();
+    EXPECT_EQ("two", choice);
+
+    args = {"--quick", "four"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InCaselessSetWithDefault) {
+
+    std::string choice = "one";
+    app.add_set_ignore_case("-q,--quick", choice, {"one", "two", "three"}, "", true);
+
+    run();
+    EXPECT_EQ("one", choice);
+
+    args = {"--quick", "tWo"};
+
+    run();
+    EXPECT_EQ("two", choice);
+
+    args = {"--quick", "four"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InIntSet) {
+
+    int choice;
+    app.add_set("-q,--quick", choice, {1, 2, 3});
+
+    args = {"--quick", "2"};
+
+    run();
+    EXPECT_EQ(2, choice);
+
+    args = {"--quick", "4"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InIntSetWindows) {
+
+    int choice;
+    app.add_set("-q,--quick", choice, {1, 2, 3});
+    app.allow_windows_style_options();
+    args = {"/q", "2"};
+
+    run();
+    EXPECT_EQ(2, choice);
+
+    args = {"/q", "4"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"/q4"};
+    EXPECT_THROW(run(), CLI::ExtrasError);
+}
+
+TEST_F(TApp, FailSet) {
+
+    int choice;
+    app.add_set("-q,--quick", choice, {1, 2, 3});
+
+    args = {"--quick", "3", "--quick=2"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+
+    args = {"--quick=hello"};
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
+TEST_F(TApp, FailMutableSet) {
+
+    int choice;
+    std::set<int> vals{1, 2, 3};
+    app.add_mutable_set("-q,--quick", choice, vals);
+    app.add_mutable_set("-s,--slow", choice, vals, "", true);
+
+    args = {"--quick=hello"};
+    EXPECT_THROW(run(), CLI::ConversionError);
+
+    args = {"--slow=hello"};
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
+TEST_F(TApp, InSetIgnoreCase) {
+
+    std::string choice;
+    app.add_set_ignore_case("-q,--quick", choice, {"one", "Two", "THREE"});
+
+    args = {"--quick", "One"};
+    run();
+    EXPECT_EQ("one", choice);
+
+    args = {"--quick", "two"};
+    run();
+    EXPECT_EQ("Two", choice); // Keeps caps from set
+
+    args = {"--quick", "ThrEE"};
+    run();
+    EXPECT_EQ("THREE", choice); // Keeps caps from set
+
+    args = {"--quick", "four"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--quick=one", "--quick=two"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, InSetIgnoreCaseMutableValue) {
+
+    std::set<std::string> options{"one", "Two", "THREE"};
+    std::string choice;
+    app.add_mutable_set_ignore_case("-q,--quick", choice, options);
+
+    args = {"--quick", "One"};
+    run();
+    EXPECT_EQ("one", choice);
+
+    args = {"--quick", "two"};
+    run();
+    EXPECT_EQ("Two", choice); // Keeps caps from set
+
+    args = {"--quick", "ThrEE"};
+    run();
+    EXPECT_EQ("THREE", choice); // Keeps caps from set
+
+    options.clear();
+    args = {"--quick", "ThrEE"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, InSetIgnoreCasePointer) {
+
+    std::set<std::string> *options = new std::set<std::string>{"one", "Two", "THREE"};
+    std::string choice;
+    app.add_set_ignore_case("-q,--quick", choice, *options);
+
+    args = {"--quick", "One"};
+    run();
+    EXPECT_EQ("one", choice);
+
+    args = {"--quick", "two"};
+    run();
+    EXPECT_EQ("Two", choice); // Keeps caps from set
+
+    args = {"--quick", "ThrEE"};
+    run();
+    EXPECT_EQ("THREE", choice); // Keeps caps from set
+
+    delete options;
+    args = {"--quick", "ThrEE"};
+    run();
+    EXPECT_EQ("THREE", choice); // this does not throw a segfault
+
+    args = {"--quick", "four"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--quick=one", "--quick=two"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, InSetIgnoreUnderscore) {
+
+    std::string choice;
+    app.add_set_ignore_underscore("-q,--quick", choice, {"option_one", "option_two", "optionthree"});
+
+    args = {"--quick", "option_one"};
+    run();
+    EXPECT_EQ("option_one", choice);
+
+    args = {"--quick", "optiontwo"};
+    run();
+    EXPECT_EQ("option_two", choice); // Keeps underscore from set
+
+    args = {"--quick", "_option_thr_ee"};
+    run();
+    EXPECT_EQ("optionthree", choice); // no underscore
+
+    args = {"--quick", "Option4"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--quick=option_one", "--quick=option_two"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+TEST_F(TApp, InSetIgnoreCaseUnderscore) {
+
+    std::string choice;
+    app.add_set_ignore_case_underscore("-q,--quick", choice, {"Option_One", "option_two", "OptionThree"});
+
+    args = {"--quick", "option_one"};
+    run();
+    EXPECT_EQ("Option_One", choice);
+
+    args = {"--quick", "OptionTwo"};
+    run();
+    EXPECT_EQ("option_two", choice); // Keeps underscore and case from set
+
+    args = {"--quick", "_OPTION_thr_ee"};
+    run();
+    EXPECT_EQ("OptionThree", choice); // no underscore
+
+    args = {"--quick", "Option4"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--quick=option_one", "--quick=option_two"};
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+}
+
+// #113
+TEST_F(TApp, AddRemoveSetItems) {
+    std::set<std::string> items{"TYPE1", "TYPE2", "TYPE3", "TYPE4", "TYPE5"};
+
+    std::string type1, type2;
+    app.add_mutable_set("--type1", type1, items);
+    app.add_mutable_set("--type2", type2, items, "", true);
+
+    args = {"--type1", "TYPE1", "--type2", "TYPE2"};
+
+    run();
+    EXPECT_EQ(type1, "TYPE1");
+    EXPECT_EQ(type2, "TYPE2");
+
+    items.insert("TYPE6");
+    items.insert("TYPE7");
+
+    items.erase("TYPE1");
+    items.erase("TYPE2");
+
+    args = {"--type1", "TYPE6", "--type2", "TYPE7"};
+    run();
+    EXPECT_EQ(type1, "TYPE6");
+    EXPECT_EQ(type2, "TYPE7");
+
+    args = {"--type1", "TYPE1"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--type2", "TYPE2"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, AddRemoveSetItemsNoCase) {
+    std::set<std::string> items{"TYPE1", "TYPE2", "TYPE3", "TYPE4", "TYPE5"};
+
+    std::string type1, type2;
+    app.add_mutable_set_ignore_case("--type1", type1, items);
+    app.add_mutable_set_ignore_case("--type2", type2, items, "", true);
+
+    args = {"--type1", "TYPe1", "--type2", "TyPE2"};
+
+    run();
+    EXPECT_EQ(type1, "TYPE1");
+    EXPECT_EQ(type2, "TYPE2");
+
+    items.insert("TYPE6");
+    items.insert("TYPE7");
+
+    items.erase("TYPE1");
+    items.erase("TYPE2");
+
+    args = {"--type1", "TyPE6", "--type2", "tYPE7"};
+    run();
+    EXPECT_EQ(type1, "TYPE6");
+    EXPECT_EQ(type2, "TYPE7");
+
+    args = {"--type1", "TYPe1"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--type2", "TYpE2"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -888,8 +888,8 @@ TEST_F(TApp, UnnamedSubMixExtras) {
     run();
     EXPECT_EQ(val, -3.0);
     EXPECT_EQ(val2, 5.93);
-    EXPECT_EQ(app.remaining_size(), 2);
-    EXPECT_EQ(sub->remaining_size(), 0);
+    EXPECT_EQ(app.remaining_size(), 2u);
+    EXPECT_EQ(sub->remaining_size(), 0u);
 }
 
 TEST_F(TApp, UnnamedSubNoExtras) {
@@ -901,8 +901,8 @@ TEST_F(TApp, UnnamedSubNoExtras) {
     run();
     EXPECT_EQ(val, -3.0);
     EXPECT_EQ(val2, 5.93);
-    EXPECT_EQ(app.remaining_size(), 0);
-    EXPECT_EQ(sub->remaining_size(), 0);
+    EXPECT_EQ(app.remaining_size(), 0u);
+    EXPECT_EQ(sub->remaining_size(), 0u);
 }
 
 TEST(SharedSubTests, SharedSubcommand) {

--- a/tests/TrueFalseTest.cpp
+++ b/tests/TrueFalseTest.cpp
@@ -1,7 +1,7 @@
 #include "app_helper.hpp"
 
 /// This allows a set of strings to be run over by a test
-struct TApp_TBO : public TApp, public ::testing::WithParamInterface<const char*> {};
+struct TApp_TBO : public TApp, public ::testing::WithParamInterface<const char *> {};
 
 TEST_P(TApp_TBO, TrueBoolOption) {
     bool value = false; // Not used, but set just in case
@@ -13,12 +13,10 @@ TEST_P(TApp_TBO, TrueBoolOption) {
 }
 
 // Change to INSTANTIATE_TEST_SUITE_P in GTest master
-INSTANTIATE_TEST_CASE_P(TrueBoolOptions,
-                         TApp_TBO,
-                         ::testing::Values("true", "on", "True", "ON"),);
+INSTANTIATE_TEST_CASE_P(TrueBoolOptions, TApp_TBO, ::testing::Values("true", "on", "True", "ON"), );
 
 /// This allows a set of strings to be run over by a test
-struct TApp_FBO : public TApp, public ::testing::WithParamInterface<const char*> {};
+struct TApp_FBO : public TApp, public ::testing::WithParamInterface<const char *> {};
 
 TEST_P(TApp_FBO, FalseBoolOptions) {
     bool value = true; // Not used, but set just in case
@@ -29,6 +27,4 @@ TEST_P(TApp_FBO, FalseBoolOptions) {
     EXPECT_FALSE(value);
 }
 
-INSTANTIATE_TEST_CASE_P(FalseBoolOptions,
-                         TApp_FBO,
-                         ::testing::Values("false", "off", "False", "OFF"),);
+INSTANTIATE_TEST_CASE_P(FalseBoolOptions, TApp_FBO, ::testing::Values("false", "off", "False", "OFF"), );

--- a/tests/TrueFalseTest.cpp
+++ b/tests/TrueFalseTest.cpp
@@ -1,0 +1,34 @@
+#include "app_helper.hpp"
+
+/// This allows a set of strings to be run over by a test
+struct TApp_TBO : public TApp, public ::testing::WithParamInterface<const char*> {};
+
+TEST_P(TApp_TBO, TrueBoolOption) {
+    bool value = false; // Not used, but set just in case
+    app.add_option("-b,--bool", value);
+    args = {"--bool", GetParam()};
+    run();
+    EXPECT_EQ(1u, app.count("--bool"));
+    EXPECT_TRUE(value);
+}
+
+// Change to INSTANTIATE_TEST_SUITE_P in GTest master
+INSTANTIATE_TEST_CASE_P(TrueBoolOptions,
+                         TApp_TBO,
+                         ::testing::Values("true", "on", "True", "ON"),);
+
+/// This allows a set of strings to be run over by a test
+struct TApp_FBO : public TApp, public ::testing::WithParamInterface<const char*> {};
+
+TEST_P(TApp_FBO, FalseBoolOptions) {
+    bool value = true; // Not used, but set just in case
+    app.add_option("-b,--bool", value);
+    args = {"--bool", GetParam()};
+    run();
+    EXPECT_EQ(1u, app.count("--bool"));
+    EXPECT_FALSE(value);
+}
+
+INSTANTIATE_TEST_CASE_P(FalseBoolOptions,
+                         TApp_FBO,
+                         ::testing::Values("false", "off", "False", "OFF"),);


### PR DESCRIPTION
This implements `CLI::IsMember`, and deprecates the default `add_set*` options . This fixes the set lifetime and mutability issues in #170 and makes sets easy to modify after adding if you use a (shared) pointer. It also combines case insensitivity and underscore ignoring into validators, without the massive number of methods on App needed now. You can use any iterable that supports `std::begin`, `std::end`, and has `::value_type`, allowing a vector (for example) to be chosen to keep definition order - first item matches.

#### New features:

* Single new validator, no longer a massive list of functions in App
* Shared pointers supported, clear pointer vs. copy semantics
* Combinable custom filter functions
* All types support filter functions
* Other containers, including ordered containers allowed

#### Changes:

* The error for not being found in a set is now `CLI::ValidationError`
* All `add_set*` functions use the new backend, and are deprecated, planned removal of most of them in 1.9, and all of them after that. `mutable` versions may be removed even in 1.8.

#### Ideas:

A `->choices(...)` shortcut could be added, but the syntax is still up for debate, so not in this PR. Feel free to make suggestions.

#### Example of use:

```cpp
// Simple sets
app.add_option("--name", name)->check(CLI::IsMember({"tom", "harry"}));

// Sets can be modified later. `ignore_case` and `ignore_underscores` is addable.
std::set<std::string> names = {"tom", "harry"};
app.add_option("--name", name)->check(CLI::IsMember(&names, CLI::ignore_case));
names->insert("john");

// Shared pointers are supported, and different types. And ordered containers.
auto vals = std::make_shared<std::vector<int>>({1,2});
app.add_option("--val", val)->check(CLI::IsMember(&vals));
names->push_back(3);
```

You can use `std::shared_ptr` (that's internally what's used if you don't give a pointer-like). You can list `CLI::ignore_case` or `CLI::ignore_underscore` (or any other function that will be applied to both sides).

#### Still to do:

- [x] Deprecate old `add_set*` methods (can't be done on all of them because some are templates.)
- [x] Provide new versions of all the tests (coexist for a little while)
- Think about combined name + number style options (might not be part of this PR)
- [x] Add test with non-string function, like abs
- [x] Needs docs and examples
- [x] Fix `ignore_underscore` (no ending s) in the README.