### PR TITLE
Fix Boost CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Set handling has been completely replaced by a new backend that works as a Valid
 * Support for composable unnamed subcommands [#216]
 * Custom vector separator [#209], [#221]
 * Validators added for IP4 addresses and positive numbers [#210]
+* Minimum required Boost for optional Optionals has been corrected to 1.61
 
 > ### Converting from CLI11 1.7:
 >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 3.4)
 # Note: this is a header only library. If you have an older CMake than 3.4,
 # just add the CLI11/include directory and that's all you need to do.
 
-# Make sure users don't get warnings on a tested (3.4 to 3.12) version
+# Make sure users don't get warnings on a tested (3.4 to 3.13) version
 # of CMake. For most of the policies, the new version is better (hence the change).
-if(${CMAKE_VERSION} VERSION_LESS 3.12)
+if(${CMAKE_VERSION} VERSION_LESS 3.13)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 else()
-    cmake_policy(VERSION 3.12)
+    cmake_policy(VERSION 3.13)
 endif()
 
 set(VERSION_REGEX "#define CLI11_VERSION[ \t]+\"(.+)\"")

--- a/include/CLI/Optional.hpp
+++ b/include/CLI/Optional.hpp
@@ -29,7 +29,7 @@
 
 #if __has_include(<boost/optional.hpp>) && !defined(CLI11_BOOST_OPTIONAL)
 #include <boost/version.hpp>
-#if BOOST_VERSION >= 105800
+#if BOOST_VERSION >= 106100
 #define CLI11_BOOST_OPTIONAL 1
 #endif
 #elif !defined(CLI11_BOOST_OPTIONAL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,7 +110,7 @@ file(WRITE "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
     )
 
 # Add boost to test boost::optional if available
-find_package(Boost 1.58)
+find_package(Boost 1.61)
 if(Boost_FOUND)
     if(TARGET Boost::boost)
         target_link_libraries(informational PUBLIC Boost::boost)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,12 +112,12 @@ file(WRITE "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
 # Add boost to test boost::optional if available
 find_package(Boost 1.58)
 if(Boost_FOUND)
-    if (TARGET Boost::boost)
+    if(TARGET Boost::boost)
         target_link_libraries(informational PUBLIC Boost::boost)
         target_link_libraries(OptionalTest PUBLIC Boost::boost)
     else()
-        target_link_libraries(informational PUBLIC ${Boost_INCLUDE_DIR})
-        target_link_libraries(OptionalTest PUBLIC ${BOOST_INCLUDE_DIR})
+        target_include_directories(informational PUBLIC ${Boost_INCLUDE_DIRS})
+        target_include_directories(OptionalTest PUBLIC ${Boost_INCLUDE_DIRS})
     endif()
     # Enforce Boost::Optional even if __has_include is missing on your compiler
     target_compile_definitions(informational PUBLIC CLI11_BOOST_OPTIONAL)


### PR DESCRIPTION
This should fix two errors related to the optional Optional Boost support. The minimum required version Boost::Optional is 1.61 (older versions do not handle CLI11's lexical cast properly), and if you have an older CMake, the Boost include directory is done correctly now. Fixes #225.