### PR TITLE
[WIP] Add radio groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Before parsing, you can set the following options:
 -   `->excludes(opt)`: This option cannot be given with `opt` present, opt is an `Option` pointer.
 -   `->envname(name)`: Gets the value from the environment if present and not passed on the command line.
 -   `->group(name)`: The help group to put the option in. No effect for positional options. Defaults to `"Options"`. `""` will not show up in the help print (hidden).
+-   `->radio_id(ID)`: The numeric group ID of mutually exclusive single-select options. Defaults to 0 (none).
 -   `->ignore_case()`: Ignore the case on the command line (also works on subcommands, does not affect arguments).
 -   `->ignore_underscore()`: Ignore any underscores in the options names (also works on subcommands, does not affect arguments). For example "option_one" will match with "optionone".  This does not apply to short form options since they only have one character
 -   `->description(str)`: Set/change the description.

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -212,6 +212,17 @@ class RequiredError : public ParseError {
             return RequiredError("Requires at least " + std::to_string(min_subcom) + " subcommands",
                                  ExitCodes::RequiredError);
     }
+    static RequiredError Radio(std::vector<std::string> list) {
+        std::string strlist;
+
+        for(auto it = list.cbegin(); it != list.cend(); ++it) {
+            strlist += *it;
+            if(it != list.cend() - 1)
+                strlist += ", ";
+        }
+
+        return RequiredError("Any of [" + strlist + "] options ");
+    }
 };
 
 /// Thrown when the wrong number of arguments has been received

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -39,6 +39,11 @@ template <typename CRTP> class OptionBase {
     /// The group membership
     std::string group_ = std::string("Options");
 
+    /// Radio-group ID. 0 = Not in a radio-group
+    int radio_id_ = 0;
+    /// Is any of the radio-group siblings specified?
+    const CRTP *radio_selected = nullptr;
+
     /// True if this is a required option
     bool required_{false};
 
@@ -57,6 +62,7 @@ template <typename CRTP> class OptionBase {
     /// Copy the contents to another similar class (one based on OptionBase)
     template <typename T> void copy_to(T *other) const {
         other->group(group_);
+        other->radio_id(radio_id_);
         other->required(required_);
         other->ignore_case(ignore_case_);
         other->ignore_underscore(ignore_underscore_);
@@ -74,6 +80,13 @@ template <typename CRTP> class OptionBase {
         ;
     }
 
+    /// Changes the radio-group membership
+    CRTP *radio_id(int id = 0) {
+        radio_id_ = id;
+        return static_cast<CRTP *>(this);
+        ;
+    }
+
     /// Set the option as required
     CRTP *required(bool value = true) {
         required_ = value;
@@ -87,6 +100,9 @@ template <typename CRTP> class OptionBase {
 
     /// Get the group of this option
     const std::string &get_group() const { return group_; }
+
+    /// Get the radio-group of this option
+    int get_radio_id() const { return radio_id_; }
 
     /// True if this is a required option
     bool get_required() const { return required_; }


### PR DESCRIPTION
Radio groups are named so after HTML radio buttons
(named so after old style car radio station select buttons).

A radio group is a numeric property of an Option.
All options having the same radio_id() become mutually
exclusive and at least one of them is required to be specified.

Example:

```cpp
CLI::Option *aopt = app.add_option("-a,--aopt", a, "Option A")->radio_id(1);
CLI::Option *bopt = app.add_option("-b,--bopt", b, "Option B")->radio_id(1);
CLI::Option *copt = app.add_flag("-c,--copt", c, "Option C")->radio_id(1);
```

Resolves CLIUtils/CLI11#88