### PR TITLE
Allow general flag types

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -132,6 +132,11 @@ add_test(NAME enum_fail COMMAND enum -l 4)
 set_property(TEST enum_fail PROPERTY PASS_REGULAR_EXPRESSION
     "--level: 4 not in {High,Medium,Low} | 4 not in {0,1,2}")
 
+add_cli_exe(digit_args digit_args.cpp)
+add_test(NAME digit_args COMMAND digit_args -h)
+set_property(TEST digit_args PROPERTY PASS_REGULAR_EXPRESSION
+    "-3{3}")
+
 add_cli_exe(modhelp modhelp.cpp)
 add_test(NAME modhelp COMMAND modhelp -a test -h)
 set_property(TEST modhelp PROPERTY PASS_REGULAR_EXPRESSION

--- a/examples/digit_args.cpp
+++ b/examples/digit_args.cpp
@@ -1,0 +1,15 @@
+#include <CLI/CLI.hpp>
+#include <iostream>
+
+int main(int argc, char **argv) {
+    CLI::App app;
+
+    int val;
+    // add a set of flags with default values associate with them
+    app.add_flag("-1{1},-2{2},-3{3},-4{4},-5{5},-6{6}, -7{7}, -8{8}, -9{9}", val, "compression level");
+
+    CLI11_PARSE(app, argc, argv);
+
+    std::cout << "value = " << val << std::endl;
+    return 0;
+}

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -69,14 +69,10 @@ class Config {
     /// Convert a configuration into an app
     virtual std::vector<ConfigItem> from_config(std::istream &) const = 0;
 
-    /// Convert a flag to a bool representation
+    /// Get a flag value
     virtual std::string to_flag(const ConfigItem &item) const {
         if(item.inputs.size() == 1) {
-            try {
-                return detail::to_flag_value(item.inputs.at(0));
-            } catch(const std::invalid_argument &) {
-                throw ConversionError::TrueFalse(item.fullname());
-            }
+            return item.inputs.at(0);
         }
         throw ConversionError::TooManyInputsFlag(item.fullname());
     }
@@ -90,7 +86,7 @@ class Config {
         return from_config(input);
     }
 
-    /// virtual destructor
+    /// Virtual destructor
     virtual ~Config() = default;
 };
 

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -231,6 +231,9 @@ class ArgumentMismatch : public ParseError {
     static ArgumentMismatch TypedAtLeast(std::string name, int num, std::string type) {
         return ArgumentMismatch(name + ": " + std::to_string(num) + " required " + type + " missing");
     }
+    static ArgumentMismatch FlagOverride(std::string name) {
+        return ArgumentMismatch(name + " was given a disallowed flag override");
+    }
 };
 
 /// Thrown when a requires option is missing

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -158,7 +158,7 @@ inline std::ostream &format_help(std::ostream &out, std::string name, std::strin
 }
 
 /// Verify the first character of an option
-template <typename T> bool valid_first_char(T c) { return std::isalpha(c, std::locale()) || c == '_'; }
+template <typename T> bool valid_first_char(T c) { return std::isalnum(c, std::locale()) || c == '_'; }
 
 /// Verify following characters of an option
 template <typename T> bool valid_later_char(T c) {
@@ -203,39 +203,50 @@ inline std::string find_and_replace(std::string str, std::string from, std::stri
 }
 
 /// check if the flag definitions has possible false flags
-inline bool has_false_flags(const std::string &flags) { return (flags.find_first_of("{!") != std::string::npos); }
+inline bool has_default_flag_values(const std::string &flags) {
+    return (flags.find_first_of("{!") != std::string::npos);
+}
 
-inline void remove_false_flag_notation(std::string &flags) {
-    flags = detail::find_and_replace(flags, "{false}", std::string{});
-    flags = detail::find_and_replace(flags, "{true}", std::string{});
+inline void remove_default_flag_values(std::string &flags) {
+    size_t loc = flags.find_first_of('{');
+    while(loc != std::string::npos) {
+        auto finish = flags.find_first_of("},", loc + 1);
+        if((finish != std::string::npos) && (flags[finish] == '}')) {
+            flags.erase(flags.begin() + loc, flags.begin() + finish + 1);
+        }
+        loc = flags.find_first_of('{', loc + 1);
+    }
     flags.erase(std::remove(flags.begin(), flags.end(), '!'), flags.end());
 }
 
 /// Check if a string is a member of a list of strings and optionally ignore case or ignore underscores
-inline bool check_is_member(std::string name,
-                            const std::vector<std::string> names,
-                            bool ignore_case = false,
-                            bool ignore_underscore = false) {
+inline std::ptrdiff_t find_member(std::string name,
+                                  const std::vector<std::string> names,
+                                  bool ignore_case = false,
+                                  bool ignore_underscore = false) {
+    auto it = std::end(names);
     if(ignore_case) {
         if(ignore_underscore) {
             name = detail::to_lower(detail::remove_underscore(name));
-            return std::find_if(std::begin(names), std::end(names), [&name](std::string local_name) {
-                       return detail::to_lower(detail::remove_underscore(local_name)) == name;
-                   }) != std::end(names);
+            it = std::find_if(std::begin(names), std::end(names), [&name](std::string local_name) {
+                return detail::to_lower(detail::remove_underscore(local_name)) == name;
+            });
         } else {
             name = detail::to_lower(name);
-            return std::find_if(std::begin(names), std::end(names), [&name](std::string local_name) {
-                       return detail::to_lower(local_name) == name;
-                   }) != std::end(names);
+            it = std::find_if(std::begin(names), std::end(names), [&name](std::string local_name) {
+                return detail::to_lower(local_name) == name;
+            });
         }
 
     } else if(ignore_underscore) {
         name = detail::remove_underscore(name);
-        return std::find_if(std::begin(names), std::end(names), [&name](std::string local_name) {
-                   return detail::remove_underscore(local_name) == name;
-               }) != std::end(names);
+        it = std::find_if(std::begin(names), std::end(names), [&name](std::string local_name) {
+            return detail::remove_underscore(local_name) == name;
+        });
     } else
-        return std::find(std::begin(names), std::end(names), name) != std::end(names);
+        it = std::find(std::begin(names), std::end(names), name);
+
+    return (it != std::end(names)) ? (it - std::begin(names)) : (-1);
 }
 
 /// Find a trigger string and call a modify callable function that takes the current string and starting position of the
@@ -248,49 +259,6 @@ template <typename Callable> inline std::string find_and_modify(std::string str,
     return str;
 }
 
-/// generate a vector of values that represent a boolean  they will be either "+" or "-"
-inline std::string to_flag_value(std::string val) {
-    val = detail::to_lower(val);
-    std::string ret;
-    if(val.size() == 1) {
-        switch(val[0]) {
-        case '0':
-        case 'f':
-        case 'n':
-        case '-':
-            ret = "-1";
-            break;
-        case '1':
-        case 't':
-        case 'y':
-        case '+':
-            ret = "1";
-            break;
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            ret = val;
-            break;
-        default:
-            throw std::invalid_argument("unrecognized character");
-        }
-        return ret;
-    }
-    if(val == "true" || val == "on" || val == "yes" || val == "enable") {
-        ret = "1";
-    } else if(val == "false" || val == "off" || val == "no" || val == "disable") {
-        ret = "-1";
-    } else {
-        auto ui = std::stoll(val);
-        ret = (ui == 0) ? "-1" : val;
-    }
-    return ret;
-}
 /// Split a string '"one two" "three"' into 'one two', 'three'
 /// Quote characters can be ` ' or "
 inline std::vector<std::string> split_up(std::string str) {

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -424,6 +424,7 @@ TEST_F(TApp, OptionFromDefaultsSubcommands) {
     EXPECT_EQ(app.option_defaults()->get_multi_option_policy(), CLI::MultiOptionPolicy::Throw);
     EXPECT_FALSE(app.option_defaults()->get_ignore_case());
     EXPECT_FALSE(app.option_defaults()->get_ignore_underscore());
+    EXPECT_FALSE(app.option_defaults()->get_disable_flag_override());
     EXPECT_TRUE(app.option_defaults()->get_configurable());
     EXPECT_EQ(app.option_defaults()->get_group(), "Options");
 
@@ -433,6 +434,7 @@ TEST_F(TApp, OptionFromDefaultsSubcommands) {
         ->ignore_case()
         ->ignore_underscore()
         ->configurable(false)
+        ->disable_flag_override()
         ->group("Something");
 
     auto app2 = app.add_subcommand("app2");
@@ -442,6 +444,7 @@ TEST_F(TApp, OptionFromDefaultsSubcommands) {
     EXPECT_TRUE(app2->option_defaults()->get_ignore_case());
     EXPECT_TRUE(app2->option_defaults()->get_ignore_underscore());
     EXPECT_FALSE(app2->option_defaults()->get_configurable());
+    EXPECT_TRUE(app.option_defaults()->get_disable_flag_override());
     EXPECT_EQ(app2->option_defaults()->get_group(), "Something");
 }
 

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -69,17 +69,17 @@ TEST(StringTools, Modify3) {
 }
 
 TEST(StringTools, flagValues) {
-    EXPECT_EQ(CLI::detail::to_flag_value("0"), "-1");
-    EXPECT_EQ(CLI::detail::to_flag_value("t"), "1");
-    EXPECT_EQ(CLI::detail::to_flag_value("1"), "1");
-    EXPECT_EQ(CLI::detail::to_flag_value("6"), "6");
-    EXPECT_EQ(CLI::detail::to_flag_value("-6"), "-6");
-    EXPECT_EQ(CLI::detail::to_flag_value("false"), "-1");
-    EXPECT_EQ(CLI::detail::to_flag_value("YES"), "1");
+    EXPECT_EQ(CLI::detail::to_flag_value("0"), -1);
+    EXPECT_EQ(CLI::detail::to_flag_value("t"), 1);
+    EXPECT_EQ(CLI::detail::to_flag_value("1"), 1);
+    EXPECT_EQ(CLI::detail::to_flag_value("6"), 6);
+    EXPECT_EQ(CLI::detail::to_flag_value("-6"), -6);
+    EXPECT_EQ(CLI::detail::to_flag_value("false"), -1);
+    EXPECT_EQ(CLI::detail::to_flag_value("YES"), 1);
     EXPECT_THROW(CLI::detail::to_flag_value("frog"), std::invalid_argument);
     EXPECT_THROW(CLI::detail::to_flag_value("q"), std::invalid_argument);
-    EXPECT_EQ(CLI::detail::to_flag_value("NO"), "-1");
-    EXPECT_EQ(CLI::detail::to_flag_value("4755263255233"), "4755263255233");
+    EXPECT_EQ(CLI::detail::to_flag_value("NO"), -1);
+    EXPECT_EQ(CLI::detail::to_flag_value("475555233"), 475555233);
 }
 
 TEST(Trim, Various) {

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -856,11 +856,21 @@ TEST_F(ManySubcommands, MaxCommands) {
 TEST_F(TApp, UnnamedSub) {
     double val;
     auto sub = app.add_subcommand("", "empty name");
-    sub->add_option("-v,--value", val);
+    auto opt = sub->add_option("-v,--value", val);
     args = {"-v", "4.56"};
 
     run();
     EXPECT_EQ(val, 4.56);
+    // make sure unnamed sub options can be found from the main app
+    auto opt2 = app.get_option("-v");
+    EXPECT_EQ(opt, opt2);
+
+    EXPECT_THROW(app.get_option("--vvvv"), CLI::OptionNotFound);
+    // now test in the constant context
+    const auto &appC = app;
+    auto opt3 = appC.get_option("-v");
+    EXPECT_EQ(opt3->get_name(), "--value");
+    EXPECT_THROW(appC.get_option("--vvvv"), CLI::OptionNotFound);
 }
 
 TEST_F(TApp, UnnamedSubMix) {


### PR DESCRIPTION
If merged this pull request will allow general flag values to be used, along with customized default values.  It also introduces a shortcut syntax for retrieving flag and option values.  Which is useful for allowing options with no storage variables.  

```
app["--flag"].as<std::string>() 
```
this is similar notation to some other Command line libraries and could make transitioning to CLI easier

It also allows numbers to be used as short flags, so `-7` and similar is now allowed

This could be specified to have a default value like `-7{7}`  in which case if the value -7 were passed it would produce a result of `7` in the output.  

This PR addresses #123 and #124.  