### PR TITLE
add transformer and checkedTransformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,17 @@ CLI11 is a command line parser for C++11 and beyond that provides a rich feature
 -   [Usage](#usage)
     -   [Adding options](#adding-options)
         -   [Option types](#option-types)
+        -   [Example](#example)
         -   [Option options](#option-options)
         -   [Validators](#validators)  🚧
+            -   [Transforming Validators](#transforming-validators)🚧
+            -   [Validator operations](#validator-operations)🚧
+            -   [Custom Validators](#custom-validators)🚧
+            -   [Querying Validators](#querying-validators)🚧
         -   [Getting Results](#getting-results) 🚧
     -   [Subcommands](#subcommands)
         -   [Subcommand options](#subcommand-options)
-        -   [Option Groups](#option-groups) 🚧
+        -   [Option groups](#option-groups) 🚧
     -   [Configuration file](#configuration-file)
     -   [Inheriting defaults](#inheriting-defaults)
     -   [Formatting](#formatting)
@@ -385,7 +390,7 @@ of `Transformer`:
 
 NOTES:  If the container used in `IsMember`, `Transformer`, or `CheckedTransformer` has a specialized search function like `std::unordered_map`  or `std::map` then that function is used to do the searching. If it does not have a find function a linear search is performed.  If there are filters present, the fast search is performed first, and if that fails a linear search with the filters on the key values is performed.
 
-##### Validator Operations🚧
+##### Validator operations🚧
 Validators are copyable and have a few operations that can be performed on them to alter settings.  Most of the built in Validators have a default description that is displayed in the help.  This can be altered via `.description(validator_description)`.
 the name of a Validator, which is useful for later reference from the `get_validator(name)` method of an `Option` can be set via `.name(validator_name)`
 The operation function of a Validator can be set via
@@ -500,7 +505,7 @@ There are several options that are supported on the main app and subcommands and
 
 > Note: if you have a fixed number of required positional options, that will match before subcommand names. `{}` is an empty filter function.
 
-#### Option Groups 🚧
+#### Option groups 🚧
 
 The method 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ CLI11 is a command line parser for C++11 and beyond that provides a rich feature
     -   [Adding options](#adding-options)
         -   [Option types](#option-types)
         -   [Option options](#option-options)
+        -   [Validators](#validators)  🚧
         -   [Getting Results](#getting-results) 🚧
     -   [Subcommands](#subcommands)
         -   [Subcommand options](#subcommand-options)
-    -   [Option Groups](#option-groups) 🚧
+        -   [Option Groups](#option-groups) 🚧
     -   [Configuration file](#configuration-file)
     -   [Inheriting defaults](#inheriting-defaults)
     -   [Formatting](#formatting)
@@ -245,7 +246,7 @@ alternative form of the syntax is more explicit: `"--flag,--no-flag{false}"`; th
 example.  This also works for short form options `"-f,!-n"` or `"-f,-n{false}"` If `variable_to_bind_to` is anything but an integer value the
 default behavior is to take the last value given, while if `variable_to_bind_to` is an integer type the behavior will be to sum
 all the given arguments and return the result.  This can be modified if needed by changing the `multi_option_policy` on each flag (this is not inherited).
-The default value can be any value For example if you wished to define a numerical flag
+The default value can be any value. For example if you wished to define a numerical flag
 ```cpp
 app.add_flag("-1{1},-2{2},-3{3}",result,"numerical flag") // 🚧
 ```
@@ -327,18 +328,19 @@ Validators are structures to check or modify inputs, they can be used to verify 
 
 CLI11 has several Validators built in that perform some common checks
 
--   `CLI::IsMember(...)`: 🚧 Require an option be a member of a given set. See below for options.
--   `CLI::Transformer(...)`: 🚧 Modify the input using a map. See below for options.
--   `CLI::CheckedTransformer(...)`: 🚧 Modify the input using a map, and verify that the input is either in the set or already one of the outputs of the set. See below for options.
+-   `CLI::IsMember(...)`: 🚧 Require an option be a member of a given set.  See [Transforming Validators](#transforming-validators) for more details.
+-   `CLI::Transformer(...)`: 🚧 Modify the input using a map.  See [Transforming Validators](#transforming-validators) for more details.
+-   `CLI::CheckedTransformer(...)`: 🚧 Modify the input using a map, and Require that the input is either in the set or already one of the outputs of the set. See [Transforming Validators](#transforming-validators) for more details.
 -   `CLI::ExistingFile`: Requires that the file exists if given.
 -   `CLI::ExistingDirectory`: Requires that the directory exists.
 -   `CLI::ExistingPath`: Requires that the path (file or directory) exists.
 -   `CLI::NonexistentPath`: Requires that the path does not exist.
 -   `CLI::Range(min,max)`: Requires that the option be between min and max (make sure to use floating point if needed). Min defaults to 0.
--   `CLI::PositiveNumber`: 🚧 Requires the number be greater or equal to 0
--   `CLI::ValidIPV4`: 🚧 Requires that the option be a valid IPv4 string e.g. `'255.255.255.255'`, `'10.1.1.7'`
+-   `CLI::Bounded(min,max)`: 🚧 Modify the input such that it is always between min and max (make sure to use floating point if needed). Min defaults to 0.  Will produce an Error if conversion is not possible.
+-   `CLI::PositiveNumber`: 🚧 Requires the number be greater or equal to 0.
+-   `CLI::ValidIPV4`: 🚧 Requires that the option be a valid IPv4 string e.g. `'255.255.255.255'`, `'10.1.1.7'`.
 
-These Validators can be used by simply passing in the name into the `check` or `transform` method on an option
+These Validators can be used by simply passing the name into the `check` or `transform` methods on an option
 ```cpp
 ->check(CLI::ExistingFile);
 ```
@@ -361,7 +363,7 @@ will produce a check for a number less than 0;
 There are a few built in Validators that let you transform values if used with the `transform` function.  If they also do some checks then they can be used `check` but some may do nothing in that case.
  * 🚧 `CLI::Bounded(min,max)` will bound values between min and max and values outside of that range are limited to min or max,  it will fail if the value cannot be converted and produce a `ValidationError`
  * 🚧 The `IsMember` Validator lets you specify a set of predefined options. You can pass any container or copyable pointer (including `std::shared_ptr`) to a container to this validator; the container just needs to be iterable and have a `::value_type`. The key type should be convertible from a string,  You can use an initializer list directly if you like. If you need to modify the set later, the pointer form lets you do that; the type message and check will correctly refer to the current version of the set.  The container passed in can be a set, vector, or a map like structure. If used in the `transform` method the output value will be the matching key as it could be modified by filters.
-After specifying a set of options, you can also specify "filter" functions of the form `T(T)`, where `T` is the type of the values. The most common choices probably will be `CLI::ignore_case` an `CLI::ignore_underscore`, and CLI::ignore_space
+After specifying a set of options, you can also specify "filter" functions of the form `T(T)`, where `T` is the type of the values. The most common choices probably will be `CLI::ignore_case` an `CLI::ignore_underscore`, and CLI::ignore_space.  These all work on strings but it is possible to define functions that work on other types.
 Here are some examples
 of `IsMember`:
 
@@ -371,17 +373,17 @@ of `IsMember`:
      *   `CLI::IsMember(std::map<std::string, TYPE>({{"one", 1}, {"two", 2}}))`: You can use maps; in `->transform()` these replace the matched value with the matched key.  The value member of the map is not used in `IsMember`.
      *   `auto p = std::make_shared<std::vector<std::string>>(std::initializer_list<std::string>("one", "two")); CLI::IsMember(p)`: You can modify `p` later.
 * 🚧 The `Transformer` and `CheckedTransformer` Validators transform one value into another. Any container or copyable pointer (including `std::shared_ptr`) to a container that generates pairs of values can be passed to these `Validator's`; the container just needs to be iterable and have a `::value_type` that consists of pairs. The key type should be convertible from a string, and the value type should be convertible to a string  You can use an initializer list directly if you like. If you need to modify the map later, the pointer form lets you do that; the description message will correctly refer to the current version of the map.  `Transformer` does not do any checking so values not in the map are ignored.  `CheckedTransformer` takes an extra step of verifying that the value is either one of the map key values, or one of the expected output values, and if not will generate a ValidationError.  A Transformer placed using `check` will not do anything.  
-After specifying a map of options, you can also specify "filter" functions of the form `T(T)`, where `T` is the type of the values. The most common choices probably will be `CLI::ignore_case` an `CLI::ignore_underscore`, and `CLI::ignore_space`
+After specifying a map of options, you can also specify "filter" just like in CLI::IsMember.
 Here are some examples (`Transfomer` and `CheckedTransformer` are interchangeable in the examples)
 of `Transformer`:
 
      *   `CLI::Transformer({{"key1", "map1"},{"key2","map2"}})`: Select from key values and produce map values.
 
      *  `CLI::Transformer(std::map<std::string,int>({"two",2},{"three",3},{"four",4}}))`: most maplike containers work,  the `::value_type` needs to produce a pair of some kind.
-     *   `CLI::CheckedTransformer(std::map<std::string, int>({{"one", 1}, {"two", 2}}))`: You can use maps; in `->transform()` these replace the matched value with the key.  `CheckedTransformer` 
+     *   `CLI::CheckedTransformer(std::map<std::string, int>({{"one", 1}, {"two", 2}}))`: You can use maps; in `->transform()` these replace the matched key with the value.  `CheckedTransformer` also requires that the value either match one of the keys or match one of known outputs.  
      *   `auto p = std::make_shared<CLI::TransformPairs<std::string>>(std::initializer_list<std::pair<std::string,std::string>>({"key1", "map1"},{"key2","map2"})); CLI::Transformer(p)`: You can modify `p` later. `TransformPairs<T>` is an alias for `std::vector<std::pair<<std::string,T>>`
 
-NOTES:  If the container used in `IsMember`, `Transformer`, or `CheckedTransformer` has a specialized search function like `std::unordered_map`  or `std::map` then that is used to do the searching, if it does not a linear search is performed,  if there are modifying functions, the fast search is performed first, and if that fails a linear search with the filters is performed.
+NOTES:  If the container used in `IsMember`, `Transformer`, or `CheckedTransformer` has a specialized search function like `std::unordered_map`  or `std::map` then that function is used to do the searching. If it does not have a find function a linear search is performed.  If there are filters present, the fast search is performed first, and if that fails a linear search with the filters on the key values is performed.
 
 ##### Validator Operations🚧
 Validators are copyable and have a few operations that can be performed on them to alter settings.  Most of the built in Validators have a default description that is displayed in the help.  This can be altered via `.description(validator_description)`.
@@ -403,19 +405,19 @@ opt->get_validator("range")->active();
 
 A validator object with a custom function can be created via
 ```cpp
-Validator(std::function<std::string(std::string &>,validator_description,validator_name="");
+CLI::Validator(std::function<std::string(std::string &>,validator_description,validator_name="");
 ```
 or if the operation function is set later they can be created with
 ```cpp
-Validator(validator_description);
+CLI::Validator(validator_description);
 ```
 
  It is also possible to create a subclass of `CLI::Validator`, in which case it can also set a custom description function, and operation function.
 
-##### Querying Validators
+##### Querying Validators 🚧
 Once loaded into an Option, a pointer to a named Validator can be retrieved via
 ```cpp
-opt->get_validator(name)
+opt->get_validator(name);
 ```
 This will retrieve a Validator with the given name or throw a CLI::OptionNotFound error.  If no name is given or name is empty the first unnamed Validator will be returned or the first Validator if there is only one.
 
@@ -425,7 +427,7 @@ Validators have a few functions to query the current values
  * `get_active()`:🚧 Will return the current active state, true if the Validator is active.
  * `get_modifying()` 🚧 Will return true if the Validator is allowed to modify the input, this can be controlled via `non_modifying()`🚧 method, though it is recommended to let check and transform function manipulate it if needed. 
 
-#### Getting results {#getting-results}
+#### Getting results
 In most cases the fastest and easiest way is to return the results through a callback or variable specified in one of the `add_*` functions.  But there are situations where this is not possible or desired.  For these cases the results may be obtained through one of the following functions. Please note that these functions will do any type conversions and processing during the call so should not used in performance critical code:
 
 - `results()`: Retrieves a vector of strings with all the results in the order they were given.
@@ -449,7 +451,7 @@ You are allowed to throw `CLI::Success` in the callbacks.
 Multiple subcommands are allowed, to allow [`Click`][click] like series of commands (order is preserved).
 
 🚧 Subcommands may also have an empty name either by calling `add_subcommand` with an empty string for the name or with no arguments.
-Nameless subcommands function a similarly to groups in the main `App`.  If an option is not defined in the main App, all nameless subcommands are checked as well.  This allows for the options to be defined in a composable group.  The `add_subcommand` function has an overload for adding a `shared_ptr<App>` so the subcommand(s) could be defined in different components and merged into a main `App`, or possibly multiple `Apps`.  Multiple nameless subcommands are allowed.
+Nameless subcommands function a similarly to groups in the main `App`. See [Option groups](#option-groups) to see how this might work.  If an option is not defined in the main App, all nameless subcommands are checked as well.  This allows for the options to be defined in a composable group.  The `add_subcommand` function has an overload for adding a `shared_ptr<App>` so the subcommand(s) could be defined in different components and merged into a main `App`, or possibly multiple `Apps`.  Multiple nameless subcommands are allowed.
 
 #### Subcommand options
 
@@ -462,16 +464,16 @@ There are several options that are supported on the main app and subcommands and
 -   `.disable()`: 🚧 Specify that the subcommand is disabled, if given with a bool value it will enable or disable the subcommand or option group.
 -   `.exludes(option_or_subcommand)`: 🚧 If given an option pointer or pointer to another subcommand, these subcommands cannot be given together.  In the case of options, if the option is passed the subcommand cannot be used and will generate an error.  
 -   `.require_option()`: 🚧 Require 1 or more options or option groups be used.
--   `.require_option(N)`:  🚧 Require `N` options or option groups if `N>0`, or up to `N` if `N<0`. `N=0` resets to the default 0 or more.
+-   `.require_option(N)`:  🚧 Require `N` options or option groups if `N>0`, or up to `N` if `N<0`. `N=0` resets to the default to 0 or more.
 -   `.require_option(min, max)`: 🚧 Explicitly set min and max allowed options or option groups. Setting `max` to 0 is unlimited.
 -   `.require_subcommand()`: Require 1 or more subcommands.
--   `.require_subcommand(N)`: Require `N` subcommands if `N>0`, or up to `N` if `N<0`. `N=0` resets to the default 0 or more.
+-   `.require_subcommand(N)`: Require `N` subcommands if `N>0`, or up to `N` if `N<0`. `N=0` resets to the default to 0 or more.
 -   `.require_subcommand(min, max)`: Explicitly set min and max allowed subcommands. Setting `max` to 0 is unlimited.
 -   `.add_subcommand(name="", description="")`: Add a subcommand, returns a pointer to the internally stored subcommand.
 -   `.add_subcommand(shared_ptr<App>)`: 🚧 Add a subcommand by shared_ptr, returns a pointer to the internally stored subcommand.
 -   `.got_subcommand(App_or_name)`: Check to see if a subcommand was received on the command line.
 -   `.get_subcommands(filter)`: The list of subcommands that match a particular filter function.
--   `.add_option_group(name="", description="")`: 🚧 Add an option group to an App,  an option group is specialized subcommand intended for containing groups of options or other groups for controlling how options interact.  
+-   `.add_option_group(name="", description="")`: 🚧 Add an [option group](#option-groups) to an App,  an option group is specialized subcommand intended for containing groups of options or other groups for controlling how options interact.  
 -   `.get_parent()`: Get the parent App or nullptr if called on master App.
 -   `.get_option(name)`: Get an option pointer by option name will throw if the specified option is not available,  nameless subcommands are also searched
 -   `.get_option_no_throw(name)`: 🚧 Get an option pointer by option name. This function will return a `nullptr` instead of throwing if the option is not available.
@@ -483,7 +485,7 @@ There are several options that are supported on the main app and subcommands and
 -   `.parsed()`: True if this subcommand was given on the command line.
 -   `.count()`: Returns the number of times the subcommand was called
 -   `.count(option_name)`: Returns the number of times a particular option was called
--   `.count_all()`: 🚧 Returns the total number of arguments a particular subcommand had, on the master App it returns the total number of processed commands
+-   `.count_all()`: 🚧 Returns the total number of arguments a particular subcommand processed, on the master App it returns the total number of processed commands
 -   `.name(name)`: Add or change the name.
 -   `.callback(void() function)`: Set the callback that runs at the end of parsing. The options have already run at this point.
 -   `.allow_extras()`: Do not throw an error if extra arguments are left over.
@@ -498,7 +500,7 @@ There are several options that are supported on the main app and subcommands and
 
 > Note: if you have a fixed number of required positional options, that will match before subcommand names. `{}` is an empty filter function.
 
-#### Option Groups 🚧 {#option-groups}
+#### Option Groups 🚧
 
 The method 
 ```cpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -155,7 +155,7 @@ add_cli_exe(enum enum.cpp)
 add_test(NAME enum_pass COMMAND enum -l 1)
 add_test(NAME enum_fail COMMAND enum -l 4)
 set_property(TEST enum_fail PROPERTY PASS_REGULAR_EXPRESSION
-    "--level: 4 not in {High,Medium,Low} | 4 not in {0,1,2}")
+    "--level: Check 4 value in {" "FAILED")
 
 add_cli_exe(digit_args digit_args.cpp)
 add_test(NAME digit_args COMMAND digit_args -h)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -109,8 +109,8 @@ set_property(TEST ranges_error PROPERTY PASS_REGULAR_EXPRESSION
 add_cli_exe(validators validators.cpp)
 add_test(NAME validators_help COMMAND validators --help)
 set_property(TEST validators_help PROPERTY PASS_REGULAR_EXPRESSION
-    "  -f,--file FILE              File name"
-    "  -v,--value INT in [3 - 6]   Value in range")
+    "  -f,--file TEXT:FILE[\\r\\n\\t ]+File name"
+    "  -v,--value INT:INT in [3 - 6][\\r\\n\\t ]+Value in range")
 add_test(NAME validators_file COMMAND validators --file nonex.xxx)
 set_property(TEST validators_file PROPERTY PASS_REGULAR_EXPRESSION
     "--file: File does not exist: nonex.xxx"

--- a/examples/enum.cpp
+++ b/examples/enum.cpp
@@ -1,5 +1,4 @@
 #include <CLI/CLI.hpp>
-#include <map>
 
 enum class Level : int { High, Medium, Low };
 
@@ -7,11 +6,14 @@ int main(int argc, char **argv) {
     CLI::App app;
 
     Level level;
-    std::map<std::string, Level> map = {{"High", Level::High}, {"Medium", Level::Medium}, {"Low", Level::Low}};
-
+    // specify string->value mappings
+    std::vector<std::pair<std::string, Level>> map{
+        {"high", Level::High}, {"medium", Level::Medium}, {"low", Level::Low}};
+    // checked Transform does the translation and checks the results are either in one of the strings or one of the
+    // translations already
     app.add_option("-l,--level", level, "Level settings")
         ->required()
-        ->transform(CLI::IsMember(map, CLI::ignore_case) | CLI::IsMember({Level::High, Level::Medium, Level::Low}));
+        ->transform(CLI::CheckedTransformer(map, CLI::ignore_case));
 
     CLI11_PARSE(app, argc, argv);
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -735,12 +735,12 @@ class Option : public OptionBase<Option> {
 
         if(ignore_case_ ||
            ignore_underscore_) { // We need to do the inverse, in case we are ignore_case or ignore underscore
-        for(const std::string &sname : other.snames_)
-            if(check_sname(sname))
-                return true;
-        for(const std::string &lname : other.lnames_)
-            if(check_lname(lname))
-                return true;
+            for(const std::string &sname : other.snames_)
+                if(check_sname(sname))
+                    return true;
+            for(const std::string &lname : other.lnames_)
+                if(check_lname(lname))
+                    return true;
         }
         return false;
     }

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -244,7 +244,7 @@ class Option : public OptionBase<Option> {
     int expected_{1};
 
     /// A list of validators to run on each value parsed
-    std::vector<std::function<std::string(std::string &)>> validators_;
+    std::vector<Validator> validators_;
 
     /// A list of options that are required with this option
     std::set<Option *> needs_;
@@ -332,40 +332,38 @@ class Option : public OptionBase<Option> {
     }
 
     /// Adds a validator with a built in type name
-    Option *check(const Validator &validator) {
-        std::function<std::string(std::string &)> func = validator.func;
-        validators_.emplace_back([func](const std::string &value) {
-            /// Throw away changes to the string value
-            std::string ignore_changes_value = value;
-            return func(ignore_changes_value);
-        });
-        _type_name_update(validator);
+    Option *check(Validator validator) {
+        validators_.push_back(std::move(validator));
         return this;
     }
 
     /// Adds a validator. Takes a const string& and returns an error message (empty if conversion/check is okay).
-    Option *check(std::function<std::string(const std::string &)> validator) {
-        validators_.emplace_back(validator);
+    Option *check(std::function<std::string(const std::string &)> validator,
+                  std::string validator_name = "",
+                  std::string check_description = "") {
+        validators_.emplace_back(validator, std::move(validator_name), std::move(check_description));
         return this;
     }
 
     /// Adds a transforming validator with a built in type name
-    Option *transform(const Validator &validator) {
-        validators_.insert(validators_.begin(), validator.func);
-        _type_name_update(validator);
+    Option *transform(Validator validator) {
+        validators_.insert(validators_.begin(), std::move(validator));
         return this;
     }
 
     /// Adds a validator-like function that can change result
-    Option *transform(std::function<std::string(std::string)> func) {
-        validators_.insert(validators_.begin(), [func](std::string &inout) {
-            try {
-                inout = func(inout);
-            } catch(const ValidationError &e) {
-                return std::string(e.what());
-            }
-            return std::string();
-        });
+    Option *transform(std::function<std::string(std::string)> func,
+                      std::string transform_name = "",
+                      std::string transform_description = "") {
+        validators_.insert(validators_.begin(),
+                           Validator(
+                               [func](std::string &val) {
+                                   val = func(val);
+                                   return std::string{};
+                               },
+                               std::move(transform_name),
+                               std::move(transform_description)));
+
         return this;
     }
 
@@ -373,11 +371,19 @@ class Option : public OptionBase<Option> {
     Option *each(std::function<void(std::string)> func) {
         validators_.emplace_back([func](std::string &inout) {
             func(inout);
-            return std::string();
+            return std::string{};
         });
         return this;
     }
-
+    /// Get a named Validator
+    Validator *get_validator(const std::string &validator_name) {
+        for(auto &validator : validators_) {
+            if(validator_name == validator.get_name()) {
+                return &validator;
+            }
+        }
+        throw OptionNotFound(std::string("Validator ") + validator_name + " Not Found");
+    }
     /// Sets required options
     Option *needs(Option *opt) {
         auto tup = needs_.insert(opt);
@@ -657,7 +663,7 @@ class Option : public OptionBase<Option> {
                     try {
                         err_msg = vali(result);
                     } catch(const ValidationError &err) {
-                        throw ValidationError(err.what(), get_name());
+                        throw ValidationError(get_name(), err.what());
                     }
 
                     if(!err_msg.empty())
@@ -718,12 +724,12 @@ class Option : public OptionBase<Option> {
 
         if(ignore_case_ ||
            ignore_underscore_) { // We need to do the inverse, in case we are ignore_case or ignore underscore
-            for(const std::string &sname : other.snames_)
-                if(check_sname(sname))
-                    return true;
-            for(const std::string &lname : other.lnames_)
-                if(check_lname(lname))
-                    return true;
+        for(const std::string &sname : other.snames_)
+            if(check_sname(sname))
+                return true;
+        for(const std::string &lname : other.lnames_)
+            if(check_lname(lname))
+                return true;
         }
         return false;
     }
@@ -871,9 +877,9 @@ class Option : public OptionBase<Option> {
         bool retval = true;
 
         for(const auto &elem : results_) {
-                        output.emplace_back();
-                retval &= detail::lexical_cast(elem, output.back());
-            }
+            output.emplace_back();
+            retval &= detail::lexical_cast(elem, output.back());
+        }
 
         if(!retval) {
             throw ConversionError(get_name(), results_);
@@ -932,8 +938,19 @@ class Option : public OptionBase<Option> {
         return this;
     }
 
-    /// Get the typename for this option
-    std::string get_type_name() const { return type_name_(); }
+    /// Get the full typename for this option
+    std::string get_type_name() const {
+        std::string full_type_name = type_name_();
+        if(!validators_.empty()) {
+            for(auto &validator : validators_) {
+                std::string vtype = validator.get_description();
+                if(!vtype.empty()) {
+                    full_type_name += ":" + vtype;
+                }
+            }
+        }
+        return full_type_name;
+    }
 
   private:
     int _add_result(std::string &&result) {
@@ -955,12 +972,6 @@ class Option : public OptionBase<Option> {
             }
         }
         return result_count;
-    }
-    void _type_name_update(const Validator &validator) {
-        if(validator.tname_function)
-            type_name_fn(validator.tname_function);
-        else if(!validator.tname.empty())
-            type_name(validator.tname);
     }
 };
 

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -57,6 +57,17 @@ inline std::vector<std::string> split(const std::string &s, char delim) {
     }
     return elems;
 }
+/// simple utility to convert various types to a string
+template <typename T> std::string as_string(const T &v) {
+    std::ostringstream s;
+    s << v;
+    return s.str();
+}
+// if the data type is already a string just forward it
+template <typename T, typename = typename std::enable_if<std::is_constructible<std::string, T>::value>::type>
+auto as_string(T &&v) -> decltype(std::forward<T>(v)) {
+    return std::forward<T>(v);
+}
 
 /// Simple function to join a string
 template <typename T> std::string join(const T &v, std::string delim = ",") {

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -58,25 +58,26 @@ inline std::vector<std::string> split(const std::string &s, char delim) {
     return elems;
 }
 /// simple utility to convert various types to a string
-template <typename T> std::string as_string(const T &v) {
+template <typename T> inline std::string as_string(const T &v) {
     std::ostringstream s;
     s << v;
     return s.str();
 }
 // if the data type is already a string just forward it
 template <typename T, typename = typename std::enable_if<std::is_constructible<std::string, T>::value>::type>
-auto as_string(T &&v) -> decltype(std::forward<T>(v)) {
+inline auto as_string(T &&v) -> decltype(std::forward<T>(v)) {
     return std::forward<T>(v);
 }
 
 /// Simple function to join a string
 template <typename T> std::string join(const T &v, std::string delim = ",") {
     std::ostringstream s;
-    size_t start = 0;
-    for(const auto &i : v) {
-        if(start++ > 0)
-            s << delim;
-        s << i;
+    auto beg = std::begin(v);
+    auto end = std::end(v);
+    if(beg != end)
+        s << *beg++;
+    while(beg != end) {
+        s << delim << *beg++;
     }
     return s.str();
 }
@@ -87,11 +88,12 @@ template <typename T,
           typename = typename std::enable_if<!std::is_constructible<std::string, Callable>::value>::type>
 std::string join(const T &v, Callable func, std::string delim = ",") {
     std::ostringstream s;
-    size_t start = 0;
-    for(const auto &i : v) {
-        if(start++ > 0)
-            s << delim;
-        s << func(i);
+    auto beg = std::begin(v);
+    auto end = std::end(v);
+    if(beg != end)
+        s << func(*beg++);
+    while(beg != end) {
+        s << delim << func(*beg++);
     }
     return s.str();
 }

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -71,7 +71,7 @@ template <> struct IsMemberType<const char *> { using type = std::string; };
 
 namespace detail {
 
-// These are utilites for IsMember
+// These are utilities for IsMember
 
 /// Handy helper to access the element_type generically. This is not part of is_copyable_ptr because it requires that
 /// pointer_traits<T> be valid.
@@ -91,9 +91,9 @@ template <typename T, typename _ = void> struct pair_adaptor : std::false_type {
     using second_type = typename std::remove_const<value_type>::type;
 
     /// Get the first value (really just the underlying value)
-    template <typename Q> static first_type first(Q &&value) { return value; }
+    template <typename Q> static first_type first(Q &&pair_value) { return pair_value; }
     /// Get the second value (really just the underlying value)
-    template <typename Q> static second_type second(Q &&value) { return value; }
+    template <typename Q> static second_type second(Q &&pair_value) { return pair_value; }
 };
 
 /// Adaptor for map-like structure (true version, must have key_type and mapped_type).
@@ -108,9 +108,9 @@ struct pair_adaptor<
     using second_type = typename std::remove_const<typename value_type::second_type>::type;
 
     /// Get the first value (really just the underlying value)
-    template <typename Q> static first_type first(Q &&value) { return value.first; }
+    template <typename Q> static first_type first(Q &&pair_value) { return pair_value.first; }
     /// Get the second value (really just the underlying value)
-    template <typename Q> static second_type second(Q &&value) { return value.second; }
+    template <typename Q> static second_type second(Q &&pair_value) { return pair_value.second; }
 };
 
 // Type name print
@@ -158,7 +158,7 @@ constexpr const char *type_name() {
 
 // Lexical cast
 
-/// convert a flag into an integer value  typically binary flags
+/// Convert a flag into an integer value  typically binary flags
 inline int64_t to_flag_value(std::string val) {
     static const std::string trueString("true");
     static const std::string falseString("false");
@@ -247,7 +247,7 @@ bool lexical_cast(std::string input, T &output) {
     }
 }
 
-/// boolean values
+/// Boolean values
 template <typename T, enable_if_t<is_bool<T>::value, detail::enabler> = detail::dummy>
 bool lexical_cast(std::string input, T &output) {
     try {
@@ -283,7 +283,7 @@ bool lexical_cast(std::string input, T &output) {
     return true;
 }
 
-/// enumerations
+/// Enumerations
 template <typename T, enable_if_t<std::is_enum<T>::value, detail::enabler> = detail::dummy>
 bool lexical_cast(std::string input, T &output) {
     typename std::underlying_type<T>::type val;
@@ -308,7 +308,7 @@ bool lexical_cast(std::string input, T &output) {
     return !is.fail() && !is.rdbuf()->in_avail();
 }
 
-/// sum a vector of flag representations
+/// Sum a vector of flag representations
 /// The flag vector produces a series of strings in a vector,  simple true is represented by a "1",  simple false is by
 /// "-1" an if numbers are passed by some fashion they are captured as well so the function just checks for the most
 /// common true and false strings then uses stoll to convert the rest for summing
@@ -322,7 +322,7 @@ void sum_flag_vector(const std::vector<std::string> &flags, T &output) {
     output = (count > 0) ? static_cast<T>(count) : T{0};
 }
 
-/// sum a vector of flag representations
+/// Sum a vector of flag representations
 /// The flag vector produces a series of strings in a vector,  simple true is represented by a "1",  simple false is by
 /// "-1" an if numbers are passed by some fashion they are captured as well so the function just checks for the most
 /// common true and false strings then uses stoll to convert the rest for summing

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -58,6 +58,9 @@ template <typename T> struct is_shared_ptr : std::false_type {};
 /// Check to see if something is a shared pointer (True if really a shared pointer)
 template <typename T> struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
 
+/// Check to see if something is a shared pointer (True if really a shared pointer)
+template <typename T> struct is_shared_ptr<const std::shared_ptr<T>> : std::true_type {};
+
 /// Check to see if something is copyable pointer
 template <typename T> struct is_copyable_ptr {
     static bool const value = is_shared_ptr<T>::value || std::is_pointer<T>::value;
@@ -84,16 +87,20 @@ template <typename T> struct element_type {
 /// the container
 template <typename T> struct element_value_type { using type = typename element_type<T>::type::value_type; };
 
-/// Adaptor for map-like structure: This just wraps a normal container in a few utilities that do almost nothing.
+/// Adaptor for set-like structure: This just wraps a normal container in a few utilities that do almost nothing.
 template <typename T, typename _ = void> struct pair_adaptor : std::false_type {
     using value_type = typename T::value_type;
     using first_type = typename std::remove_const<value_type>::type;
     using second_type = typename std::remove_const<value_type>::type;
 
     /// Get the first value (really just the underlying value)
-    template <typename Q> static first_type first(Q &&pair_value) { return pair_value; }
+    template <typename Q> static auto first(Q &&pair_value) -> decltype(std::forward<Q>(pair_value)) {
+        return std::forward<Q>(pair_value);
+    }
     /// Get the second value (really just the underlying value)
-    template <typename Q> static second_type second(Q &&pair_value) { return pair_value; }
+    template <typename Q> static auto second(Q &&pair_value) -> decltype(std::forward<Q>(pair_value)) {
+        return std::forward<Q>(pair_value);
+    }
 };
 
 /// Adaptor for map-like structure (true version, must have key_type and mapped_type).
@@ -108,9 +115,13 @@ struct pair_adaptor<
     using second_type = typename std::remove_const<typename value_type::second_type>::type;
 
     /// Get the first value (really just the underlying value)
-    template <typename Q> static first_type first(Q &&pair_value) { return pair_value.first; }
+    template <typename Q> static auto first(Q &&pair_value) -> decltype(std::get<0>(std::forward<Q>(pair_value))) {
+        return std::get<0>(std::forward<Q>(pair_value));
+    }
     /// Get the second value (really just the underlying value)
-    template <typename Q> static second_type second(Q &&pair_value) { return pair_value.second; }
+    template <typename Q> static auto second(Q &&pair_value) -> decltype(std::get<1>(std::forward<Q>(pair_value))) {
+        return std::get<1>(std::forward<Q>(pair_value));
+    }
 };
 
 // Type name print

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1861,7 +1861,7 @@ TEST_F(TApp, OrderedModifingTransforms) {
 
     run();
 
-    EXPECT_EQ(val, std::vector<std::string>({"one12", "two12"}));
+    EXPECT_EQ(val, std::vector<std::string>({"one21", "two21"}));
 }
 
 TEST_F(TApp, ThrowingTransform) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1431,7 +1431,7 @@ TEST_F(TApp, FileNotExists) {
     ASSERT_NO_THROW(CLI::NonexistentPath(myfile));
 
     std::string filename;
-    app.add_option("--file", filename)->check(CLI::NonexistentPath);
+    auto opt = app.add_option("--file", filename)->check(CLI::NonexistentPath, "path_check");
     args = {"--file", myfile};
 
     run();
@@ -1440,7 +1440,9 @@ TEST_F(TApp, FileNotExists) {
     bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a')); // create file
     EXPECT_TRUE(ok);
     EXPECT_THROW(run(), CLI::ValidationError);
-
+    // deactivate the check, so it should run now
+    opt->get_validator("path_check")->active(false);
+    EXPECT_NO_THROW(run());
     std::remove(myfile.c_str());
     EXPECT_FALSE(CLI::ExistingFile(myfile).empty());
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CLI11_TESTS
     SimpleTest
     AppTest
     SetTest
+	TransformTest
     CreationTest
     SubcommandTest
     HelpTest

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -566,7 +566,7 @@ TEST(ValidatorTests, TestValidatorCreation) {
     std::function<std::string(std::string &)> op1 = [](std::string &val) {
         return (val.size() >= 5) ? std::string{} : val;
     };
-    CLI::Validator V(op1, "size");
+    CLI::Validator V(op1, "", "size");
 
     EXPECT_EQ(V.get_name(), "size");
     V.name("harry");
@@ -594,11 +594,11 @@ TEST(ValidatorTests, TestValidatorOps) {
     std::function<std::string(std::string &)> op4 = [](std::string &val) {
         return (val.size() <= 9) ? std::string{} : val;
     };
-    CLI::Validator V1(op1, "size", "SIZE >= 5");
+    CLI::Validator V1(op1, "SIZE >= 5");
 
-    CLI::Validator V2(op2, "size2", "SIZE >= 9");
-    CLI::Validator V3(op3, "size3", "SIZE < 3");
-    CLI::Validator V4(op4, "size4", "SIZE <= 9");
+    CLI::Validator V2(op2, "SIZE >= 9");
+    CLI::Validator V3(op3, "SIZE < 3");
+    CLI::Validator V4(op4, "SIZE <= 9");
 
     std::string two(2, 'a');
     std::string four(4, 'a');
@@ -677,7 +677,7 @@ TEST(ValidatorTests, TestValidatorNegation) {
         return (val.size() >= 5) ? std::string{} : val;
     };
 
-    CLI::Validator V1(op1, "size", "SIZE >= 5");
+    CLI::Validator V1(op1, "SIZE >= 5", "size");
 
     std::string four(4, 'a');
     std::string five(5, 'a');
@@ -694,4 +694,31 @@ TEST(ValidatorTests, TestValidatorNegation) {
     EXPECT_TRUE(V2(five).empty());
     EXPECT_TRUE(V2(four).empty());
     EXPECT_TRUE(V2.get_description().empty());
+}
+
+TEST(ValidatorTests, ValidatorDefaults) {
+
+    CLI::Validator V1{};
+
+    std::string four(4, 'a');
+    std::string five(5, 'a');
+
+    // make sure this doesn't generate a seg fault or something
+    EXPECT_TRUE(V1(five).empty());
+    EXPECT_TRUE(V1(four).empty());
+
+    EXPECT_TRUE(V1.get_name().empty());
+    EXPECT_TRUE(V1.get_description().empty());
+    EXPECT_TRUE(V1.get_active());
+    EXPECT_TRUE(V1.get_modifying());
+
+    CLI::Validator V2{"check"};
+    // make sure this doesn't generate a seg fault or something
+    EXPECT_TRUE(V2(five).empty());
+    EXPECT_TRUE(V2(four).empty());
+
+    EXPECT_TRUE(V2.get_name().empty());
+    EXPECT_EQ(V2.get_description(), "check");
+    EXPECT_TRUE(V2.get_active());
+    EXPECT_TRUE(V2.get_modifying());
 }

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -251,11 +251,10 @@ TEST(THelp, ManualSetterOverFunction) {
     EXPECT_EQ(x, 1);
 
     std::string help = app.help();
-
     EXPECT_THAT(help, HasSubstr("=12"));
     EXPECT_THAT(help, HasSubstr("BIGGLES"));
     EXPECT_THAT(help, HasSubstr("QUIGGLES"));
-    EXPECT_THAT(help, Not(HasSubstr("1,2")));
+    EXPECT_THAT(help, HasSubstr("{1,2}"));
 }
 
 TEST(THelp, Subcom) {
@@ -743,10 +742,9 @@ TEST(THelp, ValidatorsText) {
     app.add_option("--f4", y)->check(CLI::Range(12));
 
     std::string help = app.help();
-    EXPECT_THAT(help, HasSubstr("FILE"));
+    EXPECT_THAT(help, HasSubstr("TEXT:FILE"));
     EXPECT_THAT(help, HasSubstr("INT in [1 - 4]"));
-    EXPECT_THAT(help, HasSubstr("INT in [0 - 12]")); // Loses UINT
-    EXPECT_THAT(help, Not(HasSubstr("TEXT")));
+    EXPECT_THAT(help, HasSubstr("UINT:INT in [0 - 12]")); // Loses UINT
 }
 
 TEST(THelp, ValidatorsNonPathText) {
@@ -756,8 +754,7 @@ TEST(THelp, ValidatorsNonPathText) {
     app.add_option("--f2", filename)->check(CLI::NonexistentPath);
 
     std::string help = app.help();
-    EXPECT_THAT(help, HasSubstr("PATH"));
-    EXPECT_THAT(help, Not(HasSubstr("TEXT")));
+    EXPECT_THAT(help, HasSubstr("TEXT:PATH"));
 }
 
 TEST(THelp, ValidatorsDirText) {
@@ -767,8 +764,7 @@ TEST(THelp, ValidatorsDirText) {
     app.add_option("--f2", filename)->check(CLI::ExistingDirectory);
 
     std::string help = app.help();
-    EXPECT_THAT(help, HasSubstr("DIR"));
-    EXPECT_THAT(help, Not(HasSubstr("TEXT")));
+    EXPECT_THAT(help, HasSubstr("TEXT:DIR"));
 }
 
 TEST(THelp, ValidatorsPathText) {
@@ -778,8 +774,7 @@ TEST(THelp, ValidatorsPathText) {
     app.add_option("--f2", filename)->check(CLI::ExistingPath);
 
     std::string help = app.help();
-    EXPECT_THAT(help, HasSubstr("PATH"));
-    EXPECT_THAT(help, Not(HasSubstr("TEXT")));
+    EXPECT_THAT(help, HasSubstr("TEXT:PATH"));
 }
 
 TEST(THelp, CombinedValidatorsText) {
@@ -792,9 +787,8 @@ TEST(THelp, CombinedValidatorsText) {
     // Can't programatically tell!
     // (Users can use ExistingPath, by the way)
     std::string help = app.help();
-    EXPECT_THAT(help, HasSubstr("TEXT"));
+    EXPECT_THAT(help, HasSubstr("TEXT:(FILE) OR (DIR)"));
     EXPECT_THAT(help, Not(HasSubstr("PATH")));
-    EXPECT_THAT(help, Not(HasSubstr("FILE")));
 }
 
 // Don't do this in real life, please
@@ -806,7 +800,7 @@ TEST(THelp, CombinedValidatorsPathyText) {
 
     // Combining validators with the same type string is OK
     std::string help = app.help();
-    EXPECT_THAT(help, Not(HasSubstr("TEXT")));
+    EXPECT_THAT(help, HasSubstr("TEXT:"));
     EXPECT_THAT(help, HasSubstr("PATH"));
 }
 
@@ -819,8 +813,7 @@ TEST(THelp, CombinedValidatorsPathyTextAsTransform) {
 
     // Combining validators with the same type string is OK
     std::string help = app.help();
-    EXPECT_THAT(help, Not(HasSubstr("TEXT")));
-    EXPECT_THAT(help, HasSubstr("PATH"));
+    EXPECT_THAT(help, HasSubstr("TEXT:(PATH(existing)) OR (PATH"));
 }
 
 // #113 Part 2

--- a/tests/SetTest.cpp
+++ b/tests/SetTest.cpp
@@ -140,6 +140,38 @@ TEST_F(TApp, structMapChange) {
     args = {"-s", "S_t_w_o"};
     run();
     EXPECT_EQ(struct_name, "stwo");
+    args = {"-s", "S two"};
+    run();
+    EXPECT_EQ(struct_name, "stwo");
+}
+
+TEST_F(TApp, structMapNoChange) {
+    struct tstruct {
+        int val2;
+        double val3;
+        std::string v4;
+    };
+    std::string struct_name;
+    std::map<std::string, struct tstruct> map = {{"sone", {4, 32.4, "foo"}}, {"stwo", {5, 99.7, "bar"}}};
+    auto opt = app.add_option("-s,--set", struct_name)
+                   ->check(CLI::IsMember(map, CLI::ignore_case, CLI::ignore_underscore, CLI::ignore_space));
+    args = {"-s", "SONE"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, app.count("--set"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(struct_name, "SONE");
+
+    args = {"-s", "sthree"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"-s", "S_t_w_o"};
+    run();
+    EXPECT_EQ(struct_name, "S_t_w_o");
+
+    args = {"-s", "S two"};
+    run();
+    EXPECT_EQ(struct_name, "S two");
 }
 
 TEST_F(TApp, NonCopyableMap) {

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -1,0 +1,250 @@
+#include "app_helper.hpp"
+
+#include <unordered_map>
+
+TEST_F(TApp, SimpleTransform) {
+    int value;
+    auto opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", std::string("1")}}));
+    args = {"-s", "one"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, 1);
+}
+
+TEST_F(TApp, SimpleTransformInitList) {
+    int value;
+    auto opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", "1"}}));
+    args = {"-s", "one"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, 1);
+}
+
+TEST_F(TApp, SimpleNumericalTransform) {
+    int value;
+    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(CLI::TransformPairs<int>{{"one", 1}}));
+    args = {"-s", "one"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, 1);
+}
+
+TEST_F(TApp, EnumTransform) {
+    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17 };
+    test value;
+    auto opt = app.add_option("-s", value)
+                   ->transform(CLI::Transformer(
+                       CLI::TransformPairs<test>{{"val1", test::val1}, {"val2", test::val2}, {"val3", test::val3}}));
+    args = {"-s", "val1"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, test::val1);
+
+    args = {"-s", "val2"};
+    run();
+    EXPECT_EQ(value, test::val2);
+
+    args = {"-s", "val3"};
+    run();
+    EXPECT_EQ(value, test::val3);
+
+    args = {"-s", "val4"};
+    EXPECT_THROW(run(), CLI::ConversionError);
+
+    // transformer doesn't do any checking so this still works
+    args = {"-s", "5"};
+    run();
+    EXPECT_EQ(static_cast<int16_t>(value), int16_t(5));
+}
+
+TEST_F(TApp, EnumCheckedTransform) {
+    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17 };
+    test value;
+    auto opt = app.add_option("-s", value)
+                   ->transform(CLI::CheckedTransformer(
+                       CLI::TransformPairs<test>{{"val1", test::val1}, {"val2", test::val2}, {"val3", test::val3}}));
+    args = {"-s", "val1"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, test::val1);
+
+    args = {"-s", "val2"};
+    run();
+    EXPECT_EQ(value, test::val2);
+
+    args = {"-s", "val3"};
+    run();
+    EXPECT_EQ(value, test::val3);
+
+    args = {"-s", "17"};
+    run();
+    EXPECT_EQ(value, test::val3);
+
+    args = {"-s", "val4"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"-s", "5"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
+TEST_F(TApp, SimpleTransformFn) {
+    int value;
+    auto opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", "1"}}, CLI::ignore_case));
+    args = {"-s", "ONE"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, 1);
+}
+
+TEST_F(TApp, SimpleNumericalTransformFn) {
+    int value;
+    auto opt =
+        app.add_option("-s", value)
+            ->transform(CLI::Transformer(std::vector<std::pair<std::string, int>>{{"one", 1}}, CLI::ignore_case));
+    args = {"-s", "ONe"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, 1);
+}
+
+TEST_F(TApp, EnumTransformFn) {
+    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17 };
+    test value;
+    auto opt = app.add_option("-s", value)
+                   ->transform(CLI::Transformer(
+                       CLI::TransformPairs<test>{{"val1", test::val1}, {"val2", test::val2}, {"val3", test::val3}},
+                       CLI::ignore_case,
+                       CLI::ignore_underscore));
+    args = {"-s", "val_1"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, test::val1);
+
+    args = {"-s", "VAL_2"};
+    run();
+    EXPECT_EQ(value, test::val2);
+
+    args = {"-s", "VAL3"};
+    run();
+    EXPECT_EQ(value, test::val3);
+
+    args = {"-s", "val_4"};
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
+TEST_F(TApp, EnumTransformFnMap) {
+    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17 };
+    std::map<std::string, test> map{{"val1", test::val1}, {"val2", test::val2}, {"val3", test::val3}};
+    test value;
+    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(map, CLI::ignore_case, CLI::ignore_underscore));
+    args = {"-s", "val_1"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, test::val1);
+
+    args = {"-s", "VAL_2"};
+    run();
+    EXPECT_EQ(value, test::val2);
+
+    args = {"-s", "VAL3"};
+    run();
+    EXPECT_EQ(value, test::val3);
+
+    args = {"-s", "val_4"};
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
+TEST_F(TApp, EnumTransformFnPtrMap) {
+    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17, val4 = 37 };
+    std::map<std::string, test> map{{"val1", test::val1}, {"val2", test::val2}, {"val3", test::val3}};
+    test value;
+    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(&map, CLI::ignore_case, CLI::ignore_underscore));
+    args = {"-s", "val_1"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, test::val1);
+
+    args = {"-s", "VAL_2"};
+    run();
+    EXPECT_EQ(value, test::val2);
+
+    args = {"-s", "VAL3"};
+    run();
+    EXPECT_EQ(value, test::val3);
+
+    args = {"-s", "val_4"};
+    EXPECT_THROW(run(), CLI::ConversionError);
+
+    map["val4"] = test::val4;
+    run();
+    EXPECT_EQ(value, test::val4);
+}
+
+TEST_F(TApp, EnumTransformFnSharedPtrMap) {
+    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17, val4 = 37 };
+    auto map = std::make_shared<std::unordered_map<std::string, test>>();
+    auto &mp = *map;
+    mp["val1"] = test::val1;
+    mp["val2"] = test::val2;
+    mp["val3"] = test::val3;
+
+    test value;
+    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(map, CLI::ignore_case, CLI::ignore_underscore));
+    args = {"-s", "val_1"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, test::val1);
+
+    args = {"-s", "VAL_2"};
+    run();
+    EXPECT_EQ(value, test::val2);
+
+    args = {"-s", "VAL3"};
+    run();
+    EXPECT_EQ(value, test::val3);
+
+    args = {"-s", "val_4"};
+    EXPECT_THROW(run(), CLI::ConversionError);
+
+    mp["val4"] = test::val4;
+    run();
+    EXPECT_EQ(value, test::val4);
+}
+
+// Test a cascade of transform functions
+TEST_F(TApp, TransformCascade) {
+
+    std::string output;
+    auto opt = app.add_option("-s", output);
+    opt->transform(CLI::Transformer({{"abc", "abcd"}, {"bbc", "bbcd"}, {"cbc", "cbcd"}}, CLI::ignore_case));
+    opt->transform(
+        CLI::Transformer({{"ab", "abc"}, {"bc", "bbc"}, {"cb", "cbc"}}, CLI::ignore_case, CLI::ignore_underscore));
+    opt->transform(CLI::Transformer({{"a", "ab"}, {"b", "bb"}, {"c", "cb"}}, CLI::ignore_case));
+    opt->check(CLI::IsMember({"abcd", "bbcd", "cbcd"}));
+    args = {"-s", "abcd"};
+    run();
+    EXPECT_EQ(output, "abcd");
+
+    args = {"-s", "Bbc"};
+    run();
+    EXPECT_EQ(output, "bbcd");
+
+    args = {"-s", "C_B"};
+    run();
+    EXPECT_EQ(output, "cbcd");
+
+    args = {"-s", "A"};
+    run();
+    EXPECT_EQ(output, "abcd");
+}


### PR DESCRIPTION
This is the last of the PR's originating from #229.  
This builds on the IsMember function and adds Transformer and CheckedTransformer validators  

Modifications include disabling the IsMember validator from using the second element of a map, so maps with non-convertible types can be used.  IsMember will modify the input to match an element of the set.

Validators added through the transform function are inserted at the beginning of the validators list, this allows transformations to occur before a check regardless of the order added.  

Some tweaks and updates to the IsMember function to clean up some loops and remove some unnecessary processing from inside the loop.  