### PR TITLE
Option delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Before parsing, you can set the following options:
 -   `->ignore_case()`: Ignore the case on the command line (also works on subcommands, does not affect arguments).
 -   `->ignore_underscore()`: Ignore any underscores in the options names (also works on subcommands, does not affect arguments). For example "option_one" will match with "optionone".  This does not apply to short form options since they only have one character
 -   `->disable_flag_override()`:  from the command line long form flag option can be assigned a value on the command line using the `=` notation `--flag=value`. If this behavior is not desired, the `disable_flag_override()` disables it and will generate an exception if it is done on the command line.  The `=` does not work with short form flag options.
+-    `->delimiter(char)`: allows specification of a custom delimiter for separating single arguments into vector arguments, for example specifying `->delimiter(',')` on an option would result in `--opt=1,2,3` producing 3 elements of a vector and the equivalent of --opt 1 2 3 assuming opt is a vector value
 -   `->description(str)`: Set/change the description.
 -   `->multi_option_policy(CLI::MultiOptionPolicy::Throw)`: Set the multi-option policy. Shortcuts available: `->take_last()`, `->take_first()`, and `->join()`. This will only affect options expecting 1 argument or bool flags (which do not inherit their default but always start with a specific policy).
 -   `->check(CLI::IsMember(...))`: Require an option be a member of a given set. See below for options.
@@ -338,9 +339,7 @@ In most cases the fastest and easiest way is to return the results through a cal
 
 - `results()`: retrieves a vector of strings with all the results in the order they were given.
 - `results(variable_to_bind_to)`: gets the results according to the MultiOptionPolicy and converts them just like the `add_option_function` with a variable.
-- `results(vector_type_variable,delimiter)`: gets the results to a vector type and uses a delimiter to further split the values
-- `Value=as<type>()`: returns the result or default value directly as the specified type if possible.
-- `Vector_value=as<type>(delimiter): same the results function with the delimiter but returns the value directly.  
+- `Value=as<type>()`: returns the result or default value directly as the specified type if possible, can be vector to return all results, and a non-vector to get the result according to the MultiOptionPolicy in place.
 
 ### Subcommands
 
@@ -434,7 +433,7 @@ arguments, use `.config_to_str(default_also=false, prefix="", write_description=
 
 Many of the defaults for subcommands and even options are inherited from their creators. The inherited default values for subcommands are `allow_extras`, `prefix_command`, `ignore_case`, `ignore_underscore`, `fallthrough`, `group`, `footer`, and maximum number of required subcommands. The help flag existence, name, and description are inherited, as well.
 
-Options have defaults for `group`, `required`, `disable_flag_override`,`multi_option_policy`, `ignore_underscore`, and `ignore_case`. To set these defaults, you should set the `option_defaults()` object, for example:
+Options have defaults for `group`, `required`, `disable_flag_override`,`multi_option_policy`, `ignore_underscore`,`delimiter`, and `ignore_case`. To set these defaults, you should set the `option_defaults()` object, for example:
 
 ```cpp
 app.option_defaults()->required();

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -439,8 +439,31 @@ class App {
     template <typename T>
     Option *add_option(std::string option_name,
                        std::vector<T> &variable, ///< The variable vector to set
-                       std::string option_description = "",
-                       bool defaulted = false) {
+                       std::string option_description = "") {
+
+        CLI::callback_t fun = [&variable](CLI::results_t res) {
+            bool retval = true;
+            variable.clear();
+            variable.reserve(res.size());
+            for(const auto &elem : res) {
+
+                variable.emplace_back();
+                retval &= detail::lexical_cast(elem, variable.back());
+            }
+            return (!variable.empty()) && retval;
+        };
+
+        Option *opt = add_option(option_name, fun, option_description, false);
+        opt->type_name(detail::type_name<T>())->type_size(-1);
+        return opt;
+    }
+
+    /// Add option for vectors with defaulted argument
+    template <typename T>
+    Option *add_option(std::string option_name,
+                       std::vector<T> &variable, ///< The variable vector to set
+                       std::string option_description,
+                       bool defaulted) {
 
         CLI::callback_t fun = [&variable](CLI::results_t res) {
             bool retval = true;

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -435,42 +435,17 @@ class App {
         return opt;
     }
 
-    /// Add option for vectors (no default)
-    template <typename T>
-    Option *add_option(std::string option_name,
-                       std::vector<T> &variable, ///< The variable vector to set
-                       std::string option_description = "",
-                       char delimiter = '\0') {
-
-        CLI::callback_t fun = [&variable](CLI::results_t res) {
-            bool retval = true;
-            variable.clear();
-            for(const auto &elem : res) {
-                variable.emplace_back();
-                retval &= detail::lexical_cast(elem, variable.back());
-            }
-            return (!variable.empty()) && retval;
-        };
-
-        Option *opt = add_option(option_name, fun, option_description, false);
-        if(delimiter != '\0') {
-            opt->delimiter(delimiter);
-        }
-        opt->type_name(detail::type_name<T>())->type_size(-1);
-        return opt;
-    }
-
     /// Add option for vectors
     template <typename T>
     Option *add_option(std::string option_name,
                        std::vector<T> &variable, ///< The variable vector to set
-                       std::string option_description,
-                       bool defaulted,
-                       char delimiter = '\0') {
+                       std::string option_description = "",
+                       bool defaulted = false) {
 
-        CLI::callback_t fun = [&variable, delimiter](CLI::results_t res) {
+        CLI::callback_t fun = [&variable](CLI::results_t res) {
             bool retval = true;
             variable.clear();
+            variable.reserve(res.size());
             for(const auto &elem : res) {
 
                 variable.emplace_back();
@@ -481,9 +456,7 @@ class App {
 
         Option *opt = add_option(option_name, fun, option_description, defaulted);
         opt->type_name(detail::type_name<T>())->type_size(-1);
-        if(delimiter != '\0') {
-            opt->delimiter(delimiter);
-        }
+
         if(defaulted)
             opt->default_str("[" + detail::join(variable) + "]");
         return opt;
@@ -493,8 +466,7 @@ class App {
     template <typename T, enable_if_t<is_vector<T>::value, detail::enabler> = detail::dummy>
     Option *add_option_function(std::string option_name,
                                 const std::function<bool(const T &)> &func, ///< the callback to execute
-                                std::string option_description = "",
-                                char delimiter = '\0') {
+                                std::string option_description = "") {
 
         CLI::callback_t fun = [func](CLI::results_t res) {
             T values;
@@ -511,9 +483,6 @@ class App {
         };
 
         Option *opt = add_option(option_name, std::move(fun), std::move(option_description), false);
-        if(delimiter != '\0') {
-            opt->delimiter(delimiter);
-        }
         opt->type_name(detail::type_name<T>())->type_size(-1);
         return opt;
     }

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -869,22 +869,13 @@ class Option : public OptionBase<Option> {
         }
     }
     /// get the results as a vector of a particular type
-    template <typename T> void results(std::vector<T> &output, char delim = '\0') const {
+    template <typename T> void results(std::vector<T> &output) const {
         output.clear();
         bool retval = true;
 
         for(const auto &elem : results_) {
-            if(delim != '\0') {
-                for(const auto &var : CLI::detail::split(elem, delim)) {
-                    if(!var.empty()) {
-                        output.emplace_back();
-                        retval &= detail::lexical_cast(var, output.back());
-                    }
-                }
-            } else {
-                output.emplace_back();
-                retval &= detail::lexical_cast(elem, output.back());
-            }
+            output.emplace_back();
+            retval &= detail::lexical_cast(elem, output.back());
         }
 
         if(!retval) {
@@ -893,17 +884,9 @@ class Option : public OptionBase<Option> {
     }
 
     /// return the results as a particular type
-    template <typename T, enable_if_t<!is_vector<T>::value, detail::enabler> = detail::dummy> T as() const {
+    template <typename T> T as() const {
         T output;
         results(output);
-        return output;
-    }
-
-    /// get the results as a vector of a particular type
-    template <typename T, enable_if_t<is_vector<T>::value, detail::enabler> = detail::dummy>
-    T as(char delim = '\0') const {
-        T output;
-        results(output, delim);
         return output;
     }
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1956,7 +1956,7 @@ TEST_F(TApp, CustomUserSepParse) {
 
     std::vector<int> vals = {1, 2, 3};
     args = {"--idx", "1,2,3"};
-    auto opt = app.add_option("--idx", vals, "", ',');
+    auto opt = app.add_option("--idx", vals)->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
     std::vector<int> vals2;
@@ -1966,29 +1966,7 @@ TEST_F(TApp, CustomUserSepParse) {
 
     app.remove_option(opt);
 
-    app.add_option("--idx", vals, "", true, ',');
-    run();
-    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
-}
-
-// #209
-TEST_F(TApp, CustomUserSepParseLaterDelimiter) {
-
-    std::vector<int> vals = {1, 2, 3};
-    args = {"--idx", "1,2,3"};
-    auto opt = app.add_option("--idx", vals);
-    opt->delimiter(',');
-    run();
-    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
-    std::vector<int> vals2;
-    // check that the results vector gets the results in the same way
-    opt->results(vals2);
-    EXPECT_EQ(vals2, vals);
-
-    app.remove_option(opt);
-
-    opt = app.add_option("--idx", vals, "", true);
-    opt->delimiter(',');
+    app.add_option("--idx", vals, "", true)->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
 }
@@ -2001,8 +1979,7 @@ TEST_F(TApp, DefaultUserSepParse) {
     auto opt = app.add_option("--idx", vals, "");
     run();
     EXPECT_EQ(vals, std::vector<std::string>({"1 2 3", "4 5 6"}));
-    app.remove_option(opt);
-    app.add_option("--idx", vals, "", true);
+    opt->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<std::string>({"1 2 3", "4 5 6"}));
 }
@@ -2011,7 +1988,7 @@ TEST_F(TApp, DefaultUserSepParse) {
 TEST_F(TApp, BadUserSepParse) {
 
     std::vector<int> vals;
-    app.add_option("--idx", vals, "");
+    app.add_option("--idx", vals);
 
     args = {"--idx", "1,2,3"};
 
@@ -2023,13 +2000,13 @@ TEST_F(TApp, CustomUserSepParse2) {
 
     std::vector<int> vals = {1, 2, 3};
     args = {"--idx", "1,2,"};
-    auto opt = app.add_option("--idx", vals, "", ',');
+    auto opt = app.add_option("--idx", vals)->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2}));
 
     app.remove_option(opt);
 
-    app.add_option("--idx", vals, "", true, ',');
+    app.add_option("--idx", vals, "", true)->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2}));
 }
@@ -2042,11 +2019,26 @@ TEST_F(TApp, CustomUserSepParseFunction) {
                                               [&vals](std::vector<int> v) {
                                                   vals = std::move(v);
                                                   return true;
-                                              },
-                                              "",
-                                              ',');
+                                              })
+        ->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+}
+
+// delimiter removal
+TEST_F(TApp, CustomUserSepParseToggle) {
+
+    std::vector<std::string> vals;
+    args = {"--idx", "1,2,3"};
+    auto opt = app.add_option("--idx", vals)->delimiter(',');
+    run();
+    EXPECT_EQ(vals, std::vector<std::string>({"1", "2", "3"}));
+    opt->delimiter('\0');
+    run();
+    EXPECT_EQ(vals, std::vector<std::string>({"1,2,3"}));
+    opt->delimiter(',');
+    run();
+    EXPECT_EQ(vals, std::vector<std::string>({"1", "2", "3"}));
 }
 
 // #209
@@ -2057,12 +2049,12 @@ TEST_F(TApp, CustomUserSepParse3) {
             "1",
             ","
             "2"};
-    auto opt = app.add_option("--idx", vals, "", ',');
+    auto opt = app.add_option("--idx", vals)->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2}));
     app.remove_option(opt);
 
-    app.add_option("--idx", vals, "", false, ',');
+    app.add_option("--idx", vals, "", false)->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2}));
 }
@@ -2072,13 +2064,13 @@ TEST_F(TApp, CustomUserSepParse4) {
 
     std::vector<int> vals;
     args = {"--idx", "1,    2"};
-    auto opt = app.add_option("--idx", vals, "", ',');
+    auto opt = app.add_option("--idx", vals)->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2}));
 
     app.remove_option(opt);
 
-    app.add_option("--idx", vals, "", true, ',');
+    app.add_option("--idx", vals, "", true)->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2}));
 }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1961,12 +1961,34 @@ TEST_F(TApp, CustomUserSepParse) {
     EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
     std::vector<int> vals2;
     // check that the results vector gets the results in the same way
-    opt->results(vals2, ',');
+    opt->results(vals2);
     EXPECT_EQ(vals2, vals);
 
     app.remove_option(opt);
 
     app.add_option("--idx", vals, "", true, ',');
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+}
+
+// #209
+TEST_F(TApp, CustomUserSepParseLaterDelimiter) {
+
+    std::vector<int> vals = {1, 2, 3};
+    args = {"--idx", "1,2,3"};
+    auto opt = app.add_option("--idx", vals);
+    opt->delimiter(',');
+    run();
+    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+    std::vector<int> vals2;
+    // check that the results vector gets the results in the same way
+    opt->results(vals2);
+    EXPECT_EQ(vals2, vals);
+
+    app.remove_option(opt);
+
+    opt = app.add_option("--idx", vals, "", true);
+    opt->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
 }

--- a/tests/NewParseTest.cpp
+++ b/tests/NewParseTest.cpp
@@ -77,6 +77,38 @@ TEST_F(TApp, BuiltinComplex) {
     EXPECT_DOUBLE_EQ(3, comp.imag());
 }
 
+TEST_F(TApp, BuiltinComplexWithDelimiter) {
+    cx comp{1, 2};
+    app.add_complex("-c,--complex", comp, "", true)->delimiter('+');
+
+    args = {"-c", "4+3i"};
+
+    std::string help = app.help();
+    EXPECT_THAT(help, HasSubstr("1"));
+    EXPECT_THAT(help, HasSubstr("2"));
+    EXPECT_THAT(help, HasSubstr("COMPLEX"));
+
+    EXPECT_DOUBLE_EQ(1, comp.real());
+    EXPECT_DOUBLE_EQ(2, comp.imag());
+
+    run();
+
+    EXPECT_DOUBLE_EQ(4, comp.real());
+    EXPECT_DOUBLE_EQ(3, comp.imag());
+
+    args = {"-c", "5+-3i"};
+    run();
+
+    EXPECT_DOUBLE_EQ(5, comp.real());
+    EXPECT_DOUBLE_EQ(-3, comp.imag());
+
+    args = {"-c", "6", "-4i"};
+    run();
+
+    EXPECT_DOUBLE_EQ(6, comp.real());
+    EXPECT_DOUBLE_EQ(-4, comp.imag());
+}
+
 TEST_F(TApp, BuiltinComplexIgnoreI) {
     cx comp{1, 2};
     app.add_complex("-c,--complex", comp);


### PR DESCRIPTION
This PR addresses an issue I came across working on the Validators.  The problem was with vectors and Validators if you wanted a vector with a range of say [0, 20]  There are options for Validating individual elements but not after the conversion if you also wanted to use a custom delimiter.  Furthermore if you wanted to require 3 elements,  that had to be 3 elements before the delimiter was applied.  

What is comes down to is the delimiter was being applied too late, and had to be applied in a bunch of places if you wanted to use it.  

The solution was to move it as part of the Option class.  Any option can now have a delimiter, and the delimiter is applied when the results are loaded into an option.  This can allow options that require multiple arguments to accept them as a comma separated list or something along those lines and have that meet the requirement.  

One twist on the add_complex is you could add ->delimiter('+') and it would accept argument such as "3+2j"  as a single command line argument since the + on +2j is redundant.   a negative number would still need to be written like 4+-2j  for that to work.

My use case I wanted to able to specify a bunch of flags  like --flags=flag1,flag2,flag3,..  and have them checked against a hash table.  That would only work if the delimiter was applied before the Validator.  