### PR TITLE
Fix Error when compiling with gcc with -Wparentheses-equality

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2346,7 +2346,7 @@ class App {
         if((help_ptr_ == opt) || (help_all_ptr_ == opt))
             throw OptionAlreadyAdded("cannot move help options");
 
-        if((config_ptr_ == opt))
+        if(config_ptr_ == opt)
             throw OptionAlreadyAdded("cannot move config file options");
 
         auto iterator =


### PR DESCRIPTION
Signed-off-by: Rafi Wiener <rafiw@mellanox.com>