### PR TITLE
Pre parse callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Option_group *app.add_option_group(name,description); // 🚧
 -app.add_mutable_set_ignore_case_underscore(... // 🆕 String only
 ```
 
-An option name must start with a alphabetic character, underscore, or a number🚧. For long options, after the first character '.', and '-' are also valid. For the `add_flag*` functions '{' has special meaning. Names are given as a comma separated string, with the dash or dashes. An option or flag can have as many names as you want, and afterward, using `count`, you can use any of the names, with dashes as needed, to count the options. One of the names is allowed to be given without proceeding dash(es); if present the option is a positional option, and that name will be used on help line for its positional form. If you want the default value to print in the help description, pass in `true` for the final parameter for `add_option`.
+An option name must start with a alphabetic character, underscore, a number 🚧,  '?'🚧, or '@'🚧. For long options, after the first character '.', and '-' are also valid characters. For the `add_flag*` functions '{' has special meaning. Names are given as a comma separated string, with the dash or dashes. An option or flag can have as many names as you want, and afterward, using `count`, you can use any of the names, with dashes as needed, to count the options. One of the names is allowed to be given without proceeding dash(es); if present the option is a positional option, and that name will be used on help line for its positional form. If you want the default value to print in the help description, pass in `true` for the final parameter for `add_option`.
 
 The `add_option_function<type>(...` function will typically require the template parameter be given unless a `std::function` object with an exact match is passed.  The type can be any type supported by the `add_option` function.
 
@@ -511,9 +511,10 @@ There are several options that are supported on the main app and subcommands and
 
 #### Callbacks 
 A subcommand has two optional callbacks that are executed at different stages of processing.  The `preparse_callback` 🚧 is executed once after the first argument of a subcommand or application is processed and gives an argument for the number of remaining arguments to process.  For the main app the first argument is considered the program name,  for subcommands the first argument is the subcommand name.  For Option groups and nameless subcommands the first argument is after the first argument or subcommand is processed from that group.
-The second callback is executed after parsing.  Depending on the status of the `immediate_callback` flag 🚧.  This is either immediately after the parsing of the subcommand.  Or if the flag is false, once after parsing of all arguments.  If the immediate_callback is set then the callback can be executed multiple times.   If the main app or subcommand has a config file, no data from the config file will be reflected in immediate_callback.
+The second callback is executed after parsing.  The behavior depends on the status of the `immediate_callback` flag 🚧. If true, this runs immediately after the parsing of the subcommand.  Or if the flag is false, once after parsing of all arguments.  If the `immediate_callback` is set then the callback can be executed multiple times if the subcommand list given multiple times.  If the main app or subcommand has a config file, no data from the config file will be reflected in immediate_callback. `immediate_callback()` has no effect on the main app, though it can be inherited.  For option_groups `immediate_callback` causes the callback to be run prior to other option groups and options in the main app, effectively giving the options in the group priority.  
 
 For example say an application was set up like
+
 ```cpp
 app.callback(ac);
 sub1=app.add_subcommand("sub1")->callback(c1)->preparse_callback(pc1)->immediate_callback();
@@ -523,6 +524,7 @@ app.preparse_callback( pa1);
 ... A bunch of other options
 
 ```
+
 Then the command line is given as
 
 ```
@@ -534,8 +536,8 @@ program --opt1 opt1_val  sub1 --sub1opt --sub1optb val sub2 --sub2opt sub1 --sub
 * c1 will be called when the `sub2` command is encountered
 * pc2 will be called with value of 6 after the sub2 command is encountered.
 * c1 will be called again after the second sub2 command is encountered
-* ac will be called after completing the parse
 * c2 will be called once after processing all arguments 
+* ac will be called after completing the parse and all lower level callbacks have been executed
 
 A subcommand is considered terminated when one of the following conditions are met.
 1. There are no more arguments to process
@@ -549,20 +551,26 @@ If the `immediate_callback` flag is set then all contained options are processed
 
 #### Option groups 🚧
 
-The subcommand method 
+The subcommand method
+
 ```cpp
 .add_option_group(name,description)
 ```
+
 Will create an option Group, and return a pointer to it.  An option group allows creation of a collection of options, similar to the groups function on options, but with additional controls and requirements.  They allow specific sets of options to be composed and controlled as a collective.  For an example see [range test](./tests/ranges.cpp).  Option groups are a specialization of an App so all [functions](#subcommand-options) that work with an App also work on option groups.  Options can be created as part of an option group using the add functions just like a subcommand, or previously created options can be added through
+
 ```cpp
 ogroup->add_option(option_pointer)
 ```
+
 ```cpp
 ogroup->add_options(option_pointer)
 ```
+
 ```cpp
 ogroup->add_options(option1,option2,option3,...)
 ```
+
 The option pointers used in this function must be options defined in the parent application of the option group otherwise an error will be generated.  
 Options in an option group are searched for a command line match after any options in the main app, so any positionals in the main app would be matched first.  So care must be taken to make sure of the order when using positional arguments and option groups.
 Option groups work well with `excludes` and `require_options` methods, as an Application will treat an option group as a single option for the purpose of counting and requirements.  Option groups allow specifying requirements such as requiring 1 of 3 options in one group and 1 of 3 options in a different group. Option groups can contain other groups as well.   Disabling an option group will turn off all options within the group.  
@@ -601,7 +609,7 @@ arguments, use `.config_to_str(default_also=false, prefix="", write_description=
 
 ### Inheriting defaults
 
-Many of the defaults for subcommands and even options are inherited from their creators. The inherited default values for subcommands are `allow_extras`, `prefix_command`, `ignore_case`, 🆕 `ignore_underscore`, `fallthrough`, `group`, `footer`, and maximum number of required subcommands. The help flag existence, name, and description are inherited, as well.
+Many of the defaults for subcommands and even options are inherited from their creators. The inherited default values for subcommands are `allow_extras`, `prefix_command`, `ignore_case`, 🆕 `ignore_underscore`, `fallthrough`, `group`, `footer`,`immediate_callback` and maximum number of required subcommands. The help flag existence, name, and description are inherited, as well.
 
 Options have defaults for `group`, `required`, `multi_option_policy`, `ignore_case`, 🆕 `ignore_underscore`, 🚧 `delimiter`, and 🚧 `disable_flag_override`. To set these defaults, you should set the `option_defaults()` object, for example:
 

--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ There are several options that are supported on the main app and subcommands and
 -   `.require_subcommand(min, max)`: Explicitly set min and max allowed subcommands. Setting `max` to 0 is unlimited.
 -   `.add_subcommand(name="", description="")`: Add a subcommand, returns a pointer to the internally stored subcommand.
 -   `.add_subcommand(shared_ptr<App>)`: 🚧 Add a subcommand by shared_ptr, returns a pointer to the internally stored subcommand.
+-   `.remove_subcommand(App)`:🚧 Remove a subcommand from the app or subcommand.
 -   `.got_subcommand(App_or_name)`: Check to see if a subcommand was received on the command line.
 -   `.get_subcommands(filter)`: The list of subcommands that match a particular filter function.
 -   `.add_option_group(name="", description="")`: 🚧 Add an [option group](#option-groups) to an App,  an option group is specialized subcommand intended for containing groups of options or other groups for controlling how options interact.  
@@ -562,18 +563,23 @@ The subcommand method
 Will create an option Group, and return a pointer to it.  An option group allows creation of a collection of options, similar to the groups function on options, but with additional controls and requirements.  They allow specific sets of options to be composed and controlled as a collective.  For an example see [range test](./tests/ranges.cpp).  Option groups are a specialization of an App so all [functions](#subcommand-options) that work with an App also work on option groups.  Options can be created as part of an option group using the add functions just like a subcommand, or previously created options can be added through
 
 ```cpp
-ogroup->add_option(option_pointer)
+ogroup->add_option(option_pointer);
 ```
 
 ```cpp
-ogroup->add_options(option_pointer)
+ogroup->add_options(option_pointer);
 ```
 
 ```cpp
-ogroup->add_options(option1,option2,option3,...)
+ogroup->add_options(option1,option2,option3,...);
 ```
 
-The option pointers used in this function must be options defined in the parent application of the option group otherwise an error will be generated.  
+The option pointers used in this function must be options defined in the parent application of the option group otherwise an error will be generated.  Subcommands can also be added via
+```cpp
+ogroup->add_subcommand(subcom_pointer);
+```
+This results in the subcommand being moved from its parent into the option group.
+
 Options in an option group are searched for a command line match after any options in the main app, so any positionals in the main app would be matched first.  So care must be taken to make sure of the order when using positional arguments and option groups.
 Option groups work well with `excludes` and `require_options` methods, as an Application will treat an option group as a single option for the purpose of counting and requirements.  Option groups allow specifying requirements such as requiring 1 of 3 options in one group and 1 of 3 options in a different group. Option groups can contain other groups as well.   Disabling an option group will turn off all options within the group.
 

--- a/cmake/AddGoogletest.cmake
+++ b/cmake/AddGoogletest.cmake
@@ -6,7 +6,10 @@
 #
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 set(BUILD_SHARED_LIBS OFF)
-
+# older version of google tests doesn't support MSYS so needs this flag to compile
+if (MSYS)
+	set(gtest_disable_pthreads ON CACHE BOOL "" FORCE)
+endif()
 set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "")
 add_subdirectory("${CLI11_SOURCE_DIR}/extern/googletest" "${CLI11_BINARY_DIR}/extern/googletest" EXCLUDE_FROM_ALL)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -94,6 +94,28 @@ add_test(NAME option_groups_extra2 COMMAND option_groups --csv --address "192.16
 set_property(TEST option_groups_extra2 PROPERTY PASS_REGULAR_EXPRESSION
     "at most 1")
 	
+add_cli_exe(positional_arity positional_arity.cpp)
+add_test(NAME positional_arity1 COMMAND positional_arity one )
+set_property(TEST positional_arity1 PROPERTY PASS_REGULAR_EXPRESSION
+    "File 1 = one")
+add_test(NAME positional_arity2 COMMAND positional_arity one two )
+set_property(TEST positional_arity2 PROPERTY PASS_REGULAR_EXPRESSION
+    "File 1 = one"
+    "File 2 = two")
+add_test(NAME positional_arity3 COMMAND positional_arity 1 2 one)
+set_property(TEST positional_arity3 PROPERTY PASS_REGULAR_EXPRESSION
+    "File 1 = one")
+add_test(NAME positional_arity_fail COMMAND positional_arity 1 one two)
+set_property(TEST positional_arity_fail PROPERTY PASS_REGULAR_EXPRESSION
+    "Could not convert")
+
+add_cli_exe(shapes shapes.cpp)
+add_test(NAME shapes_all COMMAND shapes circle 4.4 circle 10.7 rectangle 4 4 circle 2.3 triangle 4.5 ++ rectangle 2.1 ++ circle 234.675)
+set_property(TEST shapes_all PROPERTY PASS_REGULAR_EXPRESSION
+    "circle2"
+    "circle4"
+    "rectangle2 with edges [2.1,2.1]"
+    "triangel1 with sides [4.5]")
 	
 add_cli_exe(ranges ranges.cpp)
 add_test(NAME ranges_range COMMAND ranges --range 1 2 3)

--- a/examples/positional_arity.cpp
+++ b/examples/positional_arity.cpp
@@ -1,0 +1,38 @@
+#include "CLI/CLI.hpp"
+
+int main(int argc, char **argv) {
+
+    CLI::App app("test for positional arity");
+
+    auto numbers = app.add_option_group("numbers", "specify key numbers");
+    auto files = app.add_option_group("files", "specify files");
+    int num1 = -1, num2 = -1;
+    numbers->add_option("num1", num1, "first number");
+    numbers->add_option("num2", num2, "second number");
+    std::string file1, file2;
+    files->add_option("file1", file1, "first file")->required();
+    files->add_option("file2", file2, "second file");
+    // set a pre parse callback that turns the numbers group on or off depending on the number of arguments
+    app.preparse_callback([numbers](size_t arity) {
+        if(arity <= 2) {
+            numbers->disabled();
+        } else {
+            numbers->disabled(false);
+        }
+    });
+
+    CLI11_PARSE(app, argc, argv);
+
+    if(num1 != -1)
+        std::cout << "Num1 = " << num1 << '\n';
+
+    if(num2 != -1)
+        std::cout << "Num2 = " << num2 << '\n';
+
+    std::cout << "File 1 = " << file1 << '\n';
+    if(!file2.empty()) {
+        std::cout << "File 2 = " << file2 << '\n';
+    }
+
+    return 0;
+}

--- a/examples/shapes.cpp
+++ b/examples/shapes.cpp
@@ -1,0 +1,48 @@
+#include "CLI/CLI.hpp"
+
+int main(int argc, char **argv) {
+
+    CLI::App app("load shapes");
+
+    app.set_help_all_flag("--help-all");
+    auto circle = app.add_subcommand("circle", "draw a circle")->immediate_callback();
+    double radius{0.0};
+    int circle_counter = 0;
+    circle->callback([&radius, &circle_counter] {
+        ++circle_counter;
+        std::cout << "circle" << circle_counter << " with radius " << radius << std::endl;
+    });
+
+    circle->add_option("radius", radius, "the radius of the circle")->required();
+
+    auto rect = app.add_subcommand("rectangle", "draw a rectangle")->immediate_callback();
+    double edge1{0.0};
+    double edge2{0.0};
+    int rect_counter = 0;
+    rect->callback([&edge1, &edge2, &rect_counter] {
+        ++rect_counter;
+        if(edge2 == 0) {
+            edge2 = edge1;
+        }
+        std::cout << "rectangle" << rect_counter << " with edges [" << edge1 << ',' << edge2 << "]" << std::endl;
+        edge2 = 0;
+    });
+
+    rect->add_option("edge1", edge1, "the first edge length of the rectangle")->required();
+    rect->add_option("edge2", edge2, "the second edge length of the rectangle");
+
+    auto tri = app.add_subcommand("triangle", "draw a rectangle")->immediate_callback();
+    std::vector<double> sides;
+    int tri_counter = 0;
+    tri->callback([&sides, &tri_counter] {
+        ++tri_counter;
+
+        std::cout << "triangle" << tri_counter << " with sides [" << CLI::detail::join(sides) << "]" << std::endl;
+    });
+
+    tri->add_option("sides", sides, "the side lengths of the triangle");
+
+    CLI11_PARSE(app, argc, argv);
+
+    return 0;
+}

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -76,7 +76,6 @@ template <typename CRTP> class OptionBase {
     CRTP *group(std::string name) {
         group_ = name;
         return static_cast<CRTP *>(this);
-        ;
     }
 
     /// Set the option as required

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -667,7 +667,7 @@ class Option : public OptionBase<Option> {
         // Run the validators (can change the string)
         if(!validators_.empty()) {
             for(std::string &result : results_)
-                for(const std::function<std::string(std::string &)> &vali : validators_) {
+                for(const auto &vali : validators_) {
                     std::string err_msg;
 
                     try {

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -171,12 +171,12 @@ inline std::ostream &format_help(std::ostream &out, std::string name, std::strin
 }
 
 /// Verify the first character of an option
-template <typename T> bool valid_first_char(T c) { return std::isalnum(c, std::locale()) || c == '_'; }
+template <typename T> bool valid_first_char(T c) {
+    return std::isalnum(c, std::locale()) || c == '_' || c == '?' || c == '@';
+}
 
 /// Verify following characters of an option
-template <typename T> bool valid_later_char(T c) {
-    return std::isalnum(c, std::locale()) || c == '_' || c == '.' || c == '-';
-}
+template <typename T> bool valid_later_char(T c) { return valid_first_char(c) || c == '.' || c == '-'; }
 
 /// Verify an option name
 inline bool valid_name_string(const std::string &str) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -437,10 +437,7 @@ TEST_F(TApp, OneStringAgain) {
 
 TEST_F(TApp, OneStringFunction) {
     std::string str;
-    app.add_option_function<std::string>("-s,--string", [&str](const std::string &val) {
-        str = val;
-        return true;
-    });
+    app.add_option_function<std::string>("-s,--string", [&str](const std::string &val) { str = val; });
     args = {"--string", "mystring"};
     run();
     EXPECT_EQ(1u, app.count("-s"));
@@ -450,10 +447,7 @@ TEST_F(TApp, OneStringFunction) {
 
 TEST_F(TApp, doubleFunction) {
     double res;
-    app.add_option_function<double>("--val", [&res](double val) {
-        res = std::abs(val + 54);
-        return true;
-    });
+    app.add_option_function<double>("--val", [&res](double val) { res = std::abs(val + 54); });
     args = {"--val", "-354.356"};
     run();
     EXPECT_EQ(res, 300.356);
@@ -463,10 +457,7 @@ TEST_F(TApp, doubleFunction) {
 
 TEST_F(TApp, doubleFunctionFail) {
     double res;
-    app.add_option_function<double>("--val", [&res](double val) {
-        res = std::abs(val + 54);
-        return true;
-    });
+    app.add_option_function<double>("--val", [&res](double val) { res = std::abs(val + 54); });
     args = {"--val", "not_double"};
     EXPECT_THROW(run(), CLI::ConversionError);
 }
@@ -476,7 +467,6 @@ TEST_F(TApp, doubleVectorFunction) {
     app.add_option_function<std::vector<double>>("--val", [&res](const std::vector<double> &val) {
         res = val;
         std::transform(res.begin(), res.end(), res.begin(), [](double v) { return v + 5.0; });
-        return true;
     });
     args = {"--val", "5", "--val", "6", "--val", "7"};
     run();
@@ -491,7 +481,6 @@ TEST_F(TApp, doubleVectorFunctionFail) {
     app.add_option_function<std::vector<double>>(vstring, [&res](const std::vector<double> &val) {
         res = val;
         std::transform(res.begin(), res.end(), res.begin(), [](double v) { return v + 5.0; });
-        return true;
     });
     args = {"--val", "five", "--val", "nine", "--val", "7"};
     EXPECT_THROW(run(), CLI::ConversionError);
@@ -2063,11 +2052,7 @@ TEST_F(TApp, CustomUserSepParseFunction) {
 
     std::vector<int> vals = {1, 2, 3};
     args = {"--idx", "1,2,3"};
-    app.add_option_function<std::vector<int>>("--idx",
-                                              [&vals](std::vector<int> v) {
-                                                  vals = std::move(v);
-                                                  return true;
-                                              })
+    app.add_option_function<std::vector<int>>("--idx", [&vals](std::vector<int> v) { vals = std::move(v); })
         ->delimiter(',');
     run();
     EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -472,6 +472,7 @@ TEST_F(TApp, SubcommandDefaults) {
     // Initial defaults
     EXPECT_FALSE(app.get_allow_extras());
     EXPECT_FALSE(app.get_prefix_command());
+    EXPECT_FALSE(app.get_immediate_callback());
     EXPECT_FALSE(app.get_ignore_case());
     EXPECT_FALSE(app.get_ignore_underscore());
 #ifdef _WIN32
@@ -487,6 +488,7 @@ TEST_F(TApp, SubcommandDefaults) {
 
     app.allow_extras();
     app.prefix_command();
+    app.immediate_callback();
     app.ignore_case();
     app.ignore_underscore();
 #ifdef _WIN32
@@ -505,6 +507,7 @@ TEST_F(TApp, SubcommandDefaults) {
     // Initial defaults
     EXPECT_TRUE(app2->get_allow_extras());
     EXPECT_TRUE(app2->get_prefix_command());
+    EXPECT_TRUE(app2->get_immediate_callback());
     EXPECT_TRUE(app2->get_ignore_case());
     EXPECT_TRUE(app2->get_ignore_underscore());
 #ifdef _WIN32

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -337,6 +337,17 @@ TEST(THelp, OnlyOneHelp) {
     EXPECT_THROW(app.parse(input), CLI::ExtrasError);
 }
 
+TEST(THelp, MultiHelp) {
+    CLI::App app{"My prog"};
+
+    // It is not supported to have more than one help flag, last one wins
+    app.set_help_flag("--help,-h,-?", "No short name allowed");
+    app.allow_windows_style_options();
+
+    std::vector<std::string> input{"/?"};
+    EXPECT_THROW(app.parse(input), CLI::CallForHelp);
+}
+
 TEST(THelp, OnlyOneAllHelp) {
     CLI::App app{"My prog"};
 

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -33,6 +33,10 @@ TEST(String, InvalidName) {
     EXPECT_FALSE(CLI::detail::valid_name_string("vali&d"));
     EXPECT_TRUE(CLI::detail::valid_name_string("_valid"));
     EXPECT_FALSE(CLI::detail::valid_name_string("/valid"));
+    EXPECT_TRUE(CLI::detail::valid_name_string("vali?d"));
+    EXPECT_TRUE(CLI::detail::valid_name_string("@@@@"));
+    EXPECT_TRUE(CLI::detail::valid_name_string("b@d2?"));
+    EXPECT_TRUE(CLI::detail::valid_name_string("2vali?d"));
 }
 
 TEST(StringTools, Modify) {

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -575,6 +575,36 @@ TEST_F(ManyGroups, CallbackOrder) {
     EXPECT_EQ(callback_order, std::vector<int>({1, 2, 3}));
 }
 
+// Test the fallthrough for extra arguments
+TEST_F(ManyGroups, ExtrasFallDown) {
+    remove_required();
+
+    args = {"--test1", "--flag", "extra"};
+    EXPECT_THROW(run(), CLI::ExtrasError);
+    main->allow_extras();
+    EXPECT_NO_THROW(run());
+
+    EXPECT_EQ(app.remaining_size(true), 3u);
+    EXPECT_EQ(main->remaining_size(), 3u);
+
+    std::vector<std::string> extras{"--test1", "--flag", "extra"};
+    EXPECT_EQ(app.remaining(true), extras);
+    EXPECT_EQ(main->remaining(), extras);
+}
+
+// Test the option Inheritance
+TEST_F(ManyGroups, Inheritance) {
+    remove_required();
+    g1->ignore_case();
+    g1->ignore_underscore();
+    auto t2 = g1->add_subcommand("t2");
+    args = {"T2", "t_2"};
+    EXPECT_TRUE(t2->get_ignore_underscore());
+    EXPECT_TRUE(t2->get_ignore_case());
+    run();
+    EXPECT_EQ(t2->count(), 2u);
+}
+
 struct ManyGroupsPreTrigger : public ManyGroups {
     size_t triggerMain, trigger1{87u}, trigger2{34u}, trigger3{27u};
     ManyGroupsPreTrigger() {

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -420,6 +420,19 @@ TEST_F(ManyGroups, SingleGroup) {
     EXPECT_THROW(run(), CLI::RequiredError);
 }
 
+TEST_F(ManyGroups, ExcludesGroup) {
+    // only 1 group can be used
+    g1->excludes(g2);
+    g1->excludes(g3);
+    args = {"--name1", "test"};
+    run();
+    EXPECT_EQ(name1, "test");
+
+    args = {"--name1", "test", "--name2", "test2"};
+
+    EXPECT_THROW(run(), CLI::ExcludesError);
+}
+
 TEST_F(ManyGroups, SingleGroupError) {
     // only 1 group can be used
     main->require_option(1);

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -431,6 +431,11 @@ TEST_F(ManyGroups, ExcludesGroup) {
     args = {"--name1", "test", "--name2", "test2"};
 
     EXPECT_THROW(run(), CLI::ExcludesError);
+
+    EXPECT_TRUE(g1->remove_excludes(g2));
+    EXPECT_NO_THROW(run());
+    EXPECT_FALSE(g1->remove_excludes(g1));
+    EXPECT_FALSE(g1->remove_excludes(g2));
 }
 
 TEST_F(ManyGroups, SingleGroupError) {
@@ -603,6 +608,17 @@ TEST_F(ManyGroups, Inheritance) {
     EXPECT_TRUE(t2->get_ignore_case());
     run();
     EXPECT_EQ(t2->count(), 2u);
+}
+
+TEST_F(ManyGroups, Moving) {
+    remove_required();
+    auto mg = app.add_option_group("maing");
+    mg->add_subcommand(g1);
+    mg->add_subcommand(g2);
+
+    EXPECT_EQ(g1->get_parent(), mg);
+    EXPECT_EQ(g2->get_parent(), mg);
+    EXPECT_EQ(g3->get_parent(), main);
 }
 
 struct ManyGroupsPreTrigger : public ManyGroups {

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -908,6 +908,22 @@ TEST_F(SubcommandProgram, CallbackOrder) {
     EXPECT_EQ(callback_order, std::vector<int>({2, 1}));
 }
 
+TEST_F(SubcommandProgram, CallbackOrderImmediate) {
+    std::vector<int> callback_order;
+    start->callback([&callback_order]() { callback_order.push_back(1); })->immediate_callback();
+    stop->callback([&callback_order]() { callback_order.push_back(2); });
+
+    args = {"start", "stop", "start"};
+    run();
+    EXPECT_EQ(callback_order, std::vector<int>({1, 1, 2}));
+
+    callback_order.clear();
+
+    args = {"stop", "start", "stop", "start"};
+    run();
+    EXPECT_EQ(callback_order, std::vector<int>({1, 1, 2}));
+}
+
 struct ManySubcommands : public TApp {
 
     CLI::App *sub1;


### PR DESCRIPTION
This PR adds a pre parse callback and clarifies the callback timing of subcommands and option groups.  

It will also address issue #166.   The basic concept is to allow each app/subcommand/option_group to have two callbacks,  one would execute after the first argument  of the subcommand/option group is processed.  This allows an ability to effect the parsing dynamically, based on the number of arguments passed like Issue #166, or to dynamically enable or disable groups of options based on which options or subcommands were passed, or whatever other program state is appropriate to an application.    The other callback executes after parsing is complete.    With `immediate_callback` this is done immediately following the parse.    So callbacks from multiple subcommands can be executed in order and executed multiple times.    If that flag is not set all callbacks are executed on completion of all parsing in order of creation.  

To facilitate adaptive enabling or disabling option_groups some flags were created `enabled_by_default` and `disabled_by_default` that reset the disabled_ flag to a defined value on start of parsing.  

In the process of this a few issues with subcommand termination were fixed, and the readme updated with a new section on callbacks.  Also a subcommand_terminator was added (`++`)  to enable explicitly specifying that a subcommand is finished.   

Also added two new examples `shapes` with repeated subcommands and callbacks
and positional_arity which is Issue #166 coded up.
TODO: 
- [x] add missing tests for code coverage
- [x] add some helper functions to simplify triggered option groups

I am not sure I like all the names of the flags, so suggestions are welcome.