### PR TITLE
Support for size values (640 KB) and numbers with unit in general

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The `add_option_function<type>(...` function will typically require the template
 🚧 Flag options specified through the `add_flag*` functions allow a syntax for the option names to default particular options to a false value or any other value if some flags are passed.  For example:
 
 ```cpp
-app.add_flag("--flag,!--no-flag,result,"help for flag"); // 🚧
+app.add_flag("--flag,!--no-flag",result,"help for flag"); // 🚧
 ```
 
 specifies that if `--flag` is passed on the command line result will be true or contain a value of 1. If `--no-flag` is
@@ -341,6 +341,8 @@ CLI11 has several Validators built-in that perform some common checks
 -   `CLI::IsMember(...)`: 🚧 Require an option be a member of a given set.  See [Transforming Validators](#transforming-validators) for more details.
 -   `CLI::Transformer(...)`: 🚧 Modify the input using a map.  See [Transforming Validators](#transforming-validators) for more details.
 -   `CLI::CheckedTransformer(...)`: 🚧 Modify the input using a map, and require that the input is either in the set or already one of the outputs of the set. See [Transforming Validators](#transforming-validators) for more details.
+-   `CLI::SuffixedNumber(...)`: Modify the number-suffix pair by matching the suffix and multiplying the number by the corresponding factor. It can be used as a base for transformers, that accept things like size values (`1 KB`) or durations (`0.33 ms`).
+-   `CLI::AsSizeValue(...)`: Convert inputs like `100b`, `42 KB`, `101 Mb`, `11 Mib` to absolute values. `KB` is configured to be interpreted as 10^3 or 2^10.
 -   `CLI::ExistingFile`: Requires that the file exists if given.
 -   `CLI::ExistingDirectory`: Requires that the directory exists.
 -   `CLI::ExistingPath`: Requires that the path (file or directory) exists.

--- a/README.md
+++ b/README.md
@@ -341,8 +341,8 @@ CLI11 has several Validators built-in that perform some common checks
 -   `CLI::IsMember(...)`: 🚧 Require an option be a member of a given set.  See [Transforming Validators](#transforming-validators) for more details.
 -   `CLI::Transformer(...)`: 🚧 Modify the input using a map.  See [Transforming Validators](#transforming-validators) for more details.
 -   `CLI::CheckedTransformer(...)`: 🚧 Modify the input using a map, and require that the input is either in the set or already one of the outputs of the set. See [Transforming Validators](#transforming-validators) for more details.
--   `CLI::SuffixedNumber(...)`: Modify the number-suffix pair by matching the suffix and multiplying the number by the corresponding factor. It can be used as a base for transformers, that accept things like size values (`1 KB`) or durations (`0.33 ms`).
--   `CLI::AsSizeValue(...)`: Convert inputs like `100b`, `42 KB`, `101 Mb`, `11 Mib` to absolute values. `KB` is configured to be interpreted as 10^3 or 2^10.
+-   `CLI::AsNumberWithUnit(...)`: Modify the `<NUMBER> <UNIT>` pair by matching the unit and multiplying the number by the corresponding factor. It can be used as a base for transformers, that accept things like size values (`1 KB`) or durations (`0.33 ms`).
+-   `CLI::AsSizeValue(...)`: Convert inputs like `100b`, `42 KB`, `101 Mb`, `11 Mib` to absolute values. `KB` can be configured to be interpreted as 10^3 or 2^10.
 -   `CLI::ExistingFile`: Requires that the file exists if given.
 -   `CLI::ExistingDirectory`: Requires that the directory exists.
 -   `CLI::ExistingPath`: Requires that the path (file or directory) exists.

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -193,6 +193,11 @@ inline bool valid_name_string(const std::string &str) {
     return true;
 }
 
+/// Verify that str consists of letters only
+inline bool isalpha(const std::string &str) {
+    return std::all_of(str.begin(), str.end(), [](char c){return std::isalpha(c, std::locale()); });
+}
+
 /// Return a lower case version of a string
 inline std::string to_lower(std::string str) {
     std::transform(std::begin(str), std::end(str), std::begin(str), [](const std::string::value_type &x) {

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -195,7 +195,7 @@ inline bool valid_name_string(const std::string &str) {
 
 /// Verify that str consists of letters only
 inline bool isalpha(const std::string &str) {
-    return std::all_of(str.begin(), str.end(), [](char c){return std::isalpha(c, std::locale()); });
+    return std::all_of(str.begin(), str.end(), [](char c) { return std::isalpha(c, std::locale()); });
 }
 
 /// Return a lower case version of a string

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -737,9 +737,12 @@ class CheckedTransformer : public Validator {
     /// Number is interpreted as a type the same as in the provided mapping.
     /// Therefore, if it is required to interpret inputs like "0.42 s",
     /// the mapping should be of a type <string, float> or <string, double>.
-    /// 
     class SuffixedNumber : public Validator {
       public:
+        /// Adjust SuffixedNumber behavior.
+        /// CASE_SENSITIVE/CASE_INSENSITIVE controls how suffixes are be matched.
+        /// OPTIONAL_SUFFIX/MANDATORY_SUFFIX throws ValidationError
+        ///   if mandatory is set and suffix is not found.
         enum Options {
             CASE_SENSITIVE = 0,
             CASE_INSENSITIVE = 1,

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -765,7 +765,7 @@ class SuffixedNumber : public Validator {
     };
 
     template <typename Number>
-    SuffixedNumber(std::map<std::string, Number> mapping, const std::string &name = "SUFFIX", Options opts = DEFAULT) {
+    SuffixedNumber(std::map<std::string, Number> mapping, Options opts = DEFAULT, const std::string& name = "SUFFIX") {
         // generate description
         std::stringstream out;
         out << detail::type_name<Number>() << ' ';
@@ -779,6 +779,9 @@ class SuffixedNumber : public Validator {
 
         // validate mapping
         for(auto &kv : mapping) {
+            if (kv.first.empty()) {
+                throw ValidationError("Suffix must not be empty.");
+            }
             if(!detail::isalpha(kv.first)) {
                 throw ValidationError("Suffix must contain only letters.");
             }
@@ -815,7 +818,7 @@ class SuffixedNumber : public Validator {
                                       " suffix not recognized. Allowed values: " + detail::generate_map(mapping, true));
             }
 
-            // perform sefa multiplication
+            // perform safe multiplication
             bool ok = detail::checked_multiply(num, it->second);
             if(!ok) {
                 throw ValidationError(detail::as_string(num) + " multiplied by " + suffix +

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -778,8 +778,8 @@ class SuffixedNumber : public Validator {
     };
 
     template <typename Number>
-    explicit SuffixedNumber(std::map<std::string, Number> mapping, Options opts = DEFAULT, const std::string &name = "SUFFIX") {
-        description(generate_description<Number>(name, opts));
+    explicit SuffixedNumber(std::map<std::string, Number> mapping, Options opts = DEFAULT, const std::string &suff_name = "SUFFIX") {
+        description(generate_description<Number>(suff_name, opts));
         validate_mapping(mapping, opts);
 
         // transform function

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -511,28 +511,28 @@ auto search(const T &set, const V &val, const std::function<V(V)> &filter_functi
 }
 
 /// Performs a *= b; if it doesn't cause integer overflow. Returns false otherwise.
-template <typename T> bool checked_multiply(T &a, T b) {
-    static_assert(std::is_arithmetic<T>::value, "Only number types allowed");
-    // No need for SFINAE since both branches are syntactically valid
-    if(std::is_integral<T>::value) {
-        if(a == 0 || b == 0) {
-            a *= b;
-            return true;
-        }
-        T c = a * b;
-        if(c / a != b) {
-            return false;
-        }
-        a = c;
-        return true;
-    } else {
-        T c = a * b;
-        if(std::isinf(c) && !std::isinf(a) && !std::isinf(b)) {
-            return false;
-        }
-        a = c;
+template <typename T> typename std::enable_if<std::is_integral<T>::value, bool>::type checked_multiply(T &a, T b) {
+    if(a == 0 || b == 0) {
+        a *= b;
         return true;
     }
+    T c = a * b;
+    if(c / a != b) {
+        return false;
+    }
+    a = c;
+    return true;
+}
+
+/// Performs a *= b; if it doesn't equal infinity. Returns false otherwise.
+template <typename T>
+typename std::enable_if<std::is_floating_point<T>::value, bool>::type checked_multiply(T &a, T b) {
+    T c = a * b;
+    if(std::isinf(c) && !std::isinf(a) && !std::isinf(b)) {
+        return false;
+    }
+    a = c;
+    return true;
 }
 
 } // namespace detail

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -778,7 +778,9 @@ class SuffixedNumber : public Validator {
     };
 
     template <typename Number>
-    explicit SuffixedNumber(std::map<std::string, Number> mapping, Options opts = DEFAULT, const std::string &suff_name = "SUFFIX") {
+    explicit SuffixedNumber(std::map<std::string, Number> mapping,
+                            Options opts = DEFAULT,
+                            const std::string &suff_name = "SUFFIX") {
         description(generate_description<Number>(suff_name, opts));
         validate_mapping(mapping, opts);
 

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -749,7 +749,7 @@ class CheckedTransformer : public Validator {
         };
 
         template <typename Number>
-        SuffixedNumber(const std::map<std::string, Number> &mapping,
+        SuffixedNumber(std::map<std::string, Number> mapping,
                        const std::string &name = "SUFFIX",
                        Options opts = DEFAULT) {
             // generate description
@@ -762,6 +762,16 @@ class CheckedTransformer : public Validator {
             }
 
             description(out.str());
+
+            // validate mapping
+            for (auto& kv : mapping) {
+                if (!detail::isalpha(kv.first)) {
+                    throw ValidationError("Suffix must contain only letters.");
+                }
+                if (opts & CASE_INSENSITIVE) {
+                    kv.second = detail::to_lower(kv.second);
+                }
+            }
 
             // transform function
             func_ = [mapping, opts](std::string &input) -> std::string {

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -6,6 +6,7 @@
 #include "CLI/StringTools.hpp"
 #include "CLI/TypeTools.hpp"
 
+#include <cmath>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -511,16 +512,27 @@ auto search(const T &set, const V &val, const std::function<V(V)> &filter_functi
 
 /// Performs a *= b; if it doesn't cause integer overflow. Returns false otherwise.
 template <typename T> bool checked_multiply(T &a, T b) {
-    if(a == 0 || b == 0) {
-        a *= b;
+    static_assert(std::is_arithmetic<T>::value, "Only number types allowed");
+    // No need for SFINAE since both branches are syntactically valid
+    if (std::is_integral<T>::value) {
+        if (a == 0 || b == 0) {
+            a *= b;
+            return true;
+        }
+        T c = a * b;
+        if (c / a != b) {
+            return false;
+        }
+        a = c;
+        return true;
+    } else {
+        T c = a * b;
+        if (std::isinf(c) && !std::isinf(a) && !std::isinf(b)) {
+            return false;
+        }
+        a = c;
         return true;
     }
-    T c = a * b;
-    if(c / a != b) {
-        return false;
-    }
-    a = c;
-    return true;
 }
 
 } // namespace detail

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -778,7 +778,7 @@ class SuffixedNumber : public Validator {
     };
 
     template <typename Number>
-    SuffixedNumber(std::map<std::string, Number> mapping, Options opts = DEFAULT, const std::string &name = "SUFFIX") {
+    explicit SuffixedNumber(std::map<std::string, Number> mapping, Options opts = DEFAULT, const std::string &name = "SUFFIX") {
         description(generate_description<Number>(name, opts));
         validate_mapping(mapping, opts);
 
@@ -910,7 +910,7 @@ class AsSizeValue : public SuffixedNumber {
     /// The first option is formally correct, but
     /// the second interpretation is more wide-spread
     /// (see https://en.wikipedia.org/wiki/Binary_prefix).
-    AsSizeValue(bool allow_1000_factor) : SuffixedNumber(get_mapping(allow_1000_factor)) {
+    explicit AsSizeValue(bool allow_1000_factor) : SuffixedNumber(get_mapping(allow_1000_factor)) {
         if(allow_1000_factor) {
             description("SIZE [b, kb(=1000b), kib(=1024b), ...]");
         } else {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -105,6 +105,18 @@ TEST(StringTools, flagValues) {
     EXPECT_EQ(CLI::detail::to_flag_value("475555233"), 475555233);
 }
 
+TEST(StringTools, Validation) {
+    EXPECT_TRUE(CLI::detail::isalpha(""));
+    EXPECT_TRUE(CLI::detail::isalpha("a"));
+    EXPECT_TRUE(CLI::detail::isalpha("abcd"));
+    EXPECT_FALSE(CLI::detail::isalpha("_"));
+    EXPECT_FALSE(CLI::detail::isalpha("2"));
+    EXPECT_FALSE(CLI::detail::isalpha("test test"));
+    EXPECT_FALSE(CLI::detail::isalpha("test "));
+    EXPECT_FALSE(CLI::detail::isalpha(" test"));
+    EXPECT_FALSE(CLI::detail::isalpha("test2"));
+}
+
 TEST(Trim, Various) {
     std::string s1{"  sdlfkj sdflk sd s  "};
     std::string a1{"sdlfkj sdflk sd s"};
@@ -358,6 +370,196 @@ TEST(Validators, ProgramNameSplit) {
     res = CLI::detail::split_program_name(std::string("  ./") + std::string(myfile) + "    ");
     EXPECT_EQ(res.first, std::string("./") + std::string(myfile));
     EXPECT_TRUE(res.second.empty());
+}
+
+TEST(CheckedMultiply, Int) {
+    int a = 10;
+    int b = -20;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, -200);
+
+    a = 0;
+    b = -20;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, 0);
+
+    a = 20;
+    b = 0;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, 0);
+
+    a = std::numeric_limits<int>::max();
+    b = 1;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<int>::max());
+
+    a = std::numeric_limits<int>::max();
+    b = 2;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<int>::max());
+
+    a = std::numeric_limits<int>::max();
+    b = -1;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, -std::numeric_limits<int>::max());
+
+    a = std::numeric_limits<int>::max();
+    b = std::numeric_limits<int>::max();;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<int>::max());
+
+    a = std::numeric_limits<int>::min();
+    b = std::numeric_limits<int>::max();;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<int>::min());
+
+
+    a = std::numeric_limits<int>::min();
+    b = 1;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<int>::min());
+
+    a = std::numeric_limits<int>::min();
+    b = -1;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<int>::min());
+
+    a = std::numeric_limits<int>::min() / 100;
+    b = 99;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<int>::min() / 100 * 99);
+}
+
+TEST(SafeMultiply, SizeT) {
+    size_t a = 10;
+    size_t b = 20;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, 200);
+
+    a = 0;
+    b = 20;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, 0);
+
+    a = 20;
+    b = 0;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, 0);
+
+    a = std::numeric_limits<size_t>::max();
+    b = 1;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<size_t>::max());
+
+    a = std::numeric_limits<size_t>::max();
+    b = 2;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<size_t>::max());
+
+    a = std::numeric_limits<size_t>::max();
+    b = std::numeric_limits<size_t>::max();;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<size_t>::max());
+
+
+    a = std::numeric_limits<size_t>::max() / 100;
+    b = 99;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<size_t>::max() / 100 * 99);
+}
+
+TEST(SafeMultiply, Float) {
+    float a = 10;
+    float b = 20;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_FLOAT_EQ(a, 200);
+
+    a = 0;
+    b = 20;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_FLOAT_EQ(a, 0);
+
+    a = INFINITY;
+    b = 20;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_FLOAT_EQ(a, INFINITY);
+
+    a = 2;
+    b = -INFINITY;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_FLOAT_EQ(a, -INFINITY);
+
+    a = std::numeric_limits<float>::max() / 100;
+    b = 1;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_FLOAT_EQ(a, std::numeric_limits<float>::max() / 100);
+
+    a = std::numeric_limits<float>::max() / 100;
+    b = 99;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_FLOAT_EQ(a, std::numeric_limits<float>::max() / 100 * 99);
+
+    a = std::numeric_limits<float>::max() / 100;
+    b = 101;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_FLOAT_EQ(a, std::numeric_limits<float>::max() / 100);
+
+    a = std::numeric_limits<float>::max() / 100;
+    b = -99;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_FLOAT_EQ(a, std::numeric_limits<float>::max() / 100 * -99);
+
+    a = std::numeric_limits<float>::max() / 100;
+    b = -101;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_FLOAT_EQ(a, std::numeric_limits<float>::max() / 100);
+}
+
+TEST(SafeMultiply, Double) {
+    double a = 10;
+    double b = 20;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_DOUBLE_EQ(a, 200);
+
+    a = 0;
+    b = 20;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_DOUBLE_EQ(a, 0);
+
+    a = INFINITY;
+    b = 20;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_DOUBLE_EQ(a, INFINITY);
+
+    a = 2;
+    b = -INFINITY;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_DOUBLE_EQ(a, -INFINITY);
+
+    a = std::numeric_limits<double>::max() / 100;
+    b = 1;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_DOUBLE_EQ(a, std::numeric_limits<double>::max() / 100);
+
+    a = std::numeric_limits<double>::max() / 100;
+    b = 99;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_DOUBLE_EQ(a, std::numeric_limits<double>::max() / 100 * 99);
+
+    a = std::numeric_limits<double>::max() / 100;
+    b = 101;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_DOUBLE_EQ(a, std::numeric_limits<double>::max() / 100);
+
+    a = std::numeric_limits<double>::max() / 100;
+    b = -99;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    ASSERT_DOUBLE_EQ(a, std::numeric_limits<double>::max() / 100 * -99);
+
+    a = std::numeric_limits<double>::max() / 100;
+    b = -101;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_DOUBLE_EQ(a, std::numeric_limits<double>::max() / 100);
 }
 
 // Yes, this is testing an app_helper :)

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -413,7 +413,6 @@ TEST(CheckedMultiply, Int) {
     ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<int>::min());
 
-
     a = std::numeric_limits<int>::min();
     b = 1;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
@@ -430,7 +429,7 @@ TEST(CheckedMultiply, Int) {
     ASSERT_EQ(a, std::numeric_limits<int>::min() / 100 * 99);
 }
 
-TEST(SafeMultiply, SizeT) {
+TEST(CheckedMultiply, SizeT) {
     size_t a = 10;
     size_t b = 20;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
@@ -461,14 +460,13 @@ TEST(SafeMultiply, SizeT) {
     ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<size_t>::max());
 
-
     a = std::numeric_limits<size_t>::max() / 100;
     b = 99;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<size_t>::max() / 100 * 99);
 }
 
-TEST(SafeMultiply, Float) {
+TEST(CheckedMultiply, Float) {
     float a = 10;
     float b = 20;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
@@ -515,7 +513,7 @@ TEST(SafeMultiply, Float) {
     ASSERT_FLOAT_EQ(a, std::numeric_limits<float>::max() / 100);
 }
 
-TEST(SafeMultiply, Double) {
+TEST(CheckedMultiply, Double) {
     double a = 10;
     double b = 20;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -404,12 +404,12 @@ TEST(CheckedMultiply, Int) {
     ASSERT_EQ(a, -std::numeric_limits<int>::max());
 
     a = std::numeric_limits<int>::max();
-    b = std::numeric_limits<int>::max();;
+    b = std::numeric_limits<int>::max();
     ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<int>::max());
 
     a = std::numeric_limits<int>::min();
-    b = std::numeric_limits<int>::max();;
+    b = std::numeric_limits<int>::max();
     ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<int>::min());
 
@@ -457,7 +457,7 @@ TEST(SafeMultiply, SizeT) {
     ASSERT_EQ(a, std::numeric_limits<size_t>::max());
 
     a = std::numeric_limits<size_t>::max();
-    b = std::numeric_limits<size_t>::max();;
+    b = std::numeric_limits<size_t>::max();
     ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<size_t>::max());
 

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -433,25 +433,25 @@ TEST(CheckedMultiply, SizeT) {
     size_t a = 10;
     size_t b = 20;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
-    ASSERT_EQ(a, 200);
+    ASSERT_EQ(a, 200u);
 
-    a = 0;
-    b = 20;
+    a = 0u;
+    b = 20u;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
-    ASSERT_EQ(a, 0);
+    ASSERT_EQ(a, 0u);
 
-    a = 20;
-    b = 0;
+    a = 20u;
+    b = 0u;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
-    ASSERT_EQ(a, 0);
+    ASSERT_EQ(a, 0u);
 
     a = std::numeric_limits<size_t>::max();
-    b = 1;
+    b = 1u;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<size_t>::max());
 
     a = std::numeric_limits<size_t>::max();
-    b = 2;
+    b = 2u;
     ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<size_t>::max());
 
@@ -461,9 +461,9 @@ TEST(CheckedMultiply, SizeT) {
     ASSERT_EQ(a, std::numeric_limits<size_t>::max());
 
     a = std::numeric_limits<size_t>::max() / 100;
-    b = 99;
+    b = 99u;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
-    ASSERT_EQ(a, std::numeric_limits<size_t>::max() / 100 * 99);
+    ASSERT_EQ(a, std::numeric_limits<size_t>::max() / 100u * 99u);
 }
 
 TEST(CheckedMultiply, Float) {

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -628,3 +628,209 @@ TEST_F(TApp, SuffixedNumberFloatOverlow) {
     run();
     EXPECT_FLOAT_EQ(value, 0);
 }
+
+TEST_F(TApp, AsSizeValue1000_1024) {
+    uint64_t value;
+    app.add_option("-s", value)->transform(CLI::AsSizeValue(true));
+
+    args = {"-s", "10240"};
+    run();
+    EXPECT_EQ(value, 10240);
+
+    args = {"-s", "1b"};
+    run();
+    EXPECT_FLOAT_EQ(value, 1);
+
+    uint64_t k_value = 1000;
+    uint64_t ki_value = 1024;
+    args = {"-s", "1k"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1kb"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1 Kb"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1ki"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1kib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+
+    k_value = 1000ull * 1000;
+    ki_value = 1024ull * 1024;
+    args = {"-s", "1m"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1mb"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1mi"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1mib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+
+    k_value = 1000ull * 1000 * 1000;
+    ki_value = 1024ull * 1024 * 1024;
+    args = {"-s", "1g"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1gb"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1gi"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1gib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+
+    k_value = 1000ull * 1000 * 1000 * 1000;
+    ki_value = 1024ull * 1024 * 1024 * 1024;
+    args = {"-s", "1t"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1tb"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1ti"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1tib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+
+    k_value = 1000ull * 1000 * 1000 * 1000 * 1000;
+    ki_value = 1024ull * 1024 * 1024 * 1024 * 1024;
+    args = {"-s", "1p"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1pb"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1pi"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1pib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+
+    k_value = 1000ull * 1000 * 1000 * 1000 * 1000 * 1000;
+    ki_value = 1024ull * 1024 * 1024 * 1024 * 1024 * 1024;
+    args = {"-s", "1e"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1eb"};
+    run();
+    EXPECT_EQ(value, k_value);
+    args = {"-s", "1ei"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1eib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+}
+
+TEST_F(TApp, AsSizeValue1024) {
+    uint64_t value;
+    app.add_option("-s", value)->transform(CLI::AsSizeValue(false));
+
+    args = {"-s", "10240"};
+    run();
+    EXPECT_EQ(value, 10240);
+
+    args = {"-s", "1b"};
+    run();
+    EXPECT_FLOAT_EQ(value, 1);
+
+    uint64_t ki_value = 1024;
+    args = {"-s", "1k"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1kb"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1 Kb"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1ki"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1kib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+
+    ki_value = 1024ull * 1024;
+    args = {"-s", "1m"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1mb"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1mi"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1mib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+
+    ki_value = 1024ull * 1024 * 1024;
+    args = {"-s", "1g"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1gb"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1gi"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1gib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+
+    ki_value = 1024ull * 1024 * 1024 * 1024;
+    args = {"-s", "1t"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1tb"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1ti"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1tib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+
+    ki_value = 1024ull * 1024 * 1024 * 1024 * 1024;
+    args = {"-s", "1p"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1pb"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1pi"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1pib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+
+    ki_value = 1024ull * 1024 * 1024 * 1024 * 1024 * 1024;
+    args = {"-s", "1e"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1eb"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1ei"};
+    run();
+    EXPECT_EQ(value, ki_value);
+    args = {"-s", "1eib"};
+    run();
+    EXPECT_EQ(value, ki_value);
+}

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -432,11 +432,11 @@ TEST_F(TApp, BoundTests) {
     EXPECT_TRUE(help.find("[3.4 - 5.9]") != std::string::npos);
 }
 
-TEST_F(TApp, SuffixedNumberCorrecltySplitSuffix) {
+TEST_F(TApp, NumberWithUnitCorrecltySplitNumber) {
     std::map<std::string, int> mapping{{"a", 10}, {"b", 100}, {"cc", 1000}};
 
-    int value;
-    app.add_option("-n", value)->transform(CLI::SuffixedNumber(mapping));
+    int value = 0;
+    app.add_option("-n", value)->transform(CLI::AsNumberWithUnit(mapping));
 
     args = {"-n", "42"};
     run();
@@ -454,10 +454,10 @@ TEST_F(TApp, SuffixedNumberCorrecltySplitSuffix) {
     EXPECT_EQ(value, -42000);
 }
 
-TEST_F(TApp, SuffixedNumberFloatTest) {
+TEST_F(TApp, NumberWithUnitFloatTest) {
     std::map<std::string, double> mapping{{"a", 10}, {"b", 100}, {"cc", 1000}};
-    double value;
-    app.add_option("-n", value)->transform(CLI::SuffixedNumber(mapping));
+    double value = 0;
+    app.add_option("-n", value)->transform(CLI::AsNumberWithUnit(mapping));
 
     args = {"-n", "42"};
     run();
@@ -476,11 +476,11 @@ TEST_F(TApp, SuffixedNumberFloatTest) {
     EXPECT_DOUBLE_EQ(value, 42000);
 }
 
-TEST_F(TApp, SuffixedNumberCaseSensetive) {
+TEST_F(TApp, NumberWithUnitCaseSensitive) {
     std::map<std::string, int> mapping{{"a", 10}, {"A", 100}};
 
-    int value;
-    app.add_option("-n", value)->transform(CLI::SuffixedNumber(mapping, CLI::SuffixedNumber::CASE_SENSITIVE));
+    int value = 0;
+    app.add_option("-n", value)->transform(CLI::AsNumberWithUnit(mapping, CLI::AsNumberWithUnit::CASE_SENSITIVE));
 
     args = {"-n", "42a"};
     run();
@@ -491,11 +491,11 @@ TEST_F(TApp, SuffixedNumberCaseSensetive) {
     EXPECT_EQ(value, 4200);
 }
 
-TEST_F(TApp, SuffixedNumberCaseInsensitive) {
+TEST_F(TApp, NumberWithUnitCaseInsensitive) {
     std::map<std::string, int> mapping{{"a", 10}, {"B", 100}};
 
-    int value;
-    app.add_option("-n", value)->transform(CLI::SuffixedNumber(mapping, CLI::SuffixedNumber::CASE_INSENSITIVE));
+    int value = 0;
+    app.add_option("-n", value)->transform(CLI::AsNumberWithUnit(mapping, CLI::AsNumberWithUnit::CASE_INSENSITIVE));
 
     args = {"-n", "42a"};
     run();
@@ -514,14 +514,14 @@ TEST_F(TApp, SuffixedNumberCaseInsensitive) {
     EXPECT_EQ(value, 4200);
 }
 
-TEST_F(TApp, SuffixedNumberMandatorySuffix) {
+TEST_F(TApp, NumberWithUnitMandatoryUnit) {
     std::map<std::string, int> mapping{{"a", 10}, {"A", 100}};
 
     int value;
     app.add_option("-n", value)
-        ->transform(CLI::SuffixedNumber(
-            mapping,
-            CLI::SuffixedNumber::Options(CLI::SuffixedNumber::MANDATORY_SUFFIX | CLI::SuffixedNumber::CASE_SENSITIVE)));
+        ->transform(CLI::AsNumberWithUnit(mapping,
+                                          CLI::AsNumberWithUnit::Options(CLI::AsNumberWithUnit::UNIT_REQUIRED |
+                                                                         CLI::AsNumberWithUnit::CASE_SENSITIVE)));
 
     args = {"-n", "42a"};
     run();
@@ -535,14 +535,14 @@ TEST_F(TApp, SuffixedNumberMandatorySuffix) {
     EXPECT_THROW(run(), CLI::ValidationError);
 }
 
-TEST_F(TApp, SuffixedNumberMandatorySuffix2) {
+TEST_F(TApp, NumberWithUnitMandatoryUnit2) {
     std::map<std::string, int> mapping{{"a", 10}, {"B", 100}};
 
     int value;
     app.add_option("-n", value)
-        ->transform(CLI::SuffixedNumber(mapping,
-                                        CLI::SuffixedNumber::Options(CLI::SuffixedNumber::MANDATORY_SUFFIX |
-                                                                     CLI::SuffixedNumber::CASE_INSENSITIVE)));
+        ->transform(CLI::AsNumberWithUnit(mapping,
+                                          CLI::AsNumberWithUnit::Options(CLI::AsNumberWithUnit::UNIT_REQUIRED |
+                                                                         CLI::AsNumberWithUnit::CASE_INSENSITIVE)));
 
     args = {"-n", "42A"};
     run();
@@ -556,20 +556,20 @@ TEST_F(TApp, SuffixedNumberMandatorySuffix2) {
     EXPECT_THROW(run(), CLI::ValidationError);
 }
 
-TEST_F(TApp, SuffixedNumberBadMapping) {
-    EXPECT_THROW(
-        CLI::SuffixedNumber(std::map<std::string, int>{{"a", 10}, {"A", 100}}, CLI::SuffixedNumber::CASE_INSENSITIVE),
-        CLI::ValidationError);
-    EXPECT_THROW(CLI::SuffixedNumber(std::map<std::string, int>{{"a", 10}, {"9", 100}}), CLI::ValidationError);
-    EXPECT_THROW(CLI::SuffixedNumber(std::map<std::string, int>{{"a", 10}, {"AA A", 100}}), CLI::ValidationError);
-    EXPECT_THROW(CLI::SuffixedNumber(std::map<std::string, int>{{"a", 10}, {"", 100}}), CLI::ValidationError);
+TEST_F(TApp, NumberWithUnitBadMapping) {
+    EXPECT_THROW(CLI::AsNumberWithUnit(std::map<std::string, int>{{"a", 10}, {"A", 100}},
+                                       CLI::AsNumberWithUnit::CASE_INSENSITIVE),
+                 CLI::ValidationError);
+    EXPECT_THROW(CLI::AsNumberWithUnit(std::map<std::string, int>{{"a", 10}, {"9", 100}}), CLI::ValidationError);
+    EXPECT_THROW(CLI::AsNumberWithUnit(std::map<std::string, int>{{"a", 10}, {"AA A", 100}}), CLI::ValidationError);
+    EXPECT_THROW(CLI::AsNumberWithUnit(std::map<std::string, int>{{"a", 10}, {"", 100}}), CLI::ValidationError);
 }
 
-TEST_F(TApp, SuffixedNumberBadInput) {
+TEST_F(TApp, NumberWithUnitBadInput) {
     std::map<std::string, int> mapping{{"a", 10}, {"b", 100}};
 
     int value;
-    app.add_option("-n", value)->transform(CLI::SuffixedNumber(mapping));
+    app.add_option("-n", value)->transform(CLI::AsNumberWithUnit(mapping));
 
     args = {"-n", "13 a b"};
     EXPECT_THROW(run(), CLI::ValidationError);
@@ -587,11 +587,11 @@ TEST_F(TApp, SuffixedNumberBadInput) {
     EXPECT_THROW(run(), CLI::ValidationError);
 }
 
-TEST_F(TApp, SuffixedNumberIntOverlow) {
+TEST_F(TApp, NumberWithUnitIntOverflow) {
     std::map<std::string, int> mapping{{"a", 1000000}, {"b", 100}, {"c", 101}};
 
     int32_t value;
-    app.add_option("-n", value)->transform(CLI::SuffixedNumber(mapping));
+    app.add_option("-n", value)->transform(CLI::AsNumberWithUnit(mapping));
 
     args = {"-n", "1000 a"};
     run();
@@ -611,11 +611,11 @@ TEST_F(TApp, SuffixedNumberIntOverlow) {
     EXPECT_THROW(run(), CLI::ValidationError);
 }
 
-TEST_F(TApp, SuffixedNumberFloatOverlow) {
+TEST_F(TApp, NumberWithUnitFloatOverflow) {
     std::map<std::string, float> mapping{{"a", 2}, {"b", 1}, {"c", 0}};
 
     float value;
-    app.add_option("-n", value)->transform(CLI::SuffixedNumber(mapping));
+    app.add_option("-n", value)->transform(CLI::AsNumberWithUnit(mapping));
 
     args = {"-n", "3e+38 a"};
     EXPECT_THROW(run(), CLI::ValidationError);

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -635,14 +635,14 @@ TEST_F(TApp, AsSizeValue1000_1024) {
 
     args = {"-s", "10240"};
     run();
-    EXPECT_EQ(value, 10240);
+    EXPECT_EQ(value, 10240u);
 
     args = {"-s", "1b"};
     run();
     EXPECT_FLOAT_EQ(value, 1);
 
-    uint64_t k_value = 1000;
-    uint64_t ki_value = 1024;
+    uint64_t k_value = 1000u;
+    uint64_t ki_value = 1024u;
     args = {"-s", "1k"};
     run();
     EXPECT_EQ(value, k_value);
@@ -659,8 +659,8 @@ TEST_F(TApp, AsSizeValue1000_1024) {
     run();
     EXPECT_EQ(value, ki_value);
 
-    k_value = 1000ull * 1000;
-    ki_value = 1024ull * 1024;
+    k_value = 1000ull * 1000u;
+    ki_value = 1024ull * 1024u;
     args = {"-s", "1m"};
     run();
     EXPECT_EQ(value, k_value);
@@ -674,8 +674,8 @@ TEST_F(TApp, AsSizeValue1000_1024) {
     run();
     EXPECT_EQ(value, ki_value);
 
-    k_value = 1000ull * 1000 * 1000;
-    ki_value = 1024ull * 1024 * 1024;
+    k_value = 1000ull * 1000u * 1000u;
+    ki_value = 1024ull * 1024u * 1024u;
     args = {"-s", "1g"};
     run();
     EXPECT_EQ(value, k_value);
@@ -689,8 +689,8 @@ TEST_F(TApp, AsSizeValue1000_1024) {
     run();
     EXPECT_EQ(value, ki_value);
 
-    k_value = 1000ull * 1000 * 1000 * 1000;
-    ki_value = 1024ull * 1024 * 1024 * 1024;
+    k_value = 1000ull * 1000u * 1000u * 1000u;
+    ki_value = 1024ull * 1024u * 1024u * 1024u;
     args = {"-s", "1t"};
     run();
     EXPECT_EQ(value, k_value);
@@ -704,8 +704,8 @@ TEST_F(TApp, AsSizeValue1000_1024) {
     run();
     EXPECT_EQ(value, ki_value);
 
-    k_value = 1000ull * 1000 * 1000 * 1000 * 1000;
-    ki_value = 1024ull * 1024 * 1024 * 1024 * 1024;
+    k_value = 1000ull * 1000u * 1000u * 1000u * 1000u;
+    ki_value = 1024ull * 1024u * 1024u * 1024u * 1024u;
     args = {"-s", "1p"};
     run();
     EXPECT_EQ(value, k_value);
@@ -719,8 +719,8 @@ TEST_F(TApp, AsSizeValue1000_1024) {
     run();
     EXPECT_EQ(value, ki_value);
 
-    k_value = 1000ull * 1000 * 1000 * 1000 * 1000 * 1000;
-    ki_value = 1024ull * 1024 * 1024 * 1024 * 1024 * 1024;
+    k_value = 1000ull * 1000u * 1000u * 1000u * 1000u * 1000u;
+    ki_value = 1024ull * 1024u * 1024u * 1024u * 1024u * 1024u;
     args = {"-s", "1e"};
     run();
     EXPECT_EQ(value, k_value);
@@ -741,13 +741,13 @@ TEST_F(TApp, AsSizeValue1024) {
 
     args = {"-s", "10240"};
     run();
-    EXPECT_EQ(value, 10240);
+    EXPECT_EQ(value, 10240u);
 
     args = {"-s", "1b"};
     run();
     EXPECT_FLOAT_EQ(value, 1);
 
-    uint64_t ki_value = 1024;
+    uint64_t ki_value = 1024u;
     args = {"-s", "1k"};
     run();
     EXPECT_EQ(value, ki_value);
@@ -764,7 +764,7 @@ TEST_F(TApp, AsSizeValue1024) {
     run();
     EXPECT_EQ(value, ki_value);
 
-    ki_value = 1024ull * 1024;
+    ki_value = 1024ull * 1024u;
     args = {"-s", "1m"};
     run();
     EXPECT_EQ(value, ki_value);
@@ -778,7 +778,7 @@ TEST_F(TApp, AsSizeValue1024) {
     run();
     EXPECT_EQ(value, ki_value);
 
-    ki_value = 1024ull * 1024 * 1024;
+    ki_value = 1024ull * 1024u * 1024u;
     args = {"-s", "1g"};
     run();
     EXPECT_EQ(value, ki_value);
@@ -792,7 +792,7 @@ TEST_F(TApp, AsSizeValue1024) {
     run();
     EXPECT_EQ(value, ki_value);
 
-    ki_value = 1024ull * 1024 * 1024 * 1024;
+    ki_value = 1024ull * 1024u * 1024u * 1024u;
     args = {"-s", "1t"};
     run();
     EXPECT_EQ(value, ki_value);
@@ -806,7 +806,7 @@ TEST_F(TApp, AsSizeValue1024) {
     run();
     EXPECT_EQ(value, ki_value);
 
-    ki_value = 1024ull * 1024 * 1024 * 1024 * 1024;
+    ki_value = 1024ull * 1024u * 1024u * 1024u * 1024u;
     args = {"-s", "1p"};
     run();
     EXPECT_EQ(value, ki_value);
@@ -820,7 +820,7 @@ TEST_F(TApp, AsSizeValue1024) {
     run();
     EXPECT_EQ(value, ki_value);
 
-    ki_value = 1024ull * 1024 * 1024 * 1024 * 1024 * 1024;
+    ki_value = 1024ull * 1024u * 1024u * 1024u * 1024u * 1024u;
     args = {"-s", "1e"};
     run();
     EXPECT_EQ(value, ki_value);


### PR DESCRIPTION
This PR adds infrastructure for accepting inputs in form `<number> <unit>`. This covers things like size inputs, durations, and many more. `<suffix>` may or may not be separated from the number with space, must contain only letters and optionally can be matched case-insensitively.

`CLI::AsNumberWithUnit` takes a mapping from unit to factor. Transformation for durations may look like this:
```
map<string, double> m = {{"ns", 1e-9}, {"us", 1e-6}, {"ms", 1e-3}, {"s", 1}, {"m", 60}};
app.add_option("-d", duration)->transform(CLI::AsNumberWithUnit(mapping));
```
Transformation for size is already provided:
```
app.add_option("-s", size)->transform(CLI::AsSizeValue(true));
```

 