### PR TITLE
Make ConfigVersion arch independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,12 +96,8 @@ endif()
 # import Targets.cmake
 
 # Add the version in a CMake readable way
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    CLI11ConfigVersion.cmake
-    VERSION ${CLI11_VERSION}
-    COMPATIBILITY AnyNewerVersion
-    )
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CLI11ConfigVersion.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/CLI11ConfigVersion.cmake" @ONLY)
 
 # These installs only make sense for a local project
 if(CUR_PROJ)

--- a/cmake/CLI11ConfigVersion.cmake.in
+++ b/cmake/CLI11ConfigVersion.cmake.in
@@ -1,0 +1,13 @@
+# Adapted from write_basic_package_version_file(... COMPATIBILITY AnyNewerVersion) output
+# ARCH_INDEPENDENT is only present in cmake 3.14 and onwards
+
+set(PACKAGE_VERSION "@VERSION_STRING@")
+
+if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+  set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+    set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()


### PR DESCRIPTION
CLI11 is header only and the architecture shouldn't matter. The arch
dependence has the potential to cause find_package to fail incorrectly.