### PR TITLE
Resolve two switch related warnings on GCC 8

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2230,6 +2230,9 @@ class App {
             if(!detail::split_windows_style(current, arg_name, value))
                 throw HorribleError("windows option parsed but missing! You should not see this");
             break;
+        case detail::Classifier::SUBCOMMAND:
+        case detail::Classifier::POSITIONAL_MARK:
+        case detail::Classifier::NONE:
         default:
             throw HorribleError("parsing got called with invalid option! You should not see this");
         }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2090,6 +2090,9 @@ class App {
             if(positionals_at_end_) {
                 positional_only = true;
             }
+            break;
+        default:
+            HorribleError("unrecognized classifier (you should not see this!)");
         }
     }
 

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2091,8 +2091,11 @@ class App {
                 positional_only = true;
             }
             break;
+
+            // LCOV_EXCL_START
         default:
             HorribleError("unrecognized classifier (you should not see this!)");
+            // LCOV_EXCL_END
         }
     }
 


### PR DESCRIPTION
These two commits resolve one `switch-default` warning and three `switch-enum` warnings raised under GCC 8.