### PR TITLE
Positional argument checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,9 @@ CLI11 has several Validators built-in that perform some common checks
 -   `CLI::ExistingPath`: Requires that the path (file or directory) exists.
 -   `CLI::NonexistentPath`: Requires that the path does not exist.
 -   `CLI::Range(min,max)`: Requires that the option be between min and max (make sure to use floating point if needed). Min defaults to 0.
--   `CLI::Bounded(min,max)`: 🚧 Modify the input such that it is always between min and max (make sure to use floating point if needed). Min defaults to 0.  Will produce an Error if conversion is not possible.
--   `CLI::PositiveNumber`: 🚧 Requires the number be greater or equal to 0.
+-   `CLI::Bounded(min,max)`: 🚧 Modify the input such that it is always between min and max (make sure to use floating point if needed). Min defaults to 0.  Will produce an error if conversion is not possible.
+-   `CLI::PositiveNumber`: 🚧 Requires the number be greater or equal to 0
+-   `CLI::Number`: 🚧 Requires the input be a number.
 -   `CLI::ValidIPV4`: 🚧 Requires that the option be a valid IPv4 string e.g. `'255.255.255.255'`, `'10.1.1.7'`.
 
 These Validators can be used by simply passing the name into the `check` or `transform` methods on an option
@@ -467,6 +468,7 @@ There are several options that are supported on the main app and subcommands and
 -   `.disable()`: 🚧 Specify that the subcommand is disabled, if given with a bool value it will enable or disable the subcommand or option group.
 -   `.disabled_by_default()`:🚧 Specify that at the start of parsing the subcommand/option_group should be disabled. This is useful for allowing some Subcommands to trigger others.
 -   `.enabled_by_default()`: 🚧 Specify that at the start of each parse the subcommand/option_group should be enabled.  This is useful for allowing some Subcommands to disable others.
+-   `.validate_positionals()`:🚧 Specify that positionals should pass validation before matching.  Validation is specified through `transform`, `check`, and `each` for an option.  If an argument fails validation it is not an error and matching proceeds to the next available positional or extra arguments.  
 -   `.excludes(option_or_subcommand)`: 🚧 If given an option pointer or pointer to another subcommand, these subcommands cannot be given together.  In the case of options, if the option is passed the subcommand cannot be used and will generate an error.  
 -   `.require_option()`: 🚧 Require 1 or more options or option groups be used.
 -   `.require_option(N)`:  🚧 Require `N` options or option groups, if `N>0`, or up to `N` if `N<0`. `N=0` resets to the default to 0 or more.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -109,6 +109,22 @@ add_test(NAME positional_arity_fail COMMAND positional_arity 1 one two)
 set_property(TEST positional_arity_fail PROPERTY PASS_REGULAR_EXPRESSION
     "Could not convert")
 
+    add_cli_exe(positional_validation positional_validation.cpp)
+add_test(NAME positional_validation1 COMMAND positional_validation one )
+set_property(TEST positional_validation1 PROPERTY PASS_REGULAR_EXPRESSION
+    "File 1 = one")
+add_test(NAME positional_validation2 COMMAND positional_validation one 1 2 two )
+set_property(TEST positional_validation2 PROPERTY PASS_REGULAR_EXPRESSION
+    "File 1 = one"
+    "File 2 = two")
+add_test(NAME positional_validation3 COMMAND positional_validation 1 2 one)
+set_property(TEST positional_validation3 PROPERTY PASS_REGULAR_EXPRESSION
+    "File 1 = one")
+add_test(NAME positional_validation4 COMMAND positional_validation 1 one two 2)
+set_property(TEST positional_validation4 PROPERTY PASS_REGULAR_EXPRESSION
+     "File 1 = one"
+    "File 2 = two")
+
 add_cli_exe(shapes shapes.cpp)
 add_test(NAME shapes_all COMMAND shapes circle 4.4 circle 10.7 rectangle 4 4 circle 2.3 triangle 4.5 ++ rectangle 2.1 ++ circle 234.675)
 set_property(TEST shapes_all PROPERTY PASS_REGULAR_EXPRESSION

--- a/examples/positional_validation.cpp
+++ b/examples/positional_validation.cpp
@@ -1,0 +1,29 @@
+#include "CLI/CLI.hpp"
+
+int main(int argc, char **argv) {
+
+    CLI::App app("test for positional validation");
+
+    int num1 = -1, num2 = -1;
+    app.add_option("num1", num1, "first number")->check(CLI::Number);
+    app.add_option("num2", num2, "second number")->check(CLI::Number);
+    std::string file1, file2;
+    app.add_option("file1", file1, "first file")->required();
+    app.add_option("file2", file2, "second file");
+    app.validate_positionals();
+
+    CLI11_PARSE(app, argc, argv);
+
+    if(num1 != -1)
+        std::cout << "Num1 = " << num1 << '\n';
+
+    if(num2 != -1)
+        std::cout << "Num2 = " << num2 << '\n';
+
+    std::cout << "File 1 = " << file1 << '\n';
+    if(!file2.empty()) {
+        std::cout << "File 2 = " << file2 << '\n';
+    }
+
+    return 0;
+}

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -489,7 +489,7 @@ class App {
         return add_option(option_name, CLI::callback_t(), option_description, false);
     }
 
-    /// Add option for non-vectors with a default print
+    /// Add option for non-vectors with a default print, allow template to specify conversion type
     template <typename T,
               typename XC = T,
               enable_if_t<!is_vector<XC>::value && !std::is_const<XC>::value, detail::enabler> = detail::dummy>
@@ -497,7 +497,7 @@ class App {
                        T &variable, ///< The variable to set
                        std::string option_description,
                        bool defaulted) {
-
+        static_assert(std::is_constructible<T, XC>::value, "assign type must be assignable from conversion type");
         CLI::callback_t fun = [&variable](CLI::results_t res) { return detail::lexical_cast<XC>(res[0], variable); };
 
         Option *opt = add_option(option_name, fun, option_description, defaulted);
@@ -2193,7 +2193,7 @@ class App {
                 op->add_result(res);
 
             } else {
-                op->set_results(item.inputs);
+                op->add_result(item.inputs);
                 op->run_callback();
             }
         }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -491,16 +491,17 @@ class App {
 
     /// Add option for non-vectors with a default print
     template <typename T,
-              enable_if_t<!is_vector<T>::value && !std::is_const<T>::value, detail::enabler> = detail::dummy>
+              typename XC = T,
+              enable_if_t<!is_vector<XC>::value && !std::is_const<XC>::value, detail::enabler> = detail::dummy>
     Option *add_option(std::string option_name,
                        T &variable, ///< The variable to set
                        std::string option_description,
                        bool defaulted) {
 
-        CLI::callback_t fun = [&variable](CLI::results_t res) { return detail::lexical_cast(res[0], variable); };
+        CLI::callback_t fun = [&variable](CLI::results_t res) { return detail::lexical_cast<XC>(res[0], variable); };
 
         Option *opt = add_option(option_name, fun, option_description, defaulted);
-        opt->type_name(detail::type_name<T>());
+        opt->type_name(detail::type_name<XC>());
         if(defaulted) {
             std::stringstream out;
             out << variable;

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -666,19 +666,11 @@ class Option : public OptionBase<Option> {
 
         // Run the validators (can change the string)
         if(!validators_.empty()) {
-            for(std::string &result : results_)
-                for(const auto &vali : validators_) {
-                    std::string err_msg;
-
-                    try {
-                        err_msg = vali(result);
-                    } catch(const ValidationError &err) {
-                        throw ValidationError(get_name(), err.what());
-                    }
-
-                    if(!err_msg.empty())
-                        throw ValidationError(get_name(), err_msg);
-                }
+            for(std::string &result : results_) {
+                auto err_msg = _validate(result);
+                if(!err_msg.empty())
+                    throw ValidationError(get_name(), err_msg);
+            }
         }
         if(!(callback_)) {
             return;
@@ -956,6 +948,21 @@ class Option : public OptionBase<Option> {
     }
 
   private:
+    // run through the validators
+    std::string _validate(std::string &result) {
+        std::string err_msg;
+        for(const auto &vali : validators_) {
+            try {
+                err_msg = vali(result);
+            } catch(const ValidationError &err) {
+                err_msg = err.what();
+            }
+            if(!err_msg.empty())
+                break;
+        }
+        return err_msg;
+    }
+
     int _add_result(std::string &&result) {
         int result_count = 0;
         if(delimiter_ == '\0') {

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -842,13 +842,6 @@ class Option : public OptionBase<Option> {
         return this;
     }
 
-    /// Set the results vector all at once
-    Option *set_results(std::vector<std::string> result_vector) {
-        results_ = std::move(result_vector);
-        callback_run_ = false;
-        return this;
-    }
-
     /// Get a copy of the results
     std::vector<std::string> results() const { return results_; }
 

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -435,10 +435,9 @@ template <typename T> std::string generate_set(const T &set) {
     using element_t = typename detail::element_type<T>::type;
     using iteration_type_t = typename detail::pair_adaptor<element_t>::value_type; // the type of the object pair
     std::string out(1, '{');
-    out.append(detail::join(
-        detail::smart_deref(set),
-        [](const iteration_type_t &v) { return detail::pair_adaptor<element_t>::first(v); },
-        ","));
+    out.append(detail::join(detail::smart_deref(set),
+                            [](const iteration_type_t &v) { return detail::pair_adaptor<element_t>::first(v); },
+                            ","));
     out.push_back('}');
     return out;
 }
@@ -448,13 +447,12 @@ template <typename T> std::string generate_map(const T &map) {
     using element_t = typename detail::element_type<T>::type;
     using iteration_type_t = typename detail::pair_adaptor<element_t>::value_type; // the type of the object pair
     std::string out(1, '{');
-    out.append(detail::join(
-        detail::smart_deref(map),
-        [](const iteration_type_t &v) {
-            return detail::as_string(detail::pair_adaptor<element_t>::first(v)) + "->" +
-                   detail::as_string(detail::pair_adaptor<element_t>::second(v));
-        },
-        ","));
+    out.append(detail::join(detail::smart_deref(map),
+                            [](const iteration_type_t &v) {
+                                return detail::as_string(detail::pair_adaptor<element_t>::first(v)) + "->" +
+                                       detail::as_string(detail::pair_adaptor<element_t>::second(v));
+                            },
+                            ","));
     out.push_back('}');
     return out;
 }
@@ -570,10 +568,9 @@ class IsMember : public Validator {
     /// You can pass in as many filter functions as you like, they nest (string only currently)
     template <typename T, typename... Args>
     IsMember(T &&set, filter_fn_t filter_fn_1, filter_fn_t filter_fn_2, Args &&... other)
-        : IsMember(
-              std::forward<T>(set),
-              [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
-              other...) {}
+        : IsMember(std::forward<T>(set),
+                   [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
+                   other...) {}
 };
 
 /// definition of the default transformation object
@@ -631,10 +628,9 @@ class Transformer : public Validator {
     /// You can pass in as many filter functions as you like, they nest
     template <typename T, typename... Args>
     Transformer(T &&mapping, filter_fn_t filter_fn_1, filter_fn_t filter_fn_2, Args &&... other)
-        : Transformer(
-              std::forward<T>(mapping),
-              [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
-              other...) {}
+        : Transformer(std::forward<T>(mapping),
+                      [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
+                      other...) {}
 };
 
 /// translate named items to other or a value set
@@ -708,10 +704,9 @@ class CheckedTransformer : public Validator {
     /// You can pass in as many filter functions as you like, they nest
     template <typename T, typename... Args>
     CheckedTransformer(T &&mapping, filter_fn_t filter_fn_1, filter_fn_t filter_fn_2, Args &&... other)
-        : CheckedTransformer(
-              std::forward<T>(mapping),
-              [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
-              other...) {}
+        : CheckedTransformer(std::forward<T>(mapping),
+                             [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
+                             other...) {}
 }; // namespace CLI
 
 /// Helper function to allow ignore_case to be passed to IsMember or Transform

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -962,6 +962,27 @@ TEST_F(TApp, PositionalAtEnd) {
     EXPECT_THROW(run(), CLI::ExtrasError);
 }
 
+// Tests positionals at end
+TEST_F(TApp, PositionalValidation) {
+    std::string options;
+    std::string foo;
+
+    app.add_option("bar", options)->check(CLI::Number);
+    app.add_option("foo", foo);
+    app.validate_positionals();
+    args = {"1", "param1"};
+    run();
+
+    EXPECT_EQ(options, "1");
+    EXPECT_EQ(foo, "param1");
+
+    args = {"param1", "1"};
+    run();
+
+    EXPECT_EQ(options, "1");
+    EXPECT_EQ(foo, "param1");
+}
+
 TEST_F(TApp, PositionalNoSpaceLong) {
     std::vector<std::string> options;
     std::string foo, bar;

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -467,7 +467,7 @@ TEST_F(TApp, GetNameCheck) {
 }
 
 TEST_F(TApp, SubcommandDefaults) {
-    // allow_extras, prefix_command, ignore_case, fallthrough, group, min/max subcommand
+    // allow_extras, prefix_command, ignore_case, fallthrough, group, min/max subcommand, validate_positionals
 
     // Initial defaults
     EXPECT_FALSE(app.get_allow_extras());
@@ -481,6 +481,8 @@ TEST_F(TApp, SubcommandDefaults) {
     EXPECT_FALSE(app.get_allow_windows_style_options());
 #endif
     EXPECT_FALSE(app.get_fallthrough());
+    EXPECT_FALSE(app.get_validate_positionals());
+
     EXPECT_EQ(app.get_footer(), "");
     EXPECT_EQ(app.get_group(), "Subcommands");
     EXPECT_EQ(app.get_require_subcommand_min(), 0u);
@@ -498,6 +500,7 @@ TEST_F(TApp, SubcommandDefaults) {
 #endif
 
     app.fallthrough();
+    app.validate_positionals();
     app.footer("footy");
     app.group("Stuff");
     app.require_subcommand(2, 3);
@@ -516,6 +519,7 @@ TEST_F(TApp, SubcommandDefaults) {
     EXPECT_TRUE(app2->get_allow_windows_style_options());
 #endif
     EXPECT_TRUE(app2->get_fallthrough());
+    EXPECT_TRUE(app2->get_validate_positionals());
     EXPECT_EQ(app2->get_footer(), "footy");
     EXPECT_EQ(app2->get_group(), "Stuff");
     EXPECT_EQ(app2->get_require_subcommand_min(), 0u);

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -239,6 +239,21 @@ TEST(Validators, PositiveValidator) {
     EXPECT_FALSE(CLI::PositiveNumber(num).empty());
 }
 
+TEST(Validators, NumberValidator) {
+    std::string num = "1.1.1.1";
+    EXPECT_FALSE(CLI::Number(num).empty());
+    num = "1.7";
+    EXPECT_TRUE(CLI::Number(num).empty());
+    num = "10000";
+    EXPECT_TRUE(CLI::Number(num).empty());
+    num = "-0.000";
+    EXPECT_TRUE(CLI::Number(num).empty());
+    num = "+1.55";
+    EXPECT_TRUE(CLI::Number(num).empty());
+    num = "a";
+    EXPECT_FALSE(CLI::Number(num).empty());
+}
+
 TEST(Validators, CombinedAndRange) {
     auto crange = CLI::Range(0, 12) & CLI::Range(4, 16);
     EXPECT_TRUE(crange("4").empty());

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -64,8 +64,7 @@ TEST_F(TApp, BoostOptionalTest) {
 
 TEST_F(TApp, BoostOptionalVector) {
     boost::optional<std::vector<int>> opt;
-    app.add_option_function<std::vector<int>>(
-           "-v,--vec", [&opt](auto &v) { opt = v; }, "some vector")
+    app.add_option_function<std::vector<int>>("-v,--vec", [&opt](const std::vector<int> &v) { opt = v; }, "some vector")
         ->expected(3);
     run();
     EXPECT_FALSE(opt);

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -62,6 +62,21 @@ TEST_F(TApp, BoostOptionalTest) {
     EXPECT_EQ(*opt, 3);
 }
 
+TEST_F(TApp, BoostOptionalVector) {
+    boost::optional<std::vector<int>> opt;
+    app.add_option_function<std::vector<int>>(
+           "-v,--vec", [&opt](auto &v) { opt = v; }, "some vector")
+        ->expected(3);
+    run();
+    EXPECT_FALSE(opt);
+
+    args = {"-v", "1", "4", "5"};
+    run();
+    EXPECT_TRUE(opt);
+    std::vector<int> expV{1, 4, 5};
+    EXPECT_EQ(*opt, expV);
+}
+
 #endif
 
 #if !CLI11_OPTIONAL


### PR DESCRIPTION
If merged this PR will add an option to require positional arguments to pass validation before matching.    This would allow creating positionals for a file and number and allowing them to be entered in any order on the command line.  

Modifications include adding `validate_positionals` function on App
moving the `_validate` code into a separate function in options.
removing the `set_results` function in options which was being used by config file functions but it was bypassing some of the result processing, which could cause some issues if the delimiter option was also being used.  

Also tweaked the template for add_option to separate out the lexical_cast type from the assignment type if desired.  (Probably need a few more tests of this yet).  
