### PR TITLE
Alignment in multiline description

### DIFF
--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -164,7 +164,12 @@ inline std::ostream &format_help(std::ostream &out, std::string name, std::strin
     if(!description.empty()) {
         if(name.length() >= wid)
             out << "\n" << std::setw(static_cast<int>(wid)) << "";
-        out << description;
+        for(const char c : description) {
+            out.put(c);
+            if(c == '\n') {
+                out << std::setw(static_cast<int>(wid)) << "";
+            }
+        }
     }
     out << "\n";
     return out;

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -470,6 +470,18 @@ TEST(THelp, CustomHelp) {
     }
 }
 
+TEST(THelp, NextLineShouldBeAlignmentInMultilineDescription) {
+    CLI::App app;
+    int i;
+    const std::string first{"first line"};
+    const std::string second{"second line"};
+    app.add_option("-i,--int", i, first + "\n" + second);
+
+    const std::string help = app.help();
+    const auto width = app.get_formatter()->get_column_width();
+    EXPECT_THAT(help, HasSubstr(first + "\n" + std::string(width, ' ') + second));
+}
+
 TEST(THelp, NiceName) {
     CLI::App app;
 


### PR DESCRIPTION
Hi, 
I want to propose formatting for multiline description in help.
Next line of description should be alignment to first.

Regards,
elszon