### PR TITLE
remove undefined bahavior

### DIFF
--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 // Distributed under the 3-Clause BSD License.  See accompanying
 // file LICENSE or https://github.com/CLIUtils/CLI11 for details.
 
@@ -9,6 +8,7 @@
 #include <cmath>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -509,18 +509,26 @@ auto search(const T &set, const V &val, const std::function<V(V)> &filter_functi
     });
     return {(it != std::end(setref)), it};
 }
+/// Generate the absolute value of a number
+template <typename T> inline typename std::enable_if<std::is_signed<T>::value, T>::type absval(T a) {
+    return static_cast<T>((std::abs)(a));
+}
+/// unsigned values just return the value
+template <typename T> inline typename std::enable_if<!std::is_signed<T>::value, T>::type absval(T a) { return a; }
 
 /// Performs a *= b; if it doesn't cause integer overflow. Returns false otherwise.
 template <typename T> typename std::enable_if<std::is_integral<T>::value, bool>::type checked_multiply(T &a, T b) {
-    if(a == 0 || b == 0) {
+    if(a == 0 || b == 0 || a == 1 || b == 1) {
         a *= b;
         return true;
     }
-    T c = a * b;
-    if(c / a != b) {
+    if(a == (std::numeric_limits<T>::min)() || b == (std::numeric_limits<T>::min)()) {
         return false;
     }
-    a = c;
+    if((std::numeric_limits<T>::max)() / absval(a) < absval(b)) {
+        return false;
+    }
+    a *= b;
     return true;
 }
 

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -423,10 +423,20 @@ TEST(CheckedMultiply, Int) {
     ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<int>::min());
 
+    b = std::numeric_limits<int>::min();
+    a = -1;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, -1);
+
     a = std::numeric_limits<int>::min() / 100;
     b = 99;
     ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<int>::min() / 100 * 99);
+
+    a = std::numeric_limits<int>::min() / 100;
+    b = -101;
+    ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
+    ASSERT_EQ(a, std::numeric_limits<int>::min() / 100);
 }
 
 TEST(CheckedMultiply, SizeT) {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -437,6 +437,20 @@ TEST(CheckedMultiply, Int) {
     b = -101;
     ASSERT_FALSE(CLI::detail::checked_multiply(a, b));
     ASSERT_EQ(a, std::numeric_limits<int>::min() / 100);
+    a = 2;
+    b = std::numeric_limits<int>::min() / 2;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+    a = std::numeric_limits<int>::min() / 2;
+    b = 2;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+
+    a = 4;
+    b = std::numeric_limits<int>::min() / 4;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
+
+    a = 48;
+    b = std::numeric_limits<int>::min() / 48;
+    ASSERT_TRUE(CLI::detail::checked_multiply(a, b));
 }
 
 TEST(CheckedMultiply, SizeT) {


### PR DESCRIPTION
change the checked_multiply function to not use undefined behavior to check for potential undefined behavior and wrapping.

See Issue #289