### PR TITLE
Fix std::string_view support in transforming validators

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -9,9 +9,12 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+
+// [CLI11:verbatim]
 #if defined(CLI11_CPP17)
 #include <string_view>
 #endif
+// [CLI11:verbatim]
 
 namespace CLI {
 

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -9,6 +9,9 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#if defined(CLI11_CPP17)
+#include <string_view>
+#endif
 
 namespace CLI {
 
@@ -71,6 +74,10 @@ template <typename T> struct IsMemberType { using type = T; };
 
 /// The main custom type needed here is const char * should be a string.
 template <> struct IsMemberType<const char *> { using type = std::string; };
+
+#if defined(CLI11_CPP17)
+template <> struct IsMemberType<std::string_view> { using type = std::string; };
+#endif
 
 namespace detail {
 

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -12,7 +12,12 @@
 
 // [CLI11:verbatim]
 #if defined(CLI11_CPP17)
+#if defined(__has_include)
+#if __has_include(<string_view>)
 #include <string_view>
+#define CLI11_HAS_STRING_VIEW
+#endif
+#endif
 #endif
 // [CLI11:verbatim]
 
@@ -78,7 +83,7 @@ template <typename T> struct IsMemberType { using type = T; };
 /// The main custom type needed here is const char * should be a string.
 template <> struct IsMemberType<const char *> { using type = std::string; };
 
-#if defined(CLI11_CPP17)
+#ifdef CLI11_HAS_STRING_VIEW
 template <> struct IsMemberType<std::string_view> { using type = std::string; };
 #endif
 

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -503,7 +503,7 @@ auto search(const T &set, const V &val, const std::function<V(V)> &filter_functi
     // if we haven't found it do the longer linear search with all the element translations
     auto &setref = detail::smart_deref(set);
     auto it = std::find_if(std::begin(setref), std::end(setref), [&](decltype(*std::begin(setref)) v) {
-        V a = detail::pair_adaptor<element_t>::first(v);
+        V a{detail::pair_adaptor<element_t>::first(v)};
         a = filter_function(a);
         return (a == val);
     });

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -105,11 +105,8 @@ TEST_F(TApp, SimpleTransformFn) {
 #if defined(CLI11_CPP17)
 TEST_F(TApp, StringViewTransformFn) {
     std::string value;
-    std::map<std::string_view, std::string_view> map =
-    {
-      // key length > std::string().capacity() [SSO length]
-      {"a-rather-long-argument", "mapped"}
-    };
+    std::map<std::string_view, std::string_view> map = {// key length > std::string().capacity() [SSO length]
+                                                        {"a-rather-long-argument", "mapped"}};
     app.add_option("-s", value)->transform(CLI::CheckedTransformer(map));
     args = {"-s", "a-rather-long-argument"};
     run();

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -102,6 +102,21 @@ TEST_F(TApp, SimpleTransformFn) {
     EXPECT_EQ(value, 1);
 }
 
+#if defined(CLI11_CPP17)
+TEST_F(TApp, StringViewTransformFn) {
+    std::string value;
+    std::map<std::string_view, std::string_view> map =
+    {
+      // key length > std::string().capacity() [SSO length]
+      {"a-rather-long-argument", "mapped"}
+    };
+    app.add_option("-s", value)->transform(CLI::CheckedTransformer(map));
+    args = {"-s", "a-rather-long-argument"};
+    run();
+    EXPECT_EQ(value, "mapped");
+}
+#endif
+
 TEST_F(TApp, SimpleNumericalTransformFn) {
     int value;
     auto opt =

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -102,7 +102,7 @@ TEST_F(TApp, SimpleTransformFn) {
     EXPECT_EQ(value, 1);
 }
 
-#if defined(CLI11_CPP17)
+#if defined(CLI11_HAS_STRING_VIEW)
 TEST_F(TApp, StringViewTransformFn) {
     std::string value;
     std::map<std::string_view, std::string_view> map = {// key length > std::string().capacity() [SSO length]


### PR DESCRIPTION
Transforming validators convert ```const char *``` to ```std::string```, but don't do the same for ```std::string_view```. This causes UB in ```details::lexical_cast``` that returns ```std::string_view``` holding dangling pointer.