### PR TITLE
Indexed tuple validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ After I wrote this, I also found the following libraries:
 | [Clara][]               | Simple library built for the excellent [Catch][] testing framework. Unique syntax, limited scope.                                                                                    |
 | [Argh!][]               | Very minimalistic C++11 parser, single header. Don't have many features. No help generation?!?! At least it's exception-free.                                                        |
 | [CLI][]                 | Custom language and parser. Huge build-system overkill for very little benefit. Last release in 2009, but still occasionally active.  |
-|[argparse][] | C++17 single file argument parser. Design seems similar to CLI11 in some ways. |
+| [argparse][] | C++17 single file argument parser. Design seems similar to CLI11 in some ways. |
 
 See [Awesome C++][] for a less-biased list of parsers. You can also find other single file libraries at [Single file libs][].
 
@@ -194,7 +194,7 @@ While all options internally are the same type, there are several ways to add an
 app.add_option(option_name, help_str="") // 🆕
 
 app.add_option(option_name,
-               variable_to_bind_to, // bool, int, float, vector, 🆕 enum, or string-like, or anything with a defined conversion from a string or that takes an int🚧, double🚧, or string in a constructor. Also allowed are tuples(up to 5 elements) and tuple like structures such as std::array or std::pair.  
+               variable_to_bind_to, // bool, int, float, vector, 🆕 enum, or string-like, or anything with a defined conversion from a string or that takes an int🚧, double🚧, or string in a constructor. Also allowed are tuples🚧,std::array🚧 or std::pair🚧.  
                help_string="")
 
 app.add_option_function<type>(option_name,
@@ -202,7 +202,7 @@ app.add_option_function<type>(option_name,
                help_string="")
 
 app.add_complex(... // Special case: support for complex numbers
-//🚧There is a template overload which takes two template parameters the first is the type of object to assign the value to, the second is the conversion type.  The conversion type should have a known way to convert from a string, such as any of the types that work in the non-template version.  If XC is a std::pair and T is some non pair type.  Then a two argument constructor for T is called to assign the value.    
+//🚧There is a template overload which takes two template parameters the first is the type of object to assign the value to, the second is the conversion type.  The conversion type should have a known way to convert from a string, such as any of the types that work in the non-template version.  If XC is a std::pair and T is some non pair type.  Then a two argument constructor for T is called to assign the value.  For tuples or other multi element types, XC must be a single type or a tuple like object of the same size as the assignment type   
 app.add_option<typename T, typename XC>(option_name,
                T &output, // output must be assignable or constructible from a value of type XC
                help_string="")
@@ -261,7 +261,7 @@ otherwise the output would default to a string.  The add_option can be used with
 
 Type such as optional<int>, optional<double>, and optional<string> are supported directly, other optional types can be added using the two parameter template.  See [CLI11 Internals][] for information on how this could done and how you can add your own converters for additional  types.
 
-Vector types can also be used int the two parameter template overload
+Vector types can also be used in the two parameter template overload
 ```
 std::vector<double> v1;
 app.add_option<std::vector<double>,int>("--vs",v1);

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1859,8 +1859,14 @@ class App {
             return detail::Classifier::SUBCOMMAND;
         if(detail::split_long(current, dummy1, dummy2))
             return detail::Classifier::LONG;
-        if(detail::split_short(current, dummy1, dummy2))
+        if(detail::split_short(current, dummy1, dummy2)) {
+            if(dummy1[0] >= '0' && dummy1[0] <= '9') {
+                if(get_option_no_throw(std::string{'-', dummy1[0]}) == nullptr) {
+                    return detail::Classifier::NONE;
+                }
+            }
             return detail::Classifier::SHORT;
+        }
         if((allow_windows_style_options_) && (detail::split_windows_style(current, dummy1, dummy2)))
             return detail::Classifier::WINDOWS;
         if((current == "++") && !name_.empty() && parent_ != nullptr)
@@ -2314,7 +2320,7 @@ class App {
                            (opt->get_items_expected() < 0 && opt->count() == 0lu)) {
                             if(validate_positionals_) {
                                 std::string pos = positional;
-                                pos = opt->_validate(pos);
+                                pos = opt->_validate(pos, 0);
                                 if(!pos.empty()) {
                                     continue;
                                 }
@@ -2334,7 +2340,7 @@ class App {
                (static_cast<int>(opt->count()) < opt->get_items_expected() || opt->get_items_expected() < 0)) {
                 if(validate_positionals_) {
                     std::string pos = positional;
-                    pos = opt->_validate(pos);
+                    pos = opt->_validate(pos, 0);
                     if(!pos.empty()) {
                         continue;
                     }

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -43,6 +43,8 @@ class Validator {
     std::function<std::string(std::string &)> func_{[](std::string &) { return std::string{}; }};
     /// The name for search purposes of the Validator
     std::string name_;
+    /// A validate will only apply to an indexed value (-1 is all elements)
+    int application_index_ = -1;
     /// Enable for Validator to allow it to be disabled if need be
     bool active_{true};
     /// specify that a validator should not modify the input
@@ -113,7 +115,13 @@ class Validator {
         non_modifying_ = no_modify;
         return *this;
     }
-
+    /// Specify the application index of a validator
+    Validator &application_index(int app_index) {
+        application_index_ = app_index;
+        return *this;
+    };
+    /// Get the current value of the application index
+    int get_application_index() const { return application_index_; }
     /// Get a boolean if the validator is active
     bool get_active() const { return active_; }
 
@@ -141,6 +149,7 @@ class Validator {
         };
 
         newval.active_ = (active_ & other.active_);
+        newval.application_index_ = application_index_;
         return newval;
     }
 
@@ -164,6 +173,7 @@ class Validator {
             return std::string("(") + s1 + ") OR (" + s2 + ")";
         };
         newval.active_ = (active_ & other.active_);
+        newval.application_index_ = application_index_;
         return newval;
     }
 
@@ -186,6 +196,7 @@ class Validator {
             return std::string{};
         };
         newval.active_ = active_;
+        newval.application_index_ = application_index_;
         return newval;
     }
 
@@ -201,10 +212,10 @@ class Validator {
             if((f1.empty()) || (f2.empty())) {
                 return f1 + f2;
             }
-            return std::string("(") + f1 + ")" + merger + "(" + f2 + ")";
+            return std::string(1, '(') + f1 + ')' + merger + '(' + f2 + ')';
         };
     }
-};
+}; // namespace CLI
 
 /// Class wrapping some of the accessors of Validator
 class CustomValidator : public Validator {

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -43,7 +43,7 @@ class Validator {
     std::function<std::string(std::string &)> func_{[](std::string &) { return std::string{}; }};
     /// The name for search purposes of the Validator
     std::string name_;
-    /// A validate will only apply to an indexed value (-1 is all elements)
+    /// A Validator will only apply to an indexed value (-1 is all elements)
     int application_index_ = -1;
     /// Enable for Validator to allow it to be disabled if need be
     bool active_{true};
@@ -54,7 +54,7 @@ class Validator {
     Validator() = default;
     /// Construct a Validator with just the description string
     explicit Validator(std::string validator_desc) : desc_function_([validator_desc]() { return validator_desc; }) {}
-    // Construct Validator from basic information
+    /// Construct Validator from basic information
     Validator(std::function<std::string(std::string &)> op, std::string validator_desc, std::string validator_name = "")
         : desc_function_([validator_desc]() { return validator_desc; }), func_(std::move(op)),
           name_(std::move(validator_name)) {}
@@ -90,6 +90,12 @@ class Validator {
         desc_function_ = [validator_desc]() { return validator_desc; };
         return *this;
     }
+    /// Specify the type string
+    Validator description(std::string validator_desc) const {
+        Validator newval(*this);
+        newval.desc_function_ = [validator_desc]() { return validator_desc; };
+        return newval;
+    }
     /// Generate type description information for the Validator
     std::string get_description() const {
         if(active_) {
@@ -102,12 +108,24 @@ class Validator {
         name_ = std::move(validator_name);
         return *this;
     }
+    /// Specify the type string
+    Validator name(std::string validator_name) const {
+        Validator newval(*this);
+        newval.name_ = std::move(validator_name);
+        return newval;
+    }
     /// Get the name of the Validator
     const std::string &get_name() const { return name_; }
     /// Specify whether the Validator is active or not
     Validator &active(bool active_val = true) {
         active_ = active_val;
         return *this;
+    }
+    /// Specify whether the Validator is active or not
+    Validator active(bool active_val = true) const {
+        Validator newval(*this);
+        newval.active_ = active_val;
+        return newval;
     }
 
     /// Specify whether the Validator can be modifying or not
@@ -119,6 +137,12 @@ class Validator {
     Validator &application_index(int app_index) {
         application_index_ = app_index;
         return *this;
+    };
+    /// Specify the application index of a validator
+    Validator application_index(int app_index) const {
+        Validator newval(*this);
+        newval.application_index_ = app_index;
+        return newval;
     };
     /// Get the current value of the application index
     int get_application_index() const { return application_index_; }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1077,8 +1077,9 @@ TEST_F(TApp, PositionalValidation) {
     std::string options;
     std::string foo;
 
-    app.add_option("bar", options)->check(CLI::Number);
-    app.add_option("foo", foo);
+    app.add_option("bar", options)->check(CLI::Number.name("valbar"));
+    // disable the check on foo
+    app.add_option("foo", foo)->check(CLI::Number.active(false));
     app.validate_positionals();
     args = {"1", "param1"};
     run();
@@ -1087,10 +1088,12 @@ TEST_F(TApp, PositionalValidation) {
     EXPECT_EQ(foo, "param1");
 
     args = {"param1", "1"};
-    run();
+    EXPECT_NO_THROW(run());
 
     EXPECT_EQ(options, "1");
     EXPECT_EQ(foo, "param1");
+
+    EXPECT_NE(app.get_option("bar")->get_validator("valbar"), nullptr);
 }
 
 TEST_F(TApp, PositionalNoSpaceLong) {
@@ -1696,12 +1699,12 @@ TEST_F(TApp, VectorIndexedValidator) {
     run();
     EXPECT_EQ(4u, app.count("-v"));
     EXPECT_EQ(4u, vvec.size());
-    opt->check(CLI::Validator(CLI::PositiveNumber).application_index(0));
+    opt->check(CLI::PositiveNumber.application_index(0));
     opt->check((!CLI::PositiveNumber).application_index(1));
     EXPECT_NO_THROW(run());
     EXPECT_EQ(4u, vvec.size());
     // v[3] would be negative
-    opt->check(CLI::Validator(CLI::PositiveNumber).application_index(3));
+    opt->check(CLI::PositiveNumber.application_index(3));
     EXPECT_THROW(run(), CLI::ValidationError);
 }
 

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -798,6 +798,16 @@ TEST(THelp, ValidatorsText) {
     EXPECT_THAT(help, HasSubstr("UINT:INT in [0 - 12]")); // Loses UINT
 }
 
+TEST(THelp, ValidatorsTextCustom) {
+    CLI::App app;
+
+    std::string filename;
+    app.add_option("--f1", filename)->check(CLI::ExistingFile.description("Existing file"));
+
+    std::string help = app.help();
+    EXPECT_THAT(help, HasSubstr("Existing file"));
+}
+
 TEST(THelp, ValidatorsNonPathText) {
     CLI::App app;
 

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -836,6 +836,9 @@ TEST(Types, TypeName) {
     tuple_name = CLI::detail::type_name<std::tuple<int, std::string, double, unsigned int, std::string>>();
     EXPECT_EQ("[INT,TEXT,FLOAT,UINT,TEXT]", tuple_name);
 
+    tuple_name = CLI::detail::type_name<std::array<int, 10>>();
+    EXPECT_EQ("[INT,INT,INT,INT,INT,INT,INT,INT,INT,INT]", tuple_name);
+
     std::string text_name = CLI::detail::type_name<std::string>();
     EXPECT_EQ("TEXT", text_name);
 
@@ -1005,7 +1008,8 @@ TEST(Types, LexicalConversionVectorDouble) {
 
 static_assert(!CLI::detail::is_tuple_like<std::vector<double>>::value, "vector should not be like a tuple");
 static_assert(CLI::detail::is_tuple_like<std::pair<double, double>>::value, "pair of double should be like a tuple");
-static_assert(CLI::detail::is_tuple_like<std::array<double, 4>>::value, "std::array should be like a tuple");
+static_assert(CLI::detail::is_tuple_like<std::array<double, 4>>::value, "std::array<double,4> should be like a tuple");
+static_assert(CLI::detail::is_tuple_like<std::array<int, 10>>::value, "std::array<int,10> should be like a tuple");
 static_assert(!CLI::detail::is_tuple_like<std::string>::value, "std::string should not be like a tuple");
 static_assert(!CLI::detail::is_tuple_like<double>::value, "double should not be like a tuple");
 static_assert(CLI::detail::is_tuple_like<std::tuple<double, int, double>>::value, "tuple should look like a tuple");
@@ -1071,7 +1075,40 @@ TEST(Types, LexicalConversionTuple5) {
     EXPECT_FALSE(res);
 }
 
-TEST(Types, LexicalConversionXomplwz) {
+TEST(Types, LexicalConversionTuple10) {
+    CLI::results_t input = {"9", "19", "18", "5", "235235", "9", "19", "18", "5", "235235"};
+    std::array<unsigned int, 10> x;
+    bool res = CLI::detail::lexical_conversion<decltype(x), decltype(x)>(input, x);
+    EXPECT_TRUE(res);
+    EXPECT_EQ(std::get<1>(x), 19u);
+    EXPECT_EQ(x[0], 9u);
+    EXPECT_EQ(x[2], 18u);
+    EXPECT_EQ(x[3], 5u);
+    EXPECT_EQ(x[4], 235235u);
+    EXPECT_EQ(x[9], 235235u);
+    input[3] = "hippo";
+    res = CLI::detail::lexical_conversion<decltype(x), decltype(x)>(input, x);
+    EXPECT_FALSE(res);
+}
+
+TEST(Types, LexicalConversionTuple10XC) {
+    CLI::results_t input = {"9", "19", "18", "5", "235235", "9", "19", "18", "5", "235235"};
+    std::array<double, 10> x;
+    bool res = CLI::detail::lexical_conversion<decltype(x), std::array<unsigned int, 10>>(input, x);
+
+    EXPECT_TRUE(res);
+    EXPECT_EQ(std::get<1>(x), 19.0);
+    EXPECT_EQ(x[0], 9.0);
+    EXPECT_EQ(x[2], 18.0);
+    EXPECT_EQ(x[3], 5.0);
+    EXPECT_EQ(x[4], 235235.0);
+    EXPECT_EQ(x[9], 235235.0);
+    input[3] = "19.7";
+    res = CLI::detail::lexical_conversion<decltype(x), std::array<unsigned int, 10>>(input, x);
+    EXPECT_FALSE(res);
+}
+
+TEST(Types, LexicalConversionComplex) {
     CLI::results_t input = {"5.1", "3.5"};
     std::complex<double> x;
     bool res = CLI::detail::lexical_conversion<std::complex<double>, std::array<double, 2>>(input, x);


### PR DESCRIPTION
If merged this PR will remove the restrictions on tuple size, and add an index to validators to allow them to apply to specific components of a tuple type or vector type.  

it should address #296