### PR TITLE
Add needs to subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ There are several options that are supported on the main app and subcommands and
 -   `.enabled_by_default()`: 🆕 Specify that at the start of each parse the subcommand/option_group should be enabled.  This is useful for allowing some Subcommands to disable others.
 -   `.validate_positionals()`: 🆕 Specify that positionals should pass validation before matching.  Validation is specified through `transform`, `check`, and `each` for an option.  If an argument fails validation it is not an error and matching proceeds to the next available positional or extra arguments.
 -   `.excludes(option_or_subcommand)`: 🆕 If given an option pointer or pointer to another subcommand, these subcommands cannot be given together.  In the case of options, if the option is passed the subcommand cannot be used and will generate an error.
+-   `.needs(option_or_subcommand)`: 🚧 If given an option pointer or pointer to another subcommand, the subcommands will require the given option to have been given before this subcommand is validated.
 -   `.require_option()`: 🆕 Require 1 or more options or option groups be used.
 -   `.require_option(N)`: 🆕 Require `N` options or option groups, if `N>0`, or up to `N` if `N<0`. `N=0` resets to the default to 0 or more.
 -   `.require_option(min, max)`: 🆕 Explicitly set min and max allowed options or option groups. Setting `max` to 0 implies unlimited options.
@@ -555,6 +556,7 @@ There are several options that are supported on the main app and subcommands and
 -   `.formatter(fmt)`: Set a formatter, with signature `std::string(const App*, std::string, AppFormatMode)`. See Formatting for more details.
 -   `.description(str)`: Set/change the description.
 -   `.get_description()`: Access the description.
+-   `.alias(str)`:🚧 set an alias for the subcommand, this allows subcommands to be called by more than one name.
 -   `.parsed()`: True if this subcommand was given on the command line.
 -   `.count()`: Returns the number of times the subcommand was called.
 -   `.count(option_name)`: Returns the number of times a particular option was called.

--- a/README.md
+++ b/README.md
@@ -414,21 +414,21 @@ After specifying a set of options, you can also specify "filter" functions of th
 Here are some examples
 of `IsMember`:
 
-     -   `CLI::IsMember({"choice1", "choice2"})`: Select from exact match to choices.
-     -   `CLI::IsMember({"choice1", "choice2"}, CLI::ignore_case, CLI::ignore_underscore)`: Match things like `Choice_1`, too.
-     -  `CLI::IsMember(std::set<int>({2,3,4}))`: Most containers and types work; you just need `std::begin`, `std::end`, and `::value_type`.
-     -   `CLI::IsMember(std::map<std::string, TYPE>({{"one", 1}, {"two", 2}}))`: You can use maps; in `->transform()` these replace the matched value with the matched key.  The value member of the map is not used in `IsMember`, so it can be any type.
-     -   `auto p = std::make_shared<std::vector<std::string>>(std::initializer_list<std::string>("one", "two")); CLI::IsMember(p)`: You can modify `p` later.
-- 🆕 The `Transformer` and `CheckedTransformer` Validators transform one value into another. Any container or copyable pointer (including `std::shared_ptr`) to a container that generates pairs of values can be passed to these `Validator's`; the container just needs to be iterable and have a `::value_type` that consists of pairs. The key type should be convertible from a string, and the value type should be convertible to a string  You can use an initializer list directly if you like. If you need to modify the map later, the pointer form lets you do that; the description message will correctly refer to the current version of the map.  `Transformer` does not do any checking so values not in the map are ignored.  `CheckedTransformer` takes an extra step of verifying that the value is either one of the map key values, in which case it is transformed, or one of the expected output values, and if not will generate a `ValidationError`.  A Transformer placed using `check` will not do anything.
+-   `CLI::IsMember({"choice1", "choice2"})`: Select from exact match to choices.
+-   `CLI::IsMember({"choice1", "choice2"}, CLI::ignore_case, CLI::ignore_underscore)`: Match things like `Choice_1`, too.
+-   `CLI::IsMember(std::set<int>({2,3,4}))`: Most containers and types work; you just need `std::begin`, `std::end`, and `::value_type`.
+-   `CLI::IsMember(std::map<std::string, TYPE>({{"one", 1}, {"two", 2}}))`: You can use maps; in `->transform()` these replace the matched value with the matched key.  The value member of the map is not used in `IsMember`, so it can be any type.
+-   `auto p = std::make_shared<std::vector<std::string>>(std::initializer_list<std::string>("one", "two")); CLI::IsMember(p)`: You can modify `p` later.
+-   🆕 The `Transformer` and `CheckedTransformer` Validators transform one value into another. Any container or copyable pointer (including `std::shared_ptr`) to a container that generates pairs of values can be passed to these `Validator's`; the container just needs to be iterable and have a `::value_type` that consists of pairs. The key type should be convertible from a string, and the value type should be convertible to a string  You can use an initializer list directly if you like. If you need to modify the map later, the pointer form lets you do that; the description message will correctly refer to the current version of the map.  `Transformer` does not do any checking so values not in the map are ignored.  `CheckedTransformer` takes an extra step of verifying that the value is either one of the map key values, in which case it is transformed, or one of the expected output values, and if not will generate a `ValidationError`.  A Transformer placed using `check` will not do anything.
 After specifying a map of options, you can also specify "filter" just like in `CLI::IsMember`.
 Here are some examples (`Transformer` and `CheckedTransformer` are interchangeable in the examples)
 of `Transformer`:
 
-     -   `CLI::Transformer({{"key1", "map1"},{"key2","map2"}})`: Select from key values and produce map values.
+-   `CLI::Transformer({{"key1", "map1"},{"key2","map2"}})`: Select from key values and produce map values.
 
-     -  `CLI::Transformer(std::map<std::string,int>({"two",2},{"three",3},{"four",4}}))`: most maplike containers work,  the `::value_type` needs to produce a pair of some kind.
-     -   `CLI::CheckedTransformer(std::map<std::string, int>({{"one", 1}, {"two", 2}}))`: You can use maps; in `->transform()` these replace the matched key with the value.  `CheckedTransformer` also requires that the value either match one of the keys or match one of known outputs.
-     -   `auto p = std::make_shared<CLI::TransformPairs<std::string>>(std::initializer_list<std::pair<std::string,std::string>>({"key1", "map1"},{"key2","map2"})); CLI::Transformer(p)`: You can modify `p` later. `TransformPairs<T>` is an alias for `std::vector<std::pair<<std::string,T>>`
+-   `CLI::Transformer(std::map<std::string,int>({"two",2},{"three",3},{"four",4}}))`: most maplike containers work,  the `::value_type` needs to produce a pair of some kind.
+-   `CLI::CheckedTransformer(std::map<std::string, int>({{"one", 1}, {"two", 2}}))`: You can use maps; in `->transform()` these replace the matched key with the value.  `CheckedTransformer` also requires that the value either match one of the keys or match one of known outputs.
+-   `auto p = std::make_shared<CLI::TransformPairs<std::string>>(std::initializer_list<std::pair<std::string,std::string>>({"key1", "map1"},{"key2","map2"})); CLI::Transformer(p)`: You can modify `p` later. `TransformPairs<T>` is an alias for `std::vector<std::pair<<std::string,T>>`
 
 NOTES:  If the container used in `IsMember`, `Transformer`, or `CheckedTransformer` has a `find` function like `std::unordered_map`  or `std::map` then that function is used to do the searching. If it does not have a `find` function a linear search is performed.  If there are filters present, the fast search is performed first, and if that fails a linear search with the filters on the key values is performed.
 
@@ -535,7 +535,7 @@ There are several options that are supported on the main app and subcommands and
 -   `.enabled_by_default()`: 🆕 Specify that at the start of each parse the subcommand/option_group should be enabled.  This is useful for allowing some Subcommands to disable others.
 -   `.validate_positionals()`: 🆕 Specify that positionals should pass validation before matching.  Validation is specified through `transform`, `check`, and `each` for an option.  If an argument fails validation it is not an error and matching proceeds to the next available positional or extra arguments.
 -   `.excludes(option_or_subcommand)`: 🆕 If given an option pointer or pointer to another subcommand, these subcommands cannot be given together.  In the case of options, if the option is passed the subcommand cannot be used and will generate an error.
--   `.needs(option_or_subcommand)`: 🚧 If given an option pointer or pointer to another subcommand, the subcommands will require the given option to have been given before this subcommand is validated.
+-   `.needs(option_or_subcommand)`: 🚧 If given an option pointer or pointer to another subcommand, the subcommands will require the given option to have been given before this subcommand is validated which occurs prior to execution of any callback or after parsing is completed.
 -   `.require_option()`: 🆕 Require 1 or more options or option groups be used.
 -   `.require_option(N)`: 🆕 Require `N` options or option groups, if `N>0`, or up to `N` if `N<0`. `N=0` resets to the default to 0 or more.
 -   `.require_option(min, max)`: 🆕 Explicitly set min and max allowed options or option groups. Setting `max` to 0 implies unlimited options.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2804,9 +2804,14 @@ class App {
     /// Helper function to run through all possible comparisons of subcommand names to check there is no overlap
     const std::string &_compare_subcommand_names(const App &subcom, const App &base) const {
         static const std::string estring;
-
+        if(subcom.disabled_) {
+            return estring;
+        }
         for(auto &subc : base.subcommands_) {
             if(subc.get() != &subcom) {
+                if(subc->disabled_) {
+                    continue;
+                }
                 if(!subcom.get_name().empty()) {
                     if(subc->check_name(subcom.get_name())) {
                         return subcom.get_name();

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1776,14 +1776,14 @@ class App {
         if(local_name == name_to_check) {
             return true;
         }
-        for(auto alias : aliases_) {
+        for(auto les : aliases_) {
             if(ignore_underscore_) {
-                alias = detail::remove_underscore(alias);
+                les = detail::remove_underscore(les);
             }
             if(ignore_case_) {
-                alias = detail::to_lower(alias);
+                les = detail::to_lower(les);
             }
-            if(alias == name_to_check) {
+            if(les == name_to_check) {
                 return true;
             }
         }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2809,28 +2809,7 @@ class App {
     /// Helper function to run through all possible comparisons of subcommand names to check there is no overlap
     const std::string &_compare_subcommand_names(const App &subcom, const App &base) const {
         static const std::string estring;
-        if(&subcom != &base) {
-            if(!subcom.get_name().empty()) {
-                if(base.check_name(subcom.get_name())) {
-                    return subcom.get_name();
-                }
-            }
-            if(!base.get_name().empty()) {
-                if(subcom.check_name(base.get_name())) {
-                    return base.get_name();
-                }
-            }
-            for(const auto &les : subcom.aliases_) {
-                if(base.check_name(les)) {
-                    return les;
-                }
-            }
-            for(const auto &les : base.aliases_) {
-                if(subcom.check_name(les)) {
-                    return les;
-                }
-            }
-        }
+
         for(auto &subc : base.subcommands_) {
             if(subc.get() != &subcom) {
                 if(!subcom.get_name().empty()) {
@@ -2848,6 +2827,7 @@ class App {
                         return les;
                     }
                 }
+                // this loop is needed in case of ignore_underscore or ignore_case on one but not the other
                 for(const auto &les : subc->aliases_) {
                     if(subcom.check_name(les)) {
                         return les;

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2917,7 +2917,7 @@ class App {
                 throw OptionAlreadyAdded("option was not located: " + opt->get_name());
             }
         } else {
-            throw OptionNotFound("could not locate the given App");
+            throw OptionNotFound("could not locate the given Option");
         }
     }
 }; // namespace CLI

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2568,7 +2568,7 @@ class App {
         if(com != nullptr) {
             args.pop_back();
             parsed_subcommands_.push_back(com);
-              com->_parse(args);
+            com->_parse(args);
             auto parent_app = com->parent_;
             while(parent_app != this) {
                 parent_app->_trigger_pre_parse(args.size());

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -421,9 +421,9 @@ class Option : public OptionBase<Option> {
 
     /// Sets required options
     Option *needs(Option *opt) {
-        auto tup = needs_.insert(opt);
-        if(!tup.second)
-            throw OptionAlreadyAdded::Requires(get_name(), opt->get_name());
+        if(opt != this) {
+            needs_.insert(opt);
+        }
         return this;
     }
 
@@ -455,6 +455,9 @@ class Option : public OptionBase<Option> {
 
     /// Sets excluded options
     Option *excludes(Option *opt) {
+        if(opt == this) {
+            throw(IncorrectConstruction("and option cannot exclude itself"));
+        }
         excludes_.insert(opt);
 
         // Help text should be symmetric - excluding a should exclude b

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -429,10 +429,11 @@ class Option : public OptionBase<Option> {
 
     /// Can find a string if needed
     template <typename T = App> Option *needs(std::string opt_name) {
-        for(const Option_p &opt : dynamic_cast<T *>(parent_)->options_)
-            if(opt.get() != this && opt->check_name(opt_name))
-                return needs(opt.get());
-        throw IncorrectConstruction::MissingOption(opt_name);
+        auto opt = dynamic_cast<T *>(parent_)->get_option_no_throw(opt_name);
+        if(opt == nullptr) {
+            throw IncorrectConstruction::MissingOption(opt_name);
+        }
+        return needs(opt);
     }
 
     /// Any number supported, any mix of string and Opt
@@ -467,10 +468,11 @@ class Option : public OptionBase<Option> {
 
     /// Can find a string if needed
     template <typename T = App> Option *excludes(std::string opt_name) {
-        for(const Option_p &opt : dynamic_cast<T *>(parent_)->options_)
-            if(opt.get() != this && opt->check_name(opt_name))
-                return excludes(opt.get());
-        throw IncorrectConstruction::MissingOption(opt_name);
+        auto opt = dynamic_cast<T *>(parent_)->get_option_no_throw(opt_name);
+        if(opt == nullptr) {
+            throw IncorrectConstruction::MissingOption(opt_name);
+        }
+        return excludes(opt);
     }
 
     /// Any number supported, any mix of string and Opt

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -506,13 +506,22 @@ class Option : public OptionBase<Option> {
     /// The template hides the fact that we don't have the definition of App yet.
     /// You are never expected to add an argument to the template here.
     template <typename T = App> Option *ignore_case(bool value = true) {
-        ignore_case_ = value;
-        auto *parent = dynamic_cast<T *>(parent_);
-
-        for(const Option_p &opt : parent->options_)
-            if(opt.get() != this && *opt == *this)
-                throw OptionAlreadyAdded(opt->get_name(true, true));
-
+        if(!ignore_case_ && value) {
+            ignore_case_ = value;
+            auto *parent = dynamic_cast<T *>(parent_);
+            for(const Option_p &opt : parent->options_) {
+                if(opt.get() == this) {
+                    continue;
+                }
+                auto &omatch = opt->matching_name(*this);
+                if(!omatch.empty()) {
+                    ignore_case_ = false;
+                    throw OptionAlreadyAdded("adding ignore case caused a name conflict with " + omatch);
+                }
+            }
+        } else {
+            ignore_case_ = value;
+        }
         return this;
     }
 
@@ -521,12 +530,23 @@ class Option : public OptionBase<Option> {
     /// The template hides the fact that we don't have the definition of App yet.
     /// You are never expected to add an argument to the template here.
     template <typename T = App> Option *ignore_underscore(bool value = true) {
-        ignore_underscore_ = value;
-        auto *parent = dynamic_cast<T *>(parent_);
-        for(const Option_p &opt : parent->options_)
-            if(opt.get() != this && *opt == *this)
-                throw OptionAlreadyAdded(opt->get_name(true, true));
 
+        if(!ignore_underscore_ && value) {
+            ignore_underscore_ = value;
+            auto *parent = dynamic_cast<T *>(parent_);
+            for(const Option_p &opt : parent->options_) {
+                if(opt.get() == this) {
+                    continue;
+                }
+                auto &omatch = opt->matching_name(*this);
+                if(!omatch.empty()) {
+                    ignore_underscore_ = false;
+                    throw OptionAlreadyAdded("adding ignore underscore caused a name conflict with " + omatch);
+                }
+            }
+        } else {
+            ignore_underscore_ = value;
+        }
         return this;
     }
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -751,26 +751,29 @@ class Option : public OptionBase<Option> {
             throw ConversionError(get_name(), results_);
     }
 
-    /// If options share any of the same names, they are equal (not counting positional)
-    bool operator==(const Option &other) const {
+    /// If options share any of the same names, find it
+    const std::string &matching_name(const Option &other) const {
+        static const std::string estring;
         for(const std::string &sname : snames_)
             if(other.check_sname(sname))
-                return true;
+                return sname;
         for(const std::string &lname : lnames_)
             if(other.check_lname(lname))
-                return true;
+                return lname;
 
         if(ignore_case_ ||
            ignore_underscore_) { // We need to do the inverse, in case we are ignore_case or ignore underscore
             for(const std::string &sname : other.snames_)
                 if(check_sname(sname))
-                    return true;
+                    return sname;
             for(const std::string &lname : other.lnames_)
                 if(check_lname(lname))
-                    return true;
+                    return lname;
         }
-        return false;
+        return estring;
     }
+    /// If options share any of the same names, they are equal (not counting positional)
+    bool operator==(const Option &other) const { return !matching_name(other).empty(); }
 
     /// Check a name. Requires "-" or "--" for short / long, supports positional name
     bool check_name(std::string name) const {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1792,6 +1792,8 @@ TEST_F(TApp, NeedsFlags) {
 
     args = {"--both"};
     EXPECT_THROW(run(), CLI::RequiresError);
+
+    EXPECT_NO_THROW(opt->needs(opt));
 }
 
 TEST_F(TApp, ExcludesFlags) {
@@ -1811,6 +1813,8 @@ TEST_F(TApp, ExcludesFlags) {
 
     args = {"--string", "--nostr"};
     EXPECT_THROW(run(), CLI::ExcludesError);
+
+    EXPECT_THROW(opt->excludes(opt), CLI::IncorrectConstruction);
 }
 
 TEST_F(TApp, ExcludesMixedFlags) {

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -227,14 +227,16 @@ TEST_F(TApp, IncorrectConstructionDuplicateNeeds) {
     auto cat = app.add_flag("--cat");
     auto other = app.add_flag("--other");
     ASSERT_NO_THROW(cat->needs(other));
-    EXPECT_THROW(cat->needs(other), CLI::OptionAlreadyAdded);
+    // duplicated needs is redundant but not an error
+    EXPECT_NO_THROW(cat->needs(other));
 }
 
 TEST_F(TApp, IncorrectConstructionDuplicateNeedsTxt) {
     auto cat = app.add_flag("--cat");
     app.add_flag("--other");
     ASSERT_NO_THROW(cat->needs("--other"));
-    EXPECT_THROW(cat->needs("--other"), CLI::OptionAlreadyAdded);
+    // duplicate needs is redundant but not an error
+    EXPECT_NO_THROW(cat->needs("--other"));
 }
 
 // Now allowed

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -438,6 +438,23 @@ TEST_F(ManyGroups, ExcludesGroup) {
     EXPECT_FALSE(g1->remove_excludes(g2));
 }
 
+TEST_F(ManyGroups, NeedsGroup) {
+    remove_required();
+    // all groups needed if g1 is used
+    g1->needs(g2);
+    g1->needs(g3);
+    args = {"--name1", "test"};
+    EXPECT_THROW(run(), CLI::RequiresError);
+    // other groups should run fine
+    args = {"--name2", "test2"};
+
+    run();
+    // all three groups should be fine
+    args = {"--name1", "test", "--name2", "test2", "--name3", "test3"};
+
+    EXPECT_NO_THROW(run());
+}
+
 TEST_F(ManyGroups, SingleGroupError) {
     // only 1 group can be used
     main->require_option(1);

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -473,7 +473,7 @@ TEST_F(TApp, ExistingSubcommandMatch) {
     }
     sshared->remove_subcommand(s1);
 
-    auto s3 = app.add_subcommand("sub3");
+    app.add_subcommand("sub3");
     // now check that the subsubcommand overlaps
     try {
         app.add_subcommand(sshared);
@@ -569,10 +569,13 @@ TEST_F(ManyGroups, DisableFirst) {
 TEST_F(ManyGroups, SameSubcommand) {
     // only 1 group can be used if remove_required not used
     remove_required();
-    auto sub1 = g1->add_subcommand("sub1");
-    auto sub2 = g2->add_subcommand("sub1");
+    auto sub1 = g1->add_subcommand("sub1")->disabled();
+    auto sub2 = g2->add_subcommand("sub1")->disabled();
     auto sub3 = g3->add_subcommand("sub1");
-
+    // so when the subcommands are disabled they can have the same name
+    sub1->disabled(false);
+    sub2->disabled(false);
+    // if they are reenabled they are not checked for overlap on enabling so they can have the same name
     args = {"sub1", "sub1", "sub1"};
 
     run();
@@ -580,7 +583,6 @@ TEST_F(ManyGroups, SameSubcommand) {
     EXPECT_TRUE(*sub1);
     EXPECT_TRUE(*sub2);
     EXPECT_TRUE(*sub3);
-    /// This should be made to work at some point
     auto subs = app.get_subcommands();
     EXPECT_EQ(subs.size(), 3u);
     EXPECT_EQ(subs[0], sub1);

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -1300,6 +1300,20 @@ TEST_F(ManySubcommands, SubcommandNeedsOptions) {
     EXPECT_NO_THROW(run());
 }
 
+TEST_F(ManySubcommands, SubcommandNeedsFail) {
+
+    auto opt = app.add_flag("--subactive");
+    auto opt2 = app.add_flag("--dummy");
+    sub1->needs(opt);
+    EXPECT_THROW(sub1->needs((CLI::Option *)nullptr), CLI::OptionNotFound);
+    EXPECT_THROW(sub1->needs((CLI::App *)nullptr), CLI::OptionNotFound);
+    EXPECT_THROW(sub1->needs(sub1), CLI::OptionNotFound);
+
+    EXPECT_TRUE(sub1->remove_needs(opt));
+    EXPECT_FALSE(sub1->remove_needs(opt2));
+    EXPECT_FALSE(sub1->remove_needs(sub1));
+}
+
 TEST_F(ManySubcommands, SubcommandRequired) {
 
     sub1->required();
@@ -1448,7 +1462,7 @@ TEST_F(TApp, SubcommandAlias) {
     EXPECT_EQ(val, 7);
 
     auto &al = sub->get_aliases();
-    ASSERT_GE(al.size(), 2);
+    ASSERT_GE(al.size(), 2U);
 
     EXPECT_EQ(al[0], "sub2");
     EXPECT_EQ(al[1], "sub3");

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -1661,6 +1661,10 @@ TEST_F(TApp, ExistingSubcommandMatch) {
     } catch(const CLI::OptionAlreadyAdded &oaa) {
         EXPECT_THAT(oaa.what(), HasSubstr("sub2"));
     }
+    // now check that disabled subcommands can be added regardless of name
+    sshared->name("sub1");
+    sshared->disabled();
+    EXPECT_NO_THROW(app.add_subcommand(sshared));
 }
 
 TEST_F(TApp, AliasErrorsInOptionGroup) {

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -1266,6 +1266,38 @@ TEST_F(ManySubcommands, SubcommandNeeds) {
 
     args = {"sub1", "sub2", "sub4"};
     EXPECT_THROW(run(), CLI::RequiresError);
+
+    args = {"sub1", "sub2", "sub4"};
+    sub1->remove_needs(sub3);
+    EXPECT_NO_THROW(run());
+}
+
+TEST_F(ManySubcommands, SubcommandNeedsOptions) {
+
+    auto opt = app.add_flag("--subactive");
+    sub1->needs(opt);
+    sub1->fallthrough();
+    args = {"sub1", "--subactive"};
+    EXPECT_NO_THROW(run());
+
+    args = {"sub1"};
+    EXPECT_THROW(run(), CLI::RequiresError);
+
+    args = {"--subactive"};
+    EXPECT_NO_THROW(run());
+
+    auto opt2 = app.add_flag("--subactive2");
+
+    sub1->needs(opt2);
+    args = {"sub1", "--subactive"};
+    EXPECT_THROW(run(), CLI::RequiresError);
+
+    args = {"--subactive", "--subactive2", "sub1"};
+    EXPECT_NO_THROW(run());
+
+    sub1->remove_needs(opt2);
+    args = {"sub1", "--subactive"};
+    EXPECT_NO_THROW(run());
 }
 
 TEST_F(ManySubcommands, SubcommandRequired) {

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -1471,6 +1471,49 @@ TEST_F(TApp, SubcommandAlias) {
     EXPECT_TRUE(al.empty());
 }
 
+TEST_F(TApp, SubcommandAliasIgnoreCaseUnderscore) {
+    double val;
+    auto sub = app.add_subcommand("sub1");
+    sub->alias("sub2");
+    sub->alias("sub3");
+    sub->ignore_case();
+    sub->add_option("-v,--value", val);
+    args = {"sub1", "-v", "-3"};
+    run();
+    EXPECT_EQ(val, -3.0);
+
+    args = {"SUB2", "--value", "-5"};
+    run();
+    EXPECT_EQ(val, -5.0);
+
+    args = {"sUb3", "-v", "7"};
+    run();
+    EXPECT_EQ(val, 7);
+    sub->ignore_underscore();
+    args = {"sub_1", "-v", "-3"};
+    run();
+    EXPECT_EQ(val, -3.0);
+
+    args = {"SUB_2", "--value", "-5"};
+    run();
+    EXPECT_EQ(val, -5.0);
+
+    args = {"sUb_3", "-v", "7"};
+    run();
+    EXPECT_EQ(val, 7);
+
+    sub->ignore_case(false);
+    args = {"sub_1", "-v", "-3"};
+    run();
+    EXPECT_EQ(val, -3.0);
+
+    args = {"SUB_2", "--value", "-5"};
+    EXPECT_THROW(run(), CLI::ExtrasError);
+
+    args = {"sUb_3", "-v", "7"};
+    EXPECT_THROW(run(), CLI::ExtrasError);
+}
+
 TEST_F(TApp, OptionGroupAlias) {
     double val;
     auto sub = app.add_option_group("sub1");

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -1626,13 +1626,15 @@ TEST_F(TApp, AliasErrors) {
     // aliasing to an existing name should be allowed
     EXPECT_NO_THROW(sub1->alias(sub1->get_name()));
 
-    sub1->alias("les1")->alias("les2")->alias("les3");
+    sub1->alias("les1")->alias("les2")->alias("les_3");
     sub2->alias("s2les1")->alias("s2les2")->alias("s2les3");
 
     EXPECT_THROW(sub2->alias("les2"), CLI::OptionAlreadyAdded);
     EXPECT_THROW(sub1->alias("s2les2"), CLI::OptionAlreadyAdded);
 
     EXPECT_THROW(sub2->name("sub1"), CLI::OptionAlreadyAdded);
+    sub2->ignore_underscore();
+    EXPECT_THROW(sub2->alias("les3"), CLI::OptionAlreadyAdded);
 }
 // test adding a subcommand via the pointer
 TEST_F(TApp, ExistingSubcommandMatch) {


### PR DESCRIPTION
This PR will address #291 and #288 

it adds a needs function for subcommands and options to the app as well as a remove needs.  it also adds some alias operations to app so multiple subcommand names can represent a single subcommand.  

This will also work for nameless subcommands(option_groups) so the same group can be a subcommand or act just like regular options.  