### PR TITLE
Refactor CMake to use best practices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,103 +23,128 @@ string(REGEX REPLACE ${VERSION_REGEX} "\\1" VERSION_STRING "${VERSION_STRING}")
 # Add the project
 project(CLI11 LANGUAGES CXX VERSION ${VERSION_STRING})
 
+include(CMakeDependentOption)
+include(GNUInstallDirs)
+include(CTest)
+
+find_program(CLI11_CLANG_TIDY_EXE NAMES clang-tidy DOC "Path to clang-tidy")
+find_package(Doxygen)
+
+list(APPEND force-libcxx "CMAKE_CXX_COMPILER_ID STREQUAL \"Clang\"")
+list(APPEND force-libcxx "CMAKE_SYSTEM_NAME STREQUAL \"Linux\"")
+list(APPEND force-libcxx "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME")
+
+list(APPEND clang-tidy-fix "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME")
+list(APPEND clang-tidy-fix "CMAKE_VERSION VERSION_GREATER 3.5")
+list(APPEND clang-tidy-fix "CLI11_CLANG_TIDY_EXE")
+list(APPEND clang-tidy-fix "CLI11_BUILD_EXAMPLES")
+
+list(APPEND build-docs "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME")
+list(APPEND build-docs "CMAKE_VERSION VERSION_GREATER 3.10")
+list(APPEND build-docs "Doxygen_FOUND")
+
+option(CLI11_WARNINGS_AS_ERRORS "Turn all warnings into errors (for CI)")
+option(CLI11_SINGLE_FILE "Generate a single header file")
+
+cmake_dependent_option(CLI11_BUILD_DOCS
+  "Build CLI11 documentation" ON
+  "${build-docs}" OFF)
+
+cmake_dependent_option(CLI11_BUILD_TESTS
+  "Build CLI11 tests" ON
+  "BUILD_TESTING;CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME" OFF)
+
+cmake_dependent_option(CLI11_BUILD_EXAMPLES
+  "Build CLI11 examples" ON
+  "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME" OFF)
+
+cmake_dependent_option(CLI11_BUILD_EXAMPLE_JSON
+  "Build CLI11 json example" OFF
+  "CLI11_BUILD_EXAMPLES" OFF)
+
+cmake_dependent_option(CLI11_SINGLE_FILE_TESTS
+  "Duplicate all the tests for a single file build" OFF
+  "BUILD_TESTING;CLI11_SINGLE_FILE" OFF)
+
+cmake_dependent_option(CLI11_INSTALL
+  "Install the CLI11 folder to include during install process" ON
+  "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME" OFF)
+
+cmake_dependent_option(CLI11_CLANG_TIDY_FIX
+  "Perform fixes for clang-tidy" OFF
+  "${clang-tidy-fix}" OFF)
+
+cmake_dependent_option(CLI11_FORCE_LIBCXX
+  "Force clang to use libc++ instead of libstdc++ (Linux only)" OFF
+  "${force-libcxx}" OFF)
+
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+endif()
+
+if (NOT DEFINED CMAKE_CXX_EXTENSIONS)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+else()
+  get_property(cli11-use-folders GLOBAL PROPERTY USE_FOLDERS)
+  set_property(GLOBAL PROPERTY USE_FOLDERS ${cli11-use-folders})
+endif()
+
+if (CMAKE_VERSION VERSION_LESS 3.9)
+  message(STATUS "CMake 3.10 and later adds Doxygen support. Update CMake to build documentation")
+endif()
+
+if (NOT Doxygen_FOUND)
+  message(STATUS "Doxygen not found, building docs has been disabled")
+endif()
+
 # Special target that adds warnings. Is not exported.
 add_library(CLI11_warnings INTERFACE)
 
-# Only if built as the main project
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    # User settable
-    set(CLI11_CXX_STD "11"  CACHE STRING "The CMake standard to require")
-
-    # Special override for Clang on Linux (useful with an old stdlibc++ and a newer clang)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        option(CLI11_FORCE_LIBCXX "Force Clang to use libc++ instead of libstdc++ (Linux only)" OFF)
-        if(CLI11_FORCE_LIBCXX)
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
-        endif()
-    endif()
-
-    set(CUR_PROJ ON)
-    set(CMAKE_CXX_STANDARD ${CLI11_CXX_STD})
-    set(CMAKE_CXX_EXTENSIONS OFF)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-    option(CLI11_WARNINGS_AS_ERRORS "Turn all warnings into errors (for CI)")
-
-    # Be moderately paranoid with flags
-    if(MSVC)
-        target_compile_options(CLI11_warnings INTERFACE "/W4")
-        if(CLI11_WARNINGS_AS_ERRORS)
-            target_compile_options(CLI11_warnings INTERFACE "/WX")
-        endif()
-    else()
-        target_compile_options(CLI11_warnings INTERFACE -Wall -Wextra -pedantic -Wshadow)
-        if(CLI11_WARNINGS_AS_ERRORS)
-            target_compile_options(CLI11_warnings INTERFACE -Werror)
-        endif()
-    endif()
-
-    if(NOT CMAKE_VERSION VERSION_LESS 3.6)
-        # Add clang-tidy if available
-        option(CLANG_TIDY_FIX "Perform fixes for Clang-Tidy" OFF)
-        find_program(
-            CLANG_TIDY_EXE
-            NAMES "clang-tidy"
-            DOC "Path to clang-tidy executable"
-        )
-
-        if(CLANG_TIDY_EXE)
-            if(CLANG_TIDY_FIX)
-                set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-fix")
-            else()
-                set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}")
-            endif()
-        endif()
-    endif()
-
-    if(NOT CMAKE_VERSION VERSION_LESS 3.9)
-        find_package(Doxygen)
-        if(Doxygen_FOUND)
-            add_subdirectory(docs)
-        else()
-            message(STATUS "Doxygen not found, not building docs")
-        endif()
-    else()
-        message(STATUS "Newer CMake adds Doxygen support, update CMake for docs")
-    endif()
-else()
-    set(CUR_PROJ OFF)
+target_compile_options(CLI11_warnings
+  INTERFACE
+    $<$<BOOL:${CLI11_FORCE_LIBCXX}>:-stdlib=libc++>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 $<$<BOOL:${CLI11_WARNINGS_AS_ERRORS}>:/WX>>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -pedantic -Wshadow $<$<BOOL:${CLI11_WARNINGS_AS_ERRORS}>:-Werror>>)
+if (CMAKE_VERSION VERSION_GREATER 3.13)
+  target_link_options(CLI11_warnings
+    INTERFACE
+      $<$<BOOL:${CLI11_FORCE_LIBCXX}>:-stdlib=libc++>)
+endif()
+if(CLI11_FORCE_LIBCXX)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
 endif()
 
-# Allow dependent options
-include(CMakeDependentOption)
-
 # Allow IDE's to group targets into folders
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-
-file(GLOB CLI11_headers "${CMAKE_CURRENT_SOURCE_DIR}/include/CLI/*")
-# To see in IDE, must be listed for target
-
 add_library(CLI11 INTERFACE)
+add_library(CLI11::CLI11 ALIAS CLI11) # for add_subdirectory calls
+
+set(header-patterns "${PROJECT_SOURCE_DIR}/include/CLI/*")
+if (CMAKE_VERSION VERSION_GREATER 3.11)
+  list(INSERT header-patterns 0 CONFIGURE_DEPENDS)
+endif()
+
+file(GLOB CLI11_headers ${header-patterns})
+# To see in IDE, must be listed for target
 
 # Duplicated because CMake adds the current source dir if you don't.
 target_include_directories(CLI11 INTERFACE
-     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-     $<INSTALL_INTERFACE:include>)
-
-# Make add_subdirectory work like find_package
-add_library(CLI11::CLI11 ALIAS CLI11)
-
-option(CLI11_INSTALL "Install the CLI11 folder to include during install process" ${CUR_PROJ})
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
 
 # This folder should be installed
 if(CLI11_INSTALL)
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CLI DESTINATION include)
-
-    # Make an export target
-    install(TARGETS CLI11
-            EXPORT CLI11Targets)
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  # Make an export target
+  install(TARGETS CLI11 EXPORT CLI11Targets)
 endif()
 
 # Use find_package on the installed package
@@ -128,13 +153,13 @@ endif()
 # import Targets.cmake
 
 # Add the version in a CMake readable way
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CLI11ConfigVersion.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/CLI11ConfigVersion.cmake" @ONLY)
+configure_file("cmake/CLI11ConfigVersion.cmake.in"
+  "CLI11ConfigVersion.cmake" @ONLY)
 
 # These installs only make sense for a local project
-if(CUR_PROJ)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     # Make version available in the install
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/CLI11ConfigVersion.cmake"
+    install(FILES "${PROJECT_BINARY_DIR}/CLI11ConfigVersion.cmake"
             DESTINATION lib/cmake/CLI11)
 
     # Install the export target as a file
@@ -152,67 +177,54 @@ if(CUR_PROJ)
     export(PACKAGE CLI11)
 endif()
 
-option(CLI11_SINGLE_FILE "Generate a single header file" OFF)
-
 if(CLI11_SINGLE_FILE)
 # Single file test
-    if(CMAKE_VERSION VERSION_LESS 3.12)
-        find_package(PythonInterp REQUIRED)
-        set(Python_VERSION ${PYTHON_VERSION_STRING})
-        set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
-    else()
-        find_package(Python REQUIRED)
-    endif()
+  if(CMAKE_VERSION VERSION_LESS 3.12)
+      find_package(PythonInterp REQUIRED)
+      add_executable(Python::Interpreter IMPORTED)
+      set_target_properties(Python::Interpreter
+        PROPERTIES
+          IMPORTED_LOCATION "${PYTHON_EXECUTABLE}"
+          VERSION "${PYTHON_VERSION_STRING}")
+  else()
+    find_package(Python COMPONENTS Interpreter REQUIRED)
+  endif()
 
-    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
-    add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp"
-        COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/scripts/MakeSingleHeader.py" "${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp"
-        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/CLI/CLI.hpp" ${CLI11_headers}
-        )
-    add_custom_target(generate_cli_single_file ALL
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp")
-    set_target_properties(generate_cli_single_file
-                          PROPERTIES FOLDER "Scripts")
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp DESTINATION include)
-    add_library(CLI11_SINGLE INTERFACE)
-    target_link_libraries(CLI11_SINGLE INTERFACE CLI11)
-    add_dependencies(CLI11_SINGLE generate_cli_single_file)
-    target_compile_definitions(CLI11_SINGLE INTERFACE -DCLI11_SINGLE_FILE)
-    target_include_directories(CLI11_SINGLE INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/include/")
+  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
+  add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp"
+    COMMAND Python::Interpreter
+      "${CMAKE_CURRENT_SOURCE_DIR}/scripts/MakeSingleHeader.py"
+      "${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp"
+    DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/include/CLI/CLI.hpp"
+      ${CLI11_headers})
+  add_custom_target(CLI11-generate-single-file ALL
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp")
+  set_property(TARGET CLI11-generate-single-file PROPERTY FOLDER "Scripts")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/CLI11.hpp
+    DESTINATION include)
+  add_library(CLI11_SINGLE INTERFACE)
+  target_link_libraries(CLI11_SINGLE INTERFACE CLI11)
+  add_dependencies(CLI11_SINGLE CLI11-generate-single-file)
+  target_compile_definitions(CLI11_SINGLE INTERFACE -DCLI11_SINGLE_FILE)
+  target_include_directories(CLI11_SINGLE INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/>
+    $<INSTALL_INTERFACE:include>)
 endif()
 
-cmake_dependent_option(CLI11_SINGLE_FILE_TESTS
-    "Duplicate all the tests for a single file build"
-    OFF
-    "CLI11_SINGLE_FILE"
-    OFF)
 
-
-if(DEFINED CLI11_TESTING)
-    set(CLI11_TESTING_INTERNAL "${CLI11_TESTING}")
-elseif(CUR_PROJ)
-    option(BUILD_TESTING "Build the tests" ON)
-    set(CLI11_TESTING_INTERNAL "${BUILD_TESTING}")
-else()
-    set(CLI11_TESTING_INTERNAL OFF)
+if(CLI11_BUILD_TESTS)
+  add_subdirectory(tests)
 endif()
 
-if(CLI11_TESTING_INTERNAL)
-    enable_testing()
-    add_subdirectory(tests)
-endif()
-
-cmake_dependent_option(CLI11_EXAMPLES "Build the examples" ON "CUR_PROJ" OFF)
-if(CLI11_EXAMPLES)
-    add_subdirectory(examples)
+if(CLI11_BUILD_EXAMPLES)
+  add_subdirectory(examples)
 endif()
 
 # Packaging support
 set(CPACK_PACKAGE_VENDOR "github.com/CLIUtils/CLI11")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Command line interface")
-set(CPACK_PACKAGE_VERSION_MAJOR ${CLI11_VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${CLI11_VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${CLI11_VERSION_PATCH})
+set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Command line parser with simple and intuitive interface")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
 set(CPACK_SOURCE_GENERATOR "TGZ;ZIP")

--- a/cmake/AddGoogletest.cmake
+++ b/cmake/AddGoogletest.cmake
@@ -7,7 +7,7 @@
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 set(BUILD_SHARED_LIBS OFF)
 
-add_subdirectory("${CLI11_SOURCE_DIR}/extern/googletest" "${CLI11_BINARY_DIR}/extern/googletest" EXCLUDE_FROM_ALL)
+add_subdirectory("${googletest_SOURCE_DIR}" "${googletest_BINARY_DIR}" EXCLUDE_FROM_ALL)
 
 
 if(GOOGLE_TEST_INDIVIDUAL)
@@ -37,6 +37,10 @@ macro(add_gtest TESTNAME)
     else()
         add_test(${TESTNAME} ${TESTNAME})
         set_target_properties(${TESTNAME} PROPERTIES FOLDER "Tests")
+        if (CLI11_FORCE_LIBCXX)
+          set_property(TARGET ${T} APPEND_STRING
+            PROPERTY LINK_FLAGS -stdlib=libc++)
+        endif()
     endif()
 
 endmacro()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,44 +1,58 @@
-function(add_cli_exe T)
-    add_executable(${T} ${ARGN} ${CLI11_headers})
-    target_link_libraries(${T} PUBLIC CLI11)
-    set_target_properties(
-         ${T} PROPERTIES
-         FOLDER "Examples"
-         )
+if (CMAKE_VERSION VERSION_GREATER 3.10 AND CLI11_EXAMPLE_JSON)
+  FetchContent_Declare(json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_SHALLOW 1
+    GIT_TAG 1126c9c)
+  FetchContent_GetProperties(json)
+  if (NOT json_POPULATED)
+    FetchContent_Populate(json)
+  endif()
+else()
+  set(json_SOURCE_DIR "${PROJECT_SOURCE_DIR}/extern/json")
+  set(json_BINARY_DIR "${PROJECT_BINARY_DIR}/extern/json")
+endif()
 
-    if(CLANG_TIDY_EXE)
-    set_target_properties(
-        ${T} PROPERTIES
-        CXX_CLANG_TIDY "${DO_CLANG_TIDY}"
-        )
-    endif()
+function(add_cli_exe T)
+  add_executable(${T} ${ARGN} ${CLI11_headers})
+  target_link_libraries(${T} PUBLIC CLI11)
+  set_property(TARGET ${T} PROPERTY FOLDER "Examples")
+  if (CLI11_FORCE_LIBCXX)
+    set_property(TARGET ${T} APPEND_STRING PROPERTY LINK_FLAGS -stdlib=libc++)
+  endif()
+  if (CLI11_CLANG_TIDY_EXE)
+    set_property(TARGET ${T} PROPERTY CXX_CLANG_TIDY "${CLI11_CLANG_TIDY_EXE}")
+  endif()
+  if (CLI11_CLANG_TIDY_FIX)
+    set_property(TARGET ${$} APPEND_STRING PROPERTY CXX_CLANG_TIDY "-fix")
+  endif()
 endfunction()
 
-option(CLI11_EXAMPLE_JSON OFF)
 if(CLI11_EXAMPLE_JSON)
-    if(NOT EXISTS "${CLI11_SOURCE_DIR}/extern/json/single_include/nlohmann/json.hpp")
-        message(ERROR "You are missing the json package for CLI11_EXAMPLE_JSON. Please update your submodules (git submodule update --init)")
-    endif()
-    if(CMAKE_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
-        message(WARNING "The json example requires GCC 4.8+ (requirement on json library)")
-    endif()
-    add_cli_exe(json json.cpp)
-    target_include_directories(json PUBLIC SYSTEM "${CLI11_SOURCE_DIR}/extern/json/single_include")
+  if (NOT IS_DIRECTORY "${json_SOURCE_DIR}/single_include")
+    message(SEND_ERROR "You are missing the json package"
+      "for CLI11_EXAMPLE_JSON."
+      "Please update your submodules:\n"
+      "\tgit submodule update --init")
+  endif()
+  add_cli_exe(json json.cpp)
+  target_include_directories(json PUBLIC SYSTEM
+    "${json_SOURCE_DIR}/single_include")
 
     add_test(NAME json_config_out COMMAND json --item 2)
     set_property(TEST json_config_out PROPERTY PASS_REGULAR_EXPRESSION
-        "{"
-        "\"item\": \"2\""
-        "\"simple\": false"
-        "}")
+[[{
+"item": "2"
+"simple": false
+}]])
 
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/input.json" [=[{"item":3,"simple":false}]=])
+    file(GENERATE "${CMAKE_CURRENT_BINARY_DIR}/input.json"
+      CONTENT [=[{"item":3,"simple":false}]=])
     add_test(NAME json_config_in COMMAND json --config "${CMAKE_CURRENT_BINARY_DIR}/input.json")
     set_property(TEST json_config_in PROPERTY PASS_REGULAR_EXPRESSION
-        "{"
-        "\"item\": \"3\""
-        "\"simple\": false"
-        "}")
+[[{
+"item": "3"
+"simple": false
+}]])
 endif()
 
 add_cli_exe(simple simple.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,17 +1,43 @@
-if(NOT EXISTS "${CLI11_SOURCE_DIR}/extern/googletest/CMakeLists.txt")
-    message(FATAL_ERROR "You have requested tests be built, but googletest is not downloaded. Please run:
-    git submodule update --init")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+if (CMAKE_VERSION VERSION_GREATER 3.10)
+  include(FetchContent)
+  FetchContent_Declare(googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_SHALLOW 1
+    GIT_TAG 2fe3bd9)
+  FetchContent_Declare(sanitizers
+    GIT_REPOSITORY https://github.com/arsenm/sanitizers-cmake.git
+    GIT_SHALLOW 1
+    GIT_TAG 99e159e)
+  FetchContent_GetProperties(googletest)
+  FetchContent_GetProperties(sanitizers)
+  if (NOT googletest_POPULATED)
+    FetchContent_Populate(googletest)
+  endif()
+  if (NOT sanitizers_POPULATED)
+    FetchContent_Populate(sanitizers)
+  endif()
+else()
+  set(googletest_SOURCE_DIR "${PROJECT_SOURCE_DIR}/extern/googletest")
+  set(googletest_BINARY_DIR "${PROJECT_BINARY_DIR}/extern/googletest")
+  set(sanitizers_SOURCE_DIR "${PROJECT_SOURCE_DIR}/extern/sanitizers")
+  set(sanitizers_BINARY_DIR "${PROJECT_BINARY_DIR}/extern/sanitizers")
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${CLI11_SOURCE_DIR}/cmake")
+if(NOT EXISTS "${googletest_SOURCE_DIR}/CMakeLists.txt")
+  message(FATAL_ERROR "You have requested tests be built,"
+    "but googletest is not downloaded. Please run:\n"
+    "\tgit submodule update --init")
+endif()
 
 # If submodule is available, add sanitizers
 # Set SANITIZE_ADDRESS, SANITIZE_MEMORY, SANITIZE_THREAD or SANITIZE_UNDEFINED
-if(EXISTS "${CLI11_SOURCE_DIR}/extern/sanitizers/cmake/FindSanitizers.cmake")
-    list(APPEND CMAKE_MODULE_PATH "${CLI11_SOURCE_DIR}/extern/sanitizers/cmake")
+if(IS_DIRECTORY "${sanitizers_SOURCE_DIR}/cmake")
+  list(APPEND CMAKE_MODULE_PATH "${sanitizers_SOURCE_DIR}/cmake")
     find_package(Sanitizers)
     if(SANITIZE_ADDRESS)
-        message(STATUS "You might want to use \"${ASan_WRAPPER}\" to run your program")
+      message(STATUS "You might want to use \"${ASan_WRAPPER}\" to run your program")
     endif()
 else()
     macro(add_sanitizers)
@@ -22,73 +48,62 @@ set(GOOGLE_TEST_INDIVIDUAL OFF)
 include(AddGoogletest)
 
 set(CLI11_TESTS
-    HelpersTest
-    IniTest
-    SimpleTest
-    AppTest
-    SetTest
-	TransformTest
-    CreationTest
-    SubcommandTest
-    HelpTest
-    FormatterTest
-    NewParseTest
-    OptionalTest
-    DeprecatedTest
-    StringParseTest
-    TrueFalseTest
-    OptionGroupTest
-    )
+  HelpersTest
+  IniTest
+  SimpleTest
+  AppTest
+  SetTest
+  TransformTest
+  CreationTest
+  SubcommandTest
+  HelpTest
+  FormatterTest
+  NewParseTest
+  OptionalTest
+  DeprecatedTest
+  StringParseTest
+  TrueFalseTest
+  OptionGroupTest)
 
 if(WIN32)
     list(APPEND CLI11_TESTS WindowsTest)
 endif()
 
-set(CLI11_MULTIONLY_TESTS
-    TimerTest
-    )
+set(CLI11_MULTIONLY_TESTS TimerTest)
 
 # Only affects current directory, so safe
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-foreach(T ${CLI11_TESTS})
+foreach(T IN LISTS CLI11_TESTS)
+  add_executable(${T} ${T}.cpp ${CLI11_headers})
+  add_sanitizers(${T})
+  target_link_libraries(${T} PUBLIC CLI11 CLI11_warnings)
+  add_gtest(${T})
 
-    add_executable(${T} ${T}.cpp ${CLI11_headers})
-    add_sanitizers(${T})
-    target_link_libraries(${T} PUBLIC CLI11 CLI11_warnings)
-    add_gtest(${T})
-
-    if(CLI11_SINGLE_FILE AND CLI11_SINGLE_FILE_TESTS)
-        add_executable(${T}_Single ${T}.cpp)
-        target_link_libraries(${T}_Single PUBLIC CLI11_SINGLE)
-        add_gtest(${T}_Single)
-        set_target_properties(${T}_Single
-            PROPERTIES
-            FOLDER "Tests Single File")
-    endif()
-
+  if(CLI11_SINGLE_FILE AND CLI11_SINGLE_FILE_TESTS)
+    add_executable(${T}_Single ${T}.cpp)
+    target_link_libraries(${T}_Single PUBLIC CLI11_SINGLE)
+    add_gtest(${T}_Single)
+    set_property(TARGET ${T}_Single PROPERTY FOLDER "Tests Single File")
+  endif()
 endforeach()
 
-foreach(T ${CLI11_MULTIONLY_TESTS})
-
-    add_executable(${T} ${T}.cpp ${CLI11_headers})
-    add_sanitizers(${T})
-    target_link_libraries(${T} PUBLIC CLI11)
-    add_gtest(${T})
-
+foreach(T IN LISTS CLI11_MULTIONLY_TESTS)
+  add_executable(${T} ${T}.cpp ${CLI11_headers})
+  add_sanitizers(${T})
+  target_link_libraries(${T} PUBLIC CLI11)
+  add_gtest(${T})
 endforeach()
 
 # Add -Wno-deprecated-declarations to DeprecatedTest
-if(NOT MSVC)
-    target_compile_options(DeprecatedTest PRIVATE -Wno-deprecated-declarations)
-    if(TARGET DeprecatedTest_Single)
-        target_compile_options(DeprecatedTest_Single PRIVATE -Wno-deprecated-declarations)
-    endif()
-else()
-    target_compile_options(DeprecatedTest PRIVATE "/wd4996")
-    if(TARGET DeprecatedTest_Single)
-        target_compile_options(DeprecatedTest_Single PRIVATE "/wd4996")
-    endif()
+set(no-deprecated-declarations $<IF:$<CXX_COMPILER_ID:MSVC>,/wd4996,-Wno-deprecated-declarations>)
+target_compile_options(DeprecatedTest
+  PRIVATE
+    ${no-deprecated-declarations})
+if (TARGET DeprecatedTest_Single)
+  target_compile_options(DeprecatedTest_Single
+    PRIVATE
+      ${no-deprecated-declarations})
 endif()
 
 # Link test (build error if inlines missing)
@@ -98,46 +113,49 @@ set_target_properties(link_test_1 PROPERTIES FOLDER "Tests")
 add_executable(link_test_2 link_test_2.cpp)
 target_link_libraries(link_test_2 PUBLIC CLI11 link_test_1)
 add_gtest(link_test_2)
+if (CLI11_FORCE_LIBCXX)
+  set_property(TARGET link_test_1 APPEND_STRING
+    PROPERTY LINK_FLAGS -stdlib=libc++)
+  set_property(TARGET link_test_2 APPEND_STRING
+    PROPERTY LINK_FLAGS -stdlib=libc++)
+endif()
+
 
 # Add informational printout
-# Force this to be in a standard location so CTest can find it
 add_executable(informational informational.cpp)
 target_link_libraries(informational PUBLIC CLI11)
-set_target_properties(informational PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-    RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}"
-    RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}"
-    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}"
-    RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_BINARY_DIR}"
-    )
+if (CLI11_FORCE_LIBCXX)
+  set_property(TARGET informational APPEND_STRING
+    PROPERTY LINK_FLAGS -stdlib=libc++)
+endif()
 
 # Adding this printout to CTest
-file(WRITE "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
-    "set(CTEST_CUSTOM_PRE_TEST \"${CMAKE_BINARY_DIR}/informational\")"
-    )
+file(GENERATE OUTPUT "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
+  CONTENT [[
+  set(CTEST_CUSTOM_PRE_TEST "$<TARGET_FILE:informational>")
+]])
 
 # Add boost to test boost::optional if available
 find_package(Boost 1.61)
-if(Boost_FOUND)
-    if(TARGET Boost::boost)
-        target_link_libraries(informational PRIVATE Boost::boost)
-        target_link_libraries(OptionalTest PRIVATE Boost::boost)
-    else()
-        target_include_directories(informational PRIVATE ${Boost_INCLUDE_DIRS})
-        target_include_directories(OptionalTest PRIVATE ${Boost_INCLUDE_DIRS})
-    endif()
+set(boost-optional $<$<BOOL:${Boost_FOUND}>:CLI11_BOOST_OPTIONAL>)
+set(boost-include $<$<BOOL:${Boost_FOUND}>:${Boost_INCLUDE_DIRS}>)
+target_include_directories(informational PRIVATE ${boost-include})
+target_compile_definitions(informational PRIVATE ${boost-optional})
 
-    target_compile_definitions(informational PRIVATE CLI11_BOOST_OPTIONAL)
-    target_compile_definitions(OptionalTest PRIVATE CLI11_BOOST_OPTIONAL)
+target_include_directories(OptionalTest PRIVATE ${boost-include})
+target_compile_definitions(OptionalTest PRIVATE ${boost-optional})
+if(TARGET Boost::boost)
+    target_link_libraries(informational PRIVATE Boost::boost)
+    target_link_libraries(OptionalTest PRIVATE Boost::boost)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL Coverage)
-    include(CodeCoverage)
-    setup_target_for_coverage(
-        NAME CLI11_coverage
-        EXECUTABLE ctest
-        DEPENDENCIES
-          ${CLI11_TESTS}
-          ${CLI11_MULTIONLY_TESTS})
+  include(CodeCoverage)
+  setup_target_for_coverage(
+      NAME CLI11_coverage
+      EXECUTABLE ctest
+      DEPENDENCIES
+        ${CLI11_TESTS}
+        ${CLI11_MULTIONLY_TESTS})
 endif()
 


### PR DESCRIPTION
Hello! I like this library and figured the CMake files could use a bit of a cleanup and partial modernization. Obviously I tried my best to keep it in line with 3.4 through 3.14, however I did take the liberty to break existing options to reduce the chance of a option collision. Please let me know if any other changes are required, I tried very hard to keep it readable and in some cases improve the readability for others. I did test this locally on clang and gcc, but not on windows, as I'm currently traveling and don't have access to my windows machine. Anyhow, the changes involved here include:

Using `GNUInstallDirs` for some (but not all) install paths

Using generator expressions supported from 3.4 onwards

Using the `APPEND_STRING` setting for `set_property` so that we do not overwrite the `CMAKE_EXE_LINKER_FLAGS` variable.

Collated ALL options (dependent or otherwise) into one location

Modify build options to be "namespaced" to prevent collisions when used via `add_subdirectory`

Clean up `find_package(Python...)` so that an actual target is used, rather than a variable

Moved most `file(WRITE)` commands to `file(GENERATE)`. This reduces a little bit of overhead during the configure stage.

Fix having to output informational target into the root binary dir. We now use `file(GENERATE)` and `$<TARGET_FILE>` to get the correct path to the target.

If `git submodules update --init` has NOT been run, and the FetchContent cmake module is available, test and example dependencies will be cloned as necessary via `FetchContent`. This will not affect the source directory, but will place the git clones into _deps by default (This is configurable with `FetchContent`. Please see the cmake documentation for more info)

if `CONFIGURE_DEPENDS` is available for CLI11_headers, it will now be used. This could help in the future for adding or removing headers from the current library.

CTest is now provided by default, so that `BUILD_TESTING` is not defined, and `enable_testing` is not manually called. CTest takes care of this for us.

Removed unnecessary CPack variables, as it will use PROJECT_VERSION by default.