### PR TITLE
Require semicolon after CLI11_PARSE()

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -28,11 +28,13 @@ namespace CLI {
 
 #ifndef CLI11_PARSE
 #define CLI11_PARSE(app, argc, argv)                                                                                   \
-    try {                                                                                                              \
-        (app).parse((argc), (argv));                                                                                   \
-    } catch(const CLI::ParseError &e) {                                                                                \
-        return (app).exit(e);                                                                                          \
-    }
+    do {                                                                                                               \
+        try {                                                                                                          \
+            (app).parse((argc), (argv));                                                                               \
+        } catch(const CLI::ParseError &e) {                                                                            \
+            return (app).exit(e);                                                                                      \
+        }
+    } while (0)
 #endif
 
 namespace detail {

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -33,7 +33,7 @@ namespace CLI {
             (app).parse((argc), (argv));                                                                               \
         } catch(const CLI::ParseError &e) {                                                                            \
             return (app).exit(e);                                                                                      \
-        }
+        }                                                                                                              \
     } while (0)
 #endif
 


### PR DESCRIPTION
Placates some analysis tools that warn about empty statements.