### PR TITLE
Type size refactor

### DIFF
--- a/book/chapters/options.md
+++ b/book/chapters/options.md
@@ -165,7 +165,7 @@ Windows style options do not allow combining short options or values not separat
 
 ## Parse configuration
 
-How an option and its arguments are parsed depends on a set of controls that are part of the option structure.  In most circumstances these controls are set automatically based on the function used to create the option and the type the arguments are parsed into.  The variables define the size of the underlying type (essentially how many strings make up the type), the expected size (how many groups are expected) and a flag indicating if multiple groups are allowed with a single option.  And these interact with the `multi_option_policy` when it comes time to parse.  
+How an option and its arguments are parsed depends on a set of controls that are part of the option structure.  In most circumstances these controls are set automatically based on the function used to create the option and the type the arguments are parsed into.  The variables define the size of the underlying type (essentially how many strings make up the type), the expected size (how many groups are expected) and a flag indicating if multiple groups are allowed with a single option.  And these interact with the `multi_option_policy` when it comes time to parse.
 
 ### examples
 How options manage this is best illustrated through some examples
@@ -173,7 +173,7 @@ How options manage this is best illustrated through some examples
 std::string val;
 app.add_option("--opt",val,"description");
 ```
-creates an option that assigns a value to a `std::string`  When this option is constructed it sets a type_size of 1.  meaning that the assignment uses a single string.  The Expected size is also set to 1 by default, and `allow_extra_args` is set to false. meaning that each time this option is called 1 argument is expected.  This would also be the case if val were a `double`, `int` or any other single argument types.  
+creates an option that assigns a value to a `std::string`  When this option is constructed it sets a type_size of 1.  meaning that the assignment uses a single string.  The Expected size is also set to 1 by default, and `allow_extra_args` is set to false. meaning that each time this option is called 1 argument is expected.  This would also be the case if val were a `double`, `int` or any other single argument types.
 
 now for example
 ```cpp
@@ -188,20 +188,20 @@ std::vector<int> val;
 app.add_option("--opt",val,"description");
 ```
 
-detects a type size of 1, since the underlying element type is a single string, so the minimum number of strings is 1.  But since it is a vector the expected number can be very big.  The default for a vector is (1<<30), and the allow_extra_args is set to true.  This means that at least 1 argument is expected to follow the option, but arbitrary numbers of arguments may follow.  These are checked if they have the form of an option but if not they are added to the argument.   
+detects a type size of 1, since the underlying element type is a single string, so the minimum number of strings is 1.  But since it is a vector the expected number can be very big.  The default for a vector is (1<<30), and the allow_extra_args is set to true.  This means that at least 1 argument is expected to follow the option, but arbitrary numbers of arguments may follow.  These are checked if they have the form of an option but if not they are added to the argument.
 
 ```cpp
 std::vector<std::tuple<int, double, std::string>> val;
 app.add_option("--opt",val,"description");
 ```
-gets into the complicated cases where the type size is now 3.  and the expected max is set to a large number and `allow_extra_args` is set to true.  In this case at least 3 arguments are required to follow the option,  and subsequent groups must come in groups of three, otherwise an error will result.  
+gets into the complicated cases where the type size is now 3.  and the expected max is set to a large number and `allow_extra_args` is set to true.  In this case at least 3 arguments are required to follow the option,  and subsequent groups must come in groups of three, otherwise an error will result.
 
 ```cpp
 bool val;
 app.add_flag("--opt",val,"description");
 ```
 
-Using the add_flag methods for creating options creates an option with an expected size of 0, implying no arguments can be passed.  
+Using the add_flag methods for creating options creates an option with an expected size of 0, implying no arguments can be passed.
 
 ### Customization
 
@@ -212,7 +212,7 @@ std::string val;
 auto opt=app.add_flag("--opt{vvv}",val,"description");
 opt->expected(0,1);
 ```
-will create a hybrid option, that can exist on its own in which case the value "vvv" is used or if a value is given that value will be used.  
+will create a hybrid option, that can exist on its own in which case the value "vvv" is used or if a value is given that value will be used.
 
 [^1]: For example, enums are not printable to `std::cout`.
 [^2]: There is a small difference. An combined unlimited option will not prioritize over a positional that could still accept values.

--- a/book/chapters/options.md
+++ b/book/chapters/options.md
@@ -72,23 +72,26 @@ When you call `add_option`, you get a pointer to the added option. You can use t
 
 | Modifier | Description |
 |----------|-------------|
-| `->required()`| The program will quit if this option is not present. This is `mandatory` in Plumbum, but required options seems to be a more standard term. For compatibility, `->mandatory()` also works. |
-| `->expected(N)`| Take `N` values instead of as many as possible, only for vector args.|
-| `->needs(opt)`| This option requires another option to also be present, opt is an `Option` pointer.|
-| `->excludes(opt)`| This option cannot be given with `opt` present, opt is an `Option` pointer.|
-| `->envname(name)`| Gets the value from the environment if present and not passed on the command line.|
-| `->group(name)`| The help group to put the option in. No effect for positional options. Defaults to `"Options"`. `"Hidden"` will not show up in the help print.|
-| `->ignore_case()`| Ignore the case on the command line (also works on subcommands, does not affect arguments).|
-| `->ignore_underscore()`| Ignore any underscores on the command line (also works on subcommands, does not affect arguments, new in CLI11 1.7).|
-| `->multi_option_policy(CLI::MultiOptionPolicy::Throw)` | Sets the policy if 1 argument expected but this was received on the command line several times. `Throw`ing an error is the default, but `TakeLast`, `TakeFirst`, and `Join` are also available. See the next three lines for shortcuts to set this more easily. |
-| `->take_last()` | Only use the last option if passed several times. This is always true by default for bool options, regardless of the app default, but can be set to false explicitly with `->multi_option_policy()`.|
+| `->required()` | The program will quit if this option is not present. This is `mandatory` in Plumbum, but required options seems to be a more standard term. For compatibility, `->mandatory()` also works. |
+| `->expected(N)` | Take `N` values instead of as many as possible, mainly for vector args. |
+| `->expected(Nmin,Nmax)` | Take between `Nmin` and `Nmax` values. |
+| `->needs(opt)` | This option requires another option to also be present, opt is an `Option` pointer. |
+| `->excludes(opt)` | This option cannot be given with `opt` present, opt is an `Option` pointer. |
+| `->envname(name)` | Gets the value from the environment if present and not passed on the command line. |
+| `->group(name)` | The help group to put the option in. No effect for positional options. Defaults to `"Options"`. `"Hidden"` will not show up in the help print. |
+| `->ignore_case()` | Ignore the case on the command line (also works on subcommands, does not affect arguments). |
+| `->ignore_underscore()` | Ignore any underscores on the command line (also works on subcommands, does not affect arguments, new in CLI11 1.7). |
+| `->allow_extra_args()` | Allow extra argument values to be included when an option is passed. Enabled by default for vector options. |
+| `->multi_option_policy(CLI::MultiOptionPolicy::Throw)` | Sets the policy for handling multiple arguments if the option was received on the command line several times. `Throw`ing an error is the default, but `TakeLast`, `TakeFirst`, `TakeAll`, and `Join` are also available. See the next three lines for shortcuts to set this more easily. |
+| `->take_last()` | Only use the last option if passed several times. This is always true by default for bool options, regardless of the app default, but can be set to false explicitly with `->multi_option_policy()`. |
 | `->take_first()` | sets `->multi_option_policy(CLI::MultiOptionPolicy::TakeFirst)` |
-| `->join()` | sets `->multi_option_policy(CLI::MultiOptionPolicy::Join)`, which uses newlines to join all arguments into a single string output. |
-| `->check(CLI::ExistingFile)`| Requires that the file exists if given.|
-| `->check(CLI::ExistingDirectory)`| Requires that the directory exists.|
-| `->check(CLI::NonexistentPath)`| Requires that the path does not exist.|
-| `->check(CLI::Range(min,max))`| Requires that the option be between min and max (make sure to use floating point if needed). Min defaults to 0.|
-| `->each(void(std::string))` | Run a function on each parsed value, *in order*.|
+| `->join()` | sets `->multi_option_policy(CLI::MultiOptionPolicy::Join)`, which uses newlines or the specified delimiter to join all arguments into a single string output. |
+| `->join(delim)` | sets `->multi_option_policy(CLI::MultiOptionPolicy::Join)`, which uses `delim` to join all arguments into a single string output. |
+| `->check(CLI::ExistingFile)` | Requires that the file exists if given. |
+| `->check(CLI::ExistingDirectory)` | Requires that the directory exists. |
+| `->check(CLI::NonexistentPath)` | Requires that the path does not exist. |
+| `->check(CLI::Range(min,max))` | Requires that the option be between min and max (make sure to use floating point if needed). Min defaults to 0. |
+| `->each(void(std::string))` | Run a function on each parsed value, *in order*. |
 
 The `->check(...)` modifiers adds a callback function of the form `bool function(std::string)` that runs on every value that the option receives, and returns a value that tells CLI11 whether the check passed or failed.
 
@@ -101,7 +104,7 @@ CLI::Option* opt = app.add_flag("--opt");
 
 CLI11_PARSE(app, argv, argc);
 
-if(*opt)
+if(* opt)
     std::cout << "Flag recieved " << opt->count() << " times." << std::endl;
 ```
 
@@ -109,10 +112,10 @@ if(*opt)
 
 One of CLI11's systems to allow customizability without high levels of verbosity is the inheritance system. You can set default values on the parent `App`, and all options and subcommands created from it remember the default values at the point of creation. The default value for Options, specifically, are accessible through the `option_defaults()` method. There are four settings that can be set and inherited:
 
-* `group`: The group name starts as "Options"
-* `required`: If the option must be given. Defaults to `false`. Is ignored for flags.
-* `multi_option_policy`: What to do if several copies of an option are passed and one value is expected. Defaults to `CLI::MultiOptionPolicy::Throw`. This is also used for bool flags, but they always are created with the value `CLI::MultiOptionPolicy::TakeLast` regardless of the default, so that multiple bool flags does not cause an error. But you can override that flag by flag.
-* `ignore_case`: Allow any mixture of cases for the option or flag name
+*   `group`: The group name starts as "Options"
+*   `required`: If the option must be given. Defaults to `false`. Is ignored for flags.
+*   `multi_option_policy`: What to do if several copies of an option are passed and one value is expected. Defaults to `CLI::MultiOptionPolicy::Throw`. This is also used for bool flags, but they always are created with the value `CLI::MultiOptionPolicy::TakeLast` regardless of the default, so that multiple bool flags does not cause an error. But you can override that flag by flag.
+*   `ignore_case`: Allow any mixture of cases for the option or flag name
 
 An example of usage:
 
@@ -148,36 +151,68 @@ std::complex<float> val;
 app.add_complex("--cplx", val);
 ```
 
-### Optionals (New in CLI11 1.5)
-
-If you have a compiler with `__has_include`, you can use `std::optional`, `std::experimental::optional`, and `boost::optional` in `add_option`. You can manually enforce support for one of these by defining the corresponding macro before including CLI11 (or in your build system). For example:
-
-```cpp
-#define CLI11_BOOST_OPTIONAL
-#include <CLI/CLI.hpp>
-
-...
-
-boost::optional<int> x;
-app.add_option("-x", x);
-
-CLI11_PARSE(app, argc, argv);
-
-if(x)
-    std::cout << *x << std::endl;
-```
-
 ### Windows style options (New in CLI11 1.7)
 
 You can also set the app setting `app->allow_windows_style_options()` to allow windows style options to also be recognized on the command line:
 
-* `/a` (flag)
-* `/f filename` (option)
-* `/long` (long flag)
-* `/file filename` (space)
-* `/file:filename` (colon)
+*   `/a` (flag)
+*   `/f filename` (option)
+*   `/long` (long flag)
+*   `/file filename` (space)
+*   `/file:filename` (colon)
 
 Windows style options do not allow combining short options or values not separated from the short option like with `-` options. You still specify option names in the same manor as on Linux with single and double dashes when you use the `add_*` functions, and the Linux style on the command line will still work. If a long and a short option share the same name, the option will match on the first one defined.
+
+## Parse configuration
+
+How an option and its arguments are parsed depends on a set of controls that are part of the option structure.  In most circumstances these controls are set automatically based on the function used to create the option and the type the arguments are parsed into.  The variables define the size of the underlying type (essentially how many strings make up the type), the expected size (how many groups are expected) and a flag indicating if multiple groups are allowed with a single option.  And these interact with the `multi_option_policy` when it comes time to parse.  
+
+### examples
+How options manage this is best illustrated through some examples
+```cpp
+std::string val;
+app.add_option("--opt",val,"description");
+```
+creates an option that assigns a value to a `std::string`  When this option is constructed it sets a type_size of 1.  meaning that the assignment uses a single string.  The Expected size is also set to 1 by default, and `allow_extra_args` is set to false. meaning that each time this option is called 1 argument is expected.  This would also be the case if val were a `double`, `int` or any other single argument types.  
+
+now for example
+```cpp
+std::pair<int, std::string> val;
+app.add_option("--opt",val,"description");
+```
+
+In this case the typesize is automatically detected to be 2 instead of 1, so the parsing would expect 2 arguments associated with the option.
+
+```cpp
+std::vector<int> val;
+app.add_option("--opt",val,"description");
+```
+
+detects a type size of 1, since the underlying element type is a single string, so the minimum number of strings is 1.  But since it is a vector the expected number can be very big.  The default for a vector is (1<<30), and the allow_extra_args is set to true.  This means that at least 1 argument is expected to follow the option, but arbitrary numbers of arguments may follow.  These are checked if they have the form of an option but if not they are added to the argument.   
+
+```cpp
+std::vector<std::tuple<int, double, std::string>> val;
+app.add_option("--opt",val,"description");
+```
+gets into the complicated cases where the type size is now 3.  and the expected max is set to a large number and `allow_extra_args` is set to true.  In this case at least 3 arguments are required to follow the option,  and subsequent groups must come in groups of three, otherwise an error will result.  
+
+```cpp
+bool val;
+app.add_flag("--opt",val,"description");
+```
+
+Using the add_flag methods for creating options creates an option with an expected size of 0, implying no arguments can be passed.  
+
+### Customization
+
+The `type_size(N)`, `type_size(Nmin, Nmax)`, `expected(N)`, `expected(Nmin,Nmax)`, and `allow_extra_args()` can be used to customize an option.  For example
+
+```cpp
+std::string val;
+auto opt=app.add_flag("--opt{vvv}",val,"description");
+opt->expected(0,1);
+```
+will create a hybrid option, that can exist on its own in which case the value "vvv" is used or if a value is given that value will be used.  
 
 [^1]: For example, enums are not printable to `std::cout`.
 [^2]: There is a small difference. An combined unlimited option will not prioritize over a positional that could still accept values.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2778,7 +2778,7 @@ class App {
             while((collected < max_num || op->get_allow_extra_args()) && !args.empty() &&
                   _recognize(args.back(), false) == detail::Classifier::NONE) {
                 // If any required positionals remain, don't keep eating
-                if(remreqpos >= static_cast<int>(args.size())) {
+                if(remreqpos >= args.size()) {
                     break;
                 }
 

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -997,33 +997,52 @@ class App {
     }
 
     /// Add a complex number
-    template <typename T>
+    template <typename T, typename XC = double>
     Option *add_complex(std::string option_name,
                         T &variable,
                         std::string option_description = "",
                         bool defaulted = false,
                         std::string label = "COMPLEX") {
 
-        CLI::callback_t fun = [&variable](results_t res) {
-            if(res[1].back() == 'i')
-                res[1].pop_back();
-            double x, y;
-            bool worked = detail::lexical_cast(res[0], x) && detail::lexical_cast(res[1], y);
+        CLI::callback_t fun = [&variable](const results_t &res) {
+            XC x, y;
+            bool worked;
+            if(res.size() >= 2 && !res[1].empty()) {
+                auto str1 = res[1];
+                if(str1.back() == 'i' || str1.back() == 'j')
+                    str1.pop_back();
+                worked = detail::lexical_cast(res[0], x) && detail::lexical_cast(str1, y);
+            } else {
+                auto str1 = res.front();
+                auto nloc = str1.find_last_of('-');
+                if(nloc != std::string::npos && nloc > 0) {
+                    worked = detail::lexical_cast(str1.substr(0, nloc), x);
+                    str1 = str1.substr(nloc);
+                    if(str1.back() == 'i' || str1.back() == 'j')
+                        str1.pop_back();
+                    worked = worked && detail::lexical_cast(str1, y);
+                } else {
+                    if(str1.back() == 'i' || str1.back() == 'j') {
+                        str1.pop_back();
+                        worked = detail::lexical_cast(str1, y);
+                        x = XC{0};
+                    } else {
+                        worked = detail::lexical_cast(str1, x);
+                        y = XC{0};
+                    }
+                }
+            }
             if(worked)
-                variable = T(x, y);
+                variable = T{x, y};
             return worked;
         };
 
-        auto default_function = [&variable]() {
-            std::stringstream out;
-            out << variable;
-            return out.str();
-        };
+        auto default_function = [&variable]() { return CLI::detail::checked_to_string<T, T>(variable); };
 
         CLI::Option *opt =
             add_option(option_name, std::move(fun), std::move(option_description), defaulted, default_function);
 
-        opt->type_name(label)->type_size(2);
+        opt->type_name(label)->type_size(1, 2)->delimiter('+');
         return opt;
     }
 
@@ -2778,6 +2797,11 @@ class App {
                 op->add_result(res);
                 parse_order_.push_back(op.get());
             }
+        }
+
+        // if we only partially completed a type then add a Null for later processing
+        if(min_num > 0 && op->get_type_size_max() != min_num && collected % op->get_type_size_max() != 0) {
+            op->add_result(std::string{});
         }
 
         if(!rest.empty()) {

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -667,8 +667,8 @@ class App {
             remove_option(opt);
             throw IncorrectConstruction::PositionalFlag(pos_name);
         }
-
-        opt->type_size(0);
+        opt->multi_option_policy(MultiOptionPolicy::TakeLast);
+        opt->expected(0);
         return opt;
     }
 
@@ -702,7 +702,8 @@ class App {
             }
             return true;
         };
-        return _add_flag_internal(flag_name, std::move(fun), std::move(flag_description));
+        return _add_flag_internal(flag_name, std::move(fun), std::move(flag_description))
+            ->multi_option_policy(MultiOptionPolicy::TakeAll);
     }
 
     /// Other type version accepts all other types that are not vectors such as bool, enum, string or other classes
@@ -722,9 +723,7 @@ class App {
             }
             return CLI::detail::lexical_cast(res[0], flag_result);
         };
-        Option *opt = _add_flag_internal(flag_name, std::move(fun), std::move(flag_description));
-        opt->multi_option_policy(CLI::MultiOptionPolicy::TakeLast);
-        return opt;
+        return _add_flag_internal(flag_name, std::move(fun), std::move(flag_description));
     }
 
     /// Vector version to capture multiple flags.
@@ -741,7 +740,8 @@ class App {
             }
             return retval;
         };
-        return _add_flag_internal(flag_name, std::move(fun), std::move(flag_description));
+        return _add_flag_internal(flag_name, std::move(fun), std::move(flag_description))
+            ->multi_option_policy(MultiOptionPolicy::TakeAll);
     }
 
     /// Add option for callback that is triggered with a true flag and takes no arguments
@@ -759,9 +759,7 @@ class App {
                 function();
             return result;
         };
-        Option *opt = _add_flag_internal(flag_name, std::move(fun), std::move(flag_description));
-        opt->multi_option_policy(CLI::MultiOptionPolicy::TakeLast);
-        return opt;
+        return _add_flag_internal(flag_name, std::move(fun), std::move(flag_description));
     }
 
     /// Add option for callback with an integer value
@@ -775,7 +773,8 @@ class App {
             function(flag_count);
             return true;
         };
-        return _add_flag_internal(flag_name, std::move(fun), std::move(flag_description));
+        return _add_flag_internal(flag_name, std::move(fun), std::move(flag_description))
+            ->multi_option_policy(MultiOptionPolicy::TakeAll);
     }
 
 #ifdef CLI11_CPP14

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -720,9 +720,6 @@ class App {
                      std::string flag_description = "") {
 
         CLI::callback_t fun = [&flag_result](const CLI::results_t &res) {
-            if(res.size() != 1) {
-                return false;
-            }
             return CLI::detail::lexical_cast(res[0], flag_result);
         };
         return _add_flag_internal(flag_name, std::move(fun), std::move(flag_description));
@@ -752,9 +749,6 @@ class App {
                               std::string flag_description = "") {
 
         CLI::callback_t fun = [function](const CLI::results_t &res) {
-            if(res.size() != 1) {
-                return false;
-            }
             bool trigger;
             auto result = CLI::detail::lexical_cast(res[0], trigger);
             if(trigger)

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2793,7 +2793,7 @@ class App {
             }
         }
 
-        // if we only partially completed a type then add a Null for later processing
+        // if we only partially completed a type then add an empty string for later processing
         if(min_num > 0 && op->get_type_size_max() != min_num && collected % op->get_type_size_max() != 0) {
             op->add_result(std::string{});
         }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2477,8 +2477,8 @@ class App {
             }
             break;
 
-            // LCOV_EXCL_START
         default:
+            // LCOV_EXCL_START
             throw HorribleError("unrecognized classifier (you should not see this!)");
             // LCOV_EXCL_END
         }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -570,7 +570,7 @@ class App {
             return CLI::detail::checked_to_string<T, XC>(variable);
         });
         opt->type_name(detail::type_name<XC>());
-        // these must be actual variable since (std::max) sometimes is defined in terms of references and references
+        // these must be actual variables since (std::max) sometimes is defined in terms of references and references
         // to structs used in the evaluation can be temporary so that would cause issues.
         auto Tcount = detail::type_count<T>::value;
         auto XCcount = detail::type_count<XC>::value;

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -554,8 +554,7 @@ class App {
         // LCOV_EXCL_END
     }
 
-    /// Add option for non-vectors (duplicate copy needed without defaulted to avoid `iostream << value`)
-
+    /// Add option for assigning to a variable
     template <typename T, typename XC = T, enable_if_t<!std::is_const<XC>::value, detail::enabler> = detail::dummy>
     Option *add_option(std::string option_name,
                        T &variable, ///< The variable to set
@@ -575,6 +574,7 @@ class App {
         auto Tcount = detail::type_count<T>::value;
         auto XCcount = detail::type_count<XC>::value;
         opt->type_size((std::max)(Tcount, XCcount));
+        opt->expected(detail::expected_count<XC>::value);
         return opt;
     }
 
@@ -596,6 +596,7 @@ class App {
         Option *opt = add_option(option_name, std::move(fun), option_description, false);
         opt->type_name(detail::type_name<T>());
         opt->type_size(detail::type_count<T>::value);
+        opt->expected(detail::expected_count<T>::value);
         return opt;
     }
 

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2206,10 +2206,6 @@ class App {
 
             if(opt->count() != 0) {
                 ++used_options;
-                // check to make sure enough argument have been passed  (too many is handled in the parse functions
-                if(static_cast<size_t>(opt->get_items_expected_min()) > opt->count()) {
-                    throw ArgumentMismatch::AtLeast(opt->get_name(), -opt->get_items_expected());
-                }
             }
             // Required but empty
             if(opt->get_required() && opt->count() == 0) {

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -561,7 +561,7 @@ class App {
                        std::string option_description = "",
                        bool defaulted = false) {
 
-        auto fun = [&variable](CLI::results_t res) { // comment for spacing
+        auto fun = [&variable](const CLI::results_t &res) { // comment for spacing
             return detail::lexical_conversion<T, XC>(res, variable);
         };
 
@@ -584,7 +584,7 @@ class App {
                                 const std::function<void(const T &)> &func, ///< the callback to execute
                                 std::string option_description = "") {
 
-        auto fun = [func](CLI::results_t res) {
+        auto fun = [func](const CLI::results_t &res) {
             T variable;
             bool result = detail::lexical_conversion<T, T>(res, variable);
             if(result) {
@@ -696,7 +696,7 @@ class App {
                      T &flag_count, ///< A variable holding the count
                      std::string flag_description = "") {
         flag_count = 0;
-        CLI::callback_t fun = [&flag_count](CLI::results_t res) {
+        CLI::callback_t fun = [&flag_count](const CLI::results_t &res) {
             try {
                 detail::sum_flag_vector(res, flag_count);
             } catch(const std::invalid_argument &) {
@@ -719,7 +719,7 @@ class App {
                      T &flag_result, ///< A variable holding true if passed
                      std::string flag_description = "") {
 
-        CLI::callback_t fun = [&flag_result](CLI::results_t res) {
+        CLI::callback_t fun = [&flag_result](const CLI::results_t &res) {
             if(res.size() != 1) {
                 return false;
             }
@@ -734,7 +734,7 @@ class App {
     Option *add_flag(std::string flag_name,
                      std::vector<T> &flag_results, ///< A vector of values with the flag results
                      std::string flag_description = "") {
-        CLI::callback_t fun = [&flag_results](CLI::results_t res) {
+        CLI::callback_t fun = [&flag_results](const CLI::results_t &res) {
             bool retval = true;
             for(const auto &elem : res) {
                 flag_results.emplace_back();
@@ -751,7 +751,7 @@ class App {
                               std::function<void(void)> function, ///< A function to call, void(void)
                               std::string flag_description = "") {
 
-        CLI::callback_t fun = [function](CLI::results_t res) {
+        CLI::callback_t fun = [function](const CLI::results_t &res) {
             if(res.size() != 1) {
                 return false;
             }
@@ -769,7 +769,7 @@ class App {
                               std::function<void(int64_t)> function, ///< A function to call, void(int)
                               std::string flag_description = "") {
 
-        CLI::callback_t fun = [function](CLI::results_t res) {
+        CLI::callback_t fun = [function](const CLI::results_t &res) {
             int64_t flag_count = 0;
             detail::sum_flag_vector(res, flag_count);
             function(flag_count);

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2206,16 +2206,14 @@ class App {
 
             if(opt->count() != 0) {
                 ++used_options;
-            }
-            // Required or partially filled
-            if(opt->get_required() || opt->count() != 0) {
-                // Make sure enough -N arguments parsed (+N is already handled in parsing function)
-                if(opt->get_items_expected() < 0 && opt->count() < static_cast<size_t>(-opt->get_items_expected()))
+                // check to make sure enough argument have been passed  (too many is handled in the parse functions
+                if(static_cast<size_t>(opt->get_items_expected_min()) > opt->count()) {
                     throw ArgumentMismatch::AtLeast(opt->get_name(), -opt->get_items_expected());
-
-                // Required but empty
-                if(opt->get_required() && opt->count() == 0)
-                    throw RequiredError(opt->get_name());
+                }
+            }
+            // Required but empty
+            if(opt->get_required() && opt->count() == 0) {
+                throw RequiredError(opt->get_name());
             }
             // Requires
             for(const Option *opt_req : opt->needs_)
@@ -2416,7 +2414,7 @@ class App {
 
         if(op->empty()) {
             // Flag parsing
-            if(op->get_type_size() == 0) {
+            if(op->get_expected_min() == 0) {
                 auto res = config_formatter_->to_flag(item);
                 res = op->get_flag_value(item.name, res);
 
@@ -2515,7 +2513,7 @@ class App {
                 for(const Option_p &opt : options_) {
                     if(opt->get_positional() && opt->required_) {
                         if(static_cast<int>(opt->count()) < opt->get_items_expected_min() ||
-                           (opt->get_items_expected() < 0 && opt->count() == 0lu)) {
+                           (opt->get_items_expected_max() >= detail::expected_max_vector_size && opt->count() == 0lu)) {
                             if(validate_positionals_) {
                                 std::string pos = positional;
                                 pos = opt->_validate(pos, 0);

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -668,7 +668,7 @@ class App {
             throw IncorrectConstruction::PositionalFlag(pos_name);
         }
 
-        opt->expected(0, -1);
+        opt->type_size(0);
         return opt;
     }
 
@@ -702,8 +702,7 @@ class App {
             }
             return true;
         };
-        Option *opt = _add_flag_internal(flag_name, std::move(fun), std::move(flag_description));
-        opt->expected(0, -1);
+        return _add_flag_internal(flag_name, std::move(fun), std::move(flag_description));
     }
 
     /// Other type version accepts all other types that are not vectors such as bool, enum, string or other classes

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2476,9 +2476,8 @@ class App {
                 positional_only = true;
             }
             break;
-
-        default:
             // LCOV_EXCL_START
+        default:
             throw HorribleError("unrecognized classifier (you should not see this!)");
             // LCOV_EXCL_END
         }

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -25,7 +25,7 @@ ConfigINI::to_config(const App *app, bool default_also, bool write_description, 
             std::string value;
 
             // Non-flags
-            if(opt->get_type_size() != 0) {
+            if(opt->get_expected_min() != 0) {
 
                 // If the option was found on command line
                 if(opt->count() > 0)
@@ -56,7 +56,7 @@ ConfigINI::to_config(const App *app, bool default_also, bool write_description, 
                 }
 
                 // Don't try to quote anything that is not size 1
-                if(opt->get_items_expected() != 1)
+                if(opt->get_items_expected_max() != 1)
                     out << name << "=" << value << std::endl;
                 else
                     out << name << "=" << detail::add_quotes_if_needed(value) << std::endl;

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -246,8 +246,13 @@ class ArgumentMismatch : public ParseError {
                                            ", got " + std::to_string(recieved)),
                            ExitCodes::ArgumentMismatch) {}
 
-    static ArgumentMismatch AtLeast(std::string name, int num) {
-        return ArgumentMismatch(name + ": At least " + std::to_string(num) + " required");
+    static ArgumentMismatch AtLeast(std::string name, int num, size_t received) {
+        return ArgumentMismatch(name + ": At least " + std::to_string(num) + " required but received " +
+                                std::to_string(received));
+    }
+    static ArgumentMismatch AtMost(std::string name, int num, size_t received) {
+        return ArgumentMismatch(name + ": At Most " + std::to_string(num) + " required but received " +
+                                std::to_string(received));
     }
     static ArgumentMismatch TypedAtLeast(std::string name, int num, std::string type) {
         return ArgumentMismatch(name + ": " + std::to_string(num) + " required " + type + " missing");

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -234,10 +234,11 @@ inline std::string Formatter::make_option_opts(const Option *opt) const {
             out << " " << get_label(opt->get_type_name());
         if(!opt->get_default_str().empty())
             out << "=" << opt->get_default_str();
-        if(opt->get_expected() > 1)
-            out << " x " << opt->get_expected();
-        if(opt->get_expected() == -1)
+        if(opt->get_expected_max() == detail::expected_max_vector_size)
             out << " ...";
+        else if(opt->get_expected_min() > 1)
+            out << " x " << opt->get_expected();
+
         if(opt->get_required())
             out << " " << get_label("REQUIRED");
     }
@@ -262,11 +263,11 @@ inline std::string Formatter::make_option_usage(const Option *opt) const {
     // Note that these are positionals usages
     std::stringstream out;
     out << make_option_name(opt, true);
-
-    if(opt->get_expected() > 1)
-        out << "(" << std::to_string(opt->get_expected()) << "x)";
-    else if(opt->get_expected() < 0)
+    if(opt->get_expected_max() >= detail::expected_max_vector_size)
         out << "...";
+    else if(opt->get_expected_max() > 1)
+        out << "(" << opt->get_expected() << "x)";
+
     return opt->get_required() ? out.str() : "[" + out.str() + "]";
 }
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -895,7 +895,7 @@ class Option : public OptionBase<Option> {
             if(flag_like_) {
                 return (ind < 0) ? trueString : default_flag_values_[static_cast<size_t>(ind)].second;
             } else {
-                return (ind < 0) ? std::string{} : default_flag_values_[static_cast<size_t>(ind)].second;
+                return (ind < 0) ? default_str_ : default_flag_values_[static_cast<size_t>(ind)].second;
             }
         }
         if(ind < 0) {

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -1028,7 +1028,9 @@ class Option : public OptionBase<Option> {
             expected_max_ = detail::expected_max_vector_size;
         } else {
             type_size_max_ = option_type_size;
-            type_size_min_ = option_type_size;
+            if(type_size_max_ < detail::expected_max_vector_size) {
+                type_size_min_ = option_type_size;
+            }
             if(type_size_max_ == 0)
                 required_ = false;
         }
@@ -1107,10 +1109,14 @@ class Option : public OptionBase<Option> {
             if(type_size_max_ > 1) { // in this context index refers to the index in the type
                 int index = 0;
                 for(std::string &result : results_) {
+                    if(result.empty() && type_size_max_ != type_size_min_) {
+                        index = 0; // reset index for variable size chunks
+                        continue;
+                    }
                     auto err_msg = _validate(result, index % type_size_max_);
-                    ++index;
                     if(!err_msg.empty())
                         throw ValidationError(get_name(), err_msg);
+                    ++index;
                 }
             } else {
                 int index = 0;

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -353,15 +353,6 @@ class Option : public OptionBase<Option> {
 
     /// Set the number of expected arguments (Flags don't use this)
     Option *expected(int value) {
-
-        // Break if this is a flag
-        if(type_size_max_ == 0)
-            throw IncorrectConstruction::SetFlag(get_name(true, true));
-
-        // Setting 0 is not allowed
-        if(value == 0)
-            throw IncorrectConstruction::Set0Opt(get_name());
-
         if(value < 0) {
             expected_min_ = -value;
             expected_max_ = (1 << 30);
@@ -374,11 +365,6 @@ class Option : public OptionBase<Option> {
 
     /// Set the range of expected arguments (Flags don't use this)
     Option *expected(int value_min, int value_max) {
-
-        // Break if this is a flag
-        if(type_size_max_ == 0)
-            throw IncorrectConstruction::SetFlag(get_name(true, true));
-
         if(value_min <= 0)
             value_min = 1;
 
@@ -782,7 +768,7 @@ class Option : public OptionBase<Option> {
             if(!(callback_)) {
                 return;
             }
-            const results_t &send_results = proc_results_.empty() ? proc_results_ : results_;
+            const results_t &send_results = proc_results_.empty() ? results_ : proc_results_;
             bool local_result = callback_(send_results);
 
             if(local_result)

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -749,11 +749,12 @@ class Option : public OptionBase<Option> {
         if(!validators_.empty()) {
             int index = 0;
             // this is not available until multi_option_policy with type_size_>0 is enabled and functional
-            // if(type_size_ > 0 && multi_option_policy_ == CLI::MultiOptionPolicy::TakeLast) {
-            //    index = type_size_ - static_cast<int>(results_.size());
-            //}
-            if(type_size_ < 0 && multi_option_policy_ == CLI::MultiOptionPolicy::TakeLast) { // for vector operations
-                index = expected_ - static_cast<int>(results_.size());
+            if(type_size_max_ > 0 && multi_option_policy_ == CLI::MultiOptionPolicy::TakeLast) {
+                index = type_size_max_ - static_cast<int>(results_.size());
+            }
+            if(type_size_max_ > 1 &&
+               multi_option_policy_ == CLI::MultiOptionPolicy::TakeLast) { // for vector operations
+                index = expected_max_ - static_cast<int>(results_.size());
             }
             for(std::string &result : results_) {
                 auto err_msg = _validate(result, index);

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -1041,7 +1041,7 @@ class Option : public OptionBase<Option> {
             // this section is included for backwards compatibility
             expected_max_ = detail::expected_max_vector_size;
             option_type_size_min = (std::abs)(option_type_size_min);
-            option_type_size_max = (std::abs)(option_type_size_min);
+            option_type_size_max = (std::abs)(option_type_size_max);
         }
 
         if(option_type_size_min > option_type_size_max) {
@@ -1051,7 +1051,7 @@ class Option : public OptionBase<Option> {
             type_size_min_ = option_type_size_min;
             type_size_max_ = option_type_size_max;
         }
-        if(type_size_min_ == 0) {
+        if(type_size_max_ == 0) {
             required_ = false;
         }
         return this;

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -1108,12 +1108,18 @@ class Option : public OptionBase<Option> {
         if(!validators_.empty()) {
             if(type_size_max_ > 1) { // in this context index refers to the index in the type
                 int index = 0;
+                if(get_items_expected_max() < static_cast<int>(results_.size()) &&
+                   multi_option_policy_ == CLI::MultiOptionPolicy::TakeLast) {
+                    // create a negative index for the earliest ones
+                    index = get_items_expected_max() - static_cast<int>(results_.size());
+                }
+
                 for(std::string &result : results_) {
-                    if(result.empty() && type_size_max_ != type_size_min_) {
+                    if(result.empty() && type_size_max_ != type_size_min_ && index >= 0) {
                         index = 0; // reset index for variable size chunks
                         continue;
                     }
-                    auto err_msg = _validate(result, index % type_size_max_);
+                    auto err_msg = _validate(result, (index >= 0) ? (index % type_size_max_) : index);
                     if(!err_msg.empty())
                         throw ValidationError(get_name(), err_msg);
                     ++index;

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -715,7 +715,7 @@ class Option : public OptionBase<Option> {
     /// Use `get_name(true)` to get the positional name (replaces `get_pname`)
     std::string get_name(bool positional = false, //<[input] Show the positional name
                          bool all_options = false //<[input] Show every option
-    ) const {
+                         ) const {
         if(get_group().empty())
             return {}; // Hidden
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -21,7 +21,8 @@
 namespace CLI {
 
 using results_t = std::vector<std::string>;
-using callback_t = std::function<bool(results_t)>;
+/// callback function definition
+using callback_t = std::function<bool(const results_t &)>;
 
 class Option;
 class App;
@@ -326,10 +327,7 @@ class Option : public OptionBase<Option> {
     ///@}
 
     /// Making an option by hand is not defined, it must be made by the App class
-    Option(std::string option_name,
-           std::string option_description,
-           std::function<bool(results_t)> callback,
-           App *parent)
+    Option(std::string option_name, std::string option_description, callback_t callback, App *parent)
         : description_(std::move(option_description)), parent_(parent), callback_(std::move(callback)) {
         std::tie(snames_, lnames_, pname_) = detail::get_names(detail::split_names(option_name));
     }

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -352,11 +352,16 @@ class Option : public OptionBase<Option> {
     /// @name Setting options
     ///@{
 
-    /// Set the number of expected arguments (Flags don't use this)
+    /// Set the number of expected arguments
     Option *expected(int value) {
         if(value < 0) {
             expected_min_ = -value;
             expected_max_ = (1 << 30);
+            allow_extra_args_ = true;
+        } else if(value == (1 << 30)) {
+            expected_min_ = 1;
+            expected_max_ = (1 << 30);
+            allow_extra_args_ = true;
         } else {
             expected_min_ = (value < (1 << 30)) ? value : 1;
             expected_max_ = value;
@@ -366,10 +371,11 @@ class Option : public OptionBase<Option> {
 
     /// Set the range of expected arguments
     Option *expected(int value_min, int value_max) {
-        if(value_min <= 0)
+        if(value_min < 0) {
             value_min = 1;
+        }
 
-        if(value_max <= 0) {
+        if(value_max < 0) {
             value_min = (1 << 30);
         }
         if(value_max < value_min) {
@@ -382,8 +388,8 @@ class Option : public OptionBase<Option> {
 
         return this;
     }
-    /// Set the value of allow_extra_args which allows extra value arguments on the flag or option to be included with
-    /// each instance
+    /// Set the value of allow_extra_args which allows extra value arguments on the flag or option to be included
+    /// with each instance
     Option *allow_extra_args(bool value) {
         allow_extra_args_ = value;
         return this;

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -377,11 +377,11 @@ class Option : public OptionBase<Option> {
     /// Set the range of expected arguments
     Option *expected(int value_min, int value_max) {
         if(value_min < 0) {
-            value_min = 1;
+            value_min = -value_min;
         }
 
         if(value_max < 0) {
-            value_min = detail::expected_max_vector_size;
+            value_max = detail::expected_max_vector_size;
         }
         if(value_max < value_min) {
             expected_min_ = value_max;

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -673,30 +673,16 @@ class Option : public OptionBase<Option> {
     /// The max number of times the option expects to be included
     int get_expected_max() const { return expected_max_; }
 
-    /// \brief The total number of expected values (including the type)
-    /// This is positive if exactly this number is expected, and negative for at least N values
-    ///
-    /// v = fabs(size_type*expected)
-    /// !MultiOptionPolicy::Throw
-    ///           | Expected < 0  | Expected == 0 | Expected > 0
-    /// Size < 0  |      -v       |       0       |     -v
-    /// Size == 0 |       0       |       0       |      0
-    /// Size > 0  |      -v       |       0       |     -v       // Expected must be 1
-    ///
-    /// MultiOptionPolicy::Throw
-    ///           | Expected < 0  | Expected == 0 | Expected > 0
-    /// Size < 0  |      -v       |       0       |      v
-    /// Size == 0 |       0       |       0       |      0
-    /// Size > 0  |       v       |       0       |      v      // Expected must be 1
-    ///
-    int get_items_expected() const { return type_size_min_ * expected_min_; }
-
+    /// The total min number of expected  string values to be used
     int get_items_expected_min() const { return type_size_min_ * expected_min_; }
 
+    /// Get the maximum number of items expected to be returned and used for the callback
     int get_items_expected_max() const {
         int t = type_size_max_;
         return detail::checked_multiply(t, expected_max_) ? t : detail::expected_max_vector_size;
     }
+    /// The total min number of expected  string values to be used
+    int get_items_expected() const { return get_items_expected_min(); }
 
     /// True if the argument can be given directly
     bool get_positional() const { return pname_.length() > 0; }
@@ -1035,6 +1021,7 @@ class Option : public OptionBase<Option> {
     /// Set a custom option size
     Option *type_size(int option_type_size) {
         if(option_type_size < 0) {
+            // this section is included for backwards compatibility
             type_size_max_ = -option_type_size;
             type_size_min_ = -option_type_size;
             expected_max_ = detail::expected_max_vector_size;
@@ -1048,9 +1035,10 @@ class Option : public OptionBase<Option> {
         }
         return this;
     }
-    /// Set a custom option size range
+    /// Set a custom option type size range
     Option *type_size(int option_type_size_min, int option_type_size_max) {
         if(option_type_size_min < 0 || option_type_size_max < 0) {
+            // this section is included for backwards compatibility
             expected_max_ = detail::expected_max_vector_size;
             option_type_size_min = (std::abs)(option_type_size_min);
             option_type_size_max = (std::abs)(option_type_size_min);

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -319,7 +319,8 @@ class Option : public OptionBase<Option> {
     };
     /// Whether the callback has run (needed for INI parsing)
     option_state current_option_state_{option_state::parsing};
-
+    /// Specify that extra args beyond type_size_max should be allowed
+    bool allow_extra_args_{false};
     ///@}
 
     /// Making an option by hand is not defined, it must be made by the App class
@@ -357,13 +358,13 @@ class Option : public OptionBase<Option> {
             expected_min_ = -value;
             expected_max_ = (1 << 30);
         } else {
-            expected_min_ = value;
+            expected_min_ = (value < (1 << 30)) ? value : 1;
             expected_max_ = value;
         }
         return this;
     }
 
-    /// Set the range of expected arguments (Flags don't use this)
+    /// Set the range of expected arguments
     Option *expected(int value_min, int value_max) {
         if(value_min <= 0)
             value_min = 1;
@@ -381,6 +382,14 @@ class Option : public OptionBase<Option> {
 
         return this;
     }
+    /// Set the value of allow_extra_args which allows extra value arguments on the flag or option to be included with
+    /// each instance
+    Option *allow_extra_args(bool value) {
+        allow_extra_args_ = value;
+        return this;
+    }
+    /// Get the current value of allow extra args
+    bool get_allow_extra_args() const { return allow_extra_args_; }
 
     /// Adds a Validator with a built in type name
     Option *check(Validator validator, std::string validator_name = "") {

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -715,7 +715,7 @@ class Option : public OptionBase<Option> {
     /// Use `get_name(true)` to get the positional name (replaces `get_pname`)
     std::string get_name(bool positional = false, //<[input] Show the positional name
                          bool all_options = false //<[input] Show every option
-                         ) const {
+    ) const {
         if(get_group().empty())
             return {}; // Hidden
 
@@ -965,7 +965,7 @@ class Option : public OptionBase<Option> {
                         res = std::move(extra);
                     }
                 } else {
-                    res.push_back(std::string{});
+                    res.emplace_back();
                 }
             } else {
                 res = reduced_results();

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -346,7 +346,10 @@ class Option : public OptionBase<Option> {
     operator bool() const { return !empty(); }
 
     /// Clear the parsed results (mostly for testing)
-    void clear() { results_.clear(); }
+    void clear() {
+        results_.clear();
+        current_option_state_ = option_state::parsing;
+    }
 
     ///@}
     /// @name Setting options
@@ -948,25 +951,7 @@ class Option : public OptionBase<Option> {
         bool retval;
         if(current_option_state_ >= option_state::reduced || (results_.size() == 1 && validators_.empty())) {
             const results_t &res = (proc_results_.empty()) ? results_ : proc_results_;
-            if(res.empty()) {
-                results_t res2;
-                if(!default_str_.empty()) {
-                    //_add_results takes an rvalue only
-                    _add_result(std::string(default_str_), res2);
-                    _validate_results(res2);
-                    results_t extra;
-                    _reduce_results(extra, res2);
-                    if(!extra.empty()) {
-                        res2 = std::move(extra);
-                    }
-                } else {
-                    res2.push_back(std::string{});
-                }
-                retval = detail::lexical_conversion<T, T>(res2, output);
-            } else {
-                // this is the main path with no allocation
-                retval = detail::lexical_conversion<T, T>(res, output);
-            }
+            retval = detail::lexical_conversion<T, T>(res, output);
         } else {
             results_t res;
             if(results_.empty()) {

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -1143,7 +1143,7 @@ class Option : public OptionBase<Option> {
 
         // max num items expected or length of vector, always at least 1
         // Only valid for a trimming policy
-        size_t trim_size = std::min<size_t>(std::max<size_t>(get_items_expected_max(), 1), results_.size());
+
         res.clear();
         // Operation depends on the policy setting
         switch(multi_option_policy_) {
@@ -1151,15 +1151,19 @@ class Option : public OptionBase<Option> {
             break;
         case MultiOptionPolicy::TakeLast:
             // Allow multi-option sizes (including 0)
-            if(results_.size() != trim_size) {
-                res.assign(results_.end() - trim_size, results_.end());
+            {
+                size_t trim_size = std::min<size_t>(std::max<size_t>(get_items_expected_max(), 1), results_.size());
+                if(results_.size() != trim_size) {
+                    res.assign(results_.end() - trim_size, results_.end());
+                }
             }
             break;
-        case MultiOptionPolicy::TakeFirst:
+        case MultiOptionPolicy::TakeFirst: {
+            size_t trim_size = std::min<size_t>(std::max<size_t>(get_items_expected_max(), 1), results_.size());
             if(results_.size() != trim_size) {
                 res.assign(results_.begin(), results_.begin() + trim_size);
             }
-            break;
+        } break;
         case MultiOptionPolicy::Join:
             if(results_.size() > 1) {
                 res.push_back(detail::join(results_, std::string(1, (delimiter_ == '\0') ? '\n' : delimiter_)));
@@ -1180,13 +1184,6 @@ class Option : public OptionBase<Option> {
             }
             if(results_.size() > num_max) {
                 throw ArgumentMismatch::AtMost(get_name(), static_cast<int>(num_max), results_.size());
-            }
-            auto tmax = get_type_size_max();
-            if(tmax > 1) {
-                auto mod = results_.size() % static_cast<size_t>(tmax);
-                if(mod != 0 && mod < static_cast<size_t>(get_type_size_min())) {
-                    throw ArgumentMismatch(get_name(), get_type_size_min(), mod);
-                }
             }
             break;
         }

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -1167,8 +1167,8 @@ class Option : public OptionBase<Option> {
             break;
         case MultiOptionPolicy::Throw:
         default: {
-            size_t num_min = static_cast<size_t>(get_items_expected_min());
-            size_t num_max = static_cast<size_t>(get_items_expected_max());
+            auto num_min = static_cast<size_t>(get_items_expected_min());
+            auto num_max = static_cast<size_t>(get_items_expected_max());
             if(num_min == 0) {
                 num_min = 1;
             }

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -771,7 +771,7 @@ class Option : public OptionBase<Option> {
             const results_t &send_results = proc_results_.empty() ? results_ : proc_results_;
             bool local_result = callback_(send_results);
 
-            if(local_result)
+            if(!local_result)
                 throw ConversionError(get_name(), results_);
         }
     }

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -31,7 +31,9 @@ std::ostream &operator<<(std::ostream &in, const T &item) {
 using namespace enums;
 
 namespace detail {
-
+/// a constant defining an expected max vector size defined to be a big number that could be multiplied by 4 and not
+/// produce overflow for some expected uses
+constexpr int expected_max_vector_size{1 << 29};
 // Based on http://stackoverflow.com/questions/236129/split-a-string-in-c
 /// Split a string by a delim
 inline std::vector<std::string> split(const std::string &s, char delim) {

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -756,7 +756,7 @@ template <typename T,
               detail::dummy>
 bool lexical_conversion(const std::vector<std ::string> &strings, T &output) {
 
-    if(strings.size() > 1 || strings.size() == 1 && !strings[0].empty()) {
+    if(strings.size() > 1 || (!strings.empty() && !(strings.front().empty()))) {
         XC val;
         auto retval = lexical_conversion<XC, XC>(strings, val);
         output = T{val};

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -749,23 +749,6 @@ bool lexical_conversion(const std::vector<std ::string> &strings, T &output) {
     return lexical_assign<T, XC>(strings[0], output);
 }
 
-/// Lexical conversion if there is only one element but the conversion type is a vector
-template <typename T,
-          typename XC,
-          enable_if_t<!is_tuple_like<T>::value && !is_vector<T>::value && is_vector<XC>::value, detail::enabler> =
-              detail::dummy>
-bool lexical_conversion(const std::vector<std ::string> &strings, T &output) {
-
-    if(strings.size() > 1 || (!strings.empty() && !(strings.front().empty()))) {
-        XC val;
-        auto retval = lexical_conversion<XC, XC>(strings, val);
-        output = T{val};
-        return retval;
-    }
-    output = T{};
-    return true;
-}
-
 /// Lexical conversion if there is only one element but the conversion type is for two call a two element constructor
 template <typename T,
           typename XC,
@@ -843,6 +826,23 @@ bool lexical_conversion(const std::vector<std ::string> &strings, T &output) {
         retval &= lexical_assign<typename T::value_type, XC>(elem, output.back());
     }
     return (!output.empty()) && retval;
+}
+// This one is last since it can call other lexical_conversion functions
+/// Lexical conversion if there is only one element but the conversion type is a vector
+template <typename T,
+          typename XC,
+          enable_if_t<!is_tuple_like<T>::value && !is_vector<T>::value && is_vector<XC>::value, detail::enabler> =
+              detail::dummy>
+bool lexical_conversion(const std::vector<std ::string> &strings, T &output) {
+
+    if(strings.size() > 1 || (!strings.empty() && !(strings.front().empty()))) {
+        XC val;
+        auto retval = lexical_conversion<XC, XC>(strings, val);
+        output = T{val};
+        return retval;
+    }
+    output = T{};
+    return true;
 }
 
 /// function template for converting tuples if the static Index is greater than the tuple size

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -900,7 +900,7 @@ bool lexical_conversion(const std::vector<std ::string> &strings, T &output) {
             retval = retval && lexical_conversion<typename T::value_type, typename XC::value_type>(temp, output.back());
             temp.clear();
             if(!retval) {
-                return retval;
+                return false;
             }
             icount = 0;
         }

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -740,12 +740,30 @@ bool lexical_assign(const std::string &input, T &output) {
     return parse_result;
 }
 /// Lexical conversion if there is only one element
-template <typename T,
-          typename XC,
-          enable_if_t<!is_tuple_like<T>::value && !is_tuple_like<XC>::value && !is_vector<T>::value, detail::enabler> =
-              detail::dummy>
+template <
+    typename T,
+    typename XC,
+    enable_if_t<!is_tuple_like<T>::value && !is_tuple_like<XC>::value && !is_vector<T>::value && !is_vector<XC>::value,
+                detail::enabler> = detail::dummy>
 bool lexical_conversion(const std::vector<std ::string> &strings, T &output) {
     return lexical_assign<T, XC>(strings[0], output);
+}
+
+/// Lexical conversion if there is only one element but the conversion type is a vector
+template <typename T,
+          typename XC,
+          enable_if_t<!is_tuple_like<T>::value && !is_vector<T>::value && is_vector<XC>::value, detail::enabler> =
+              detail::dummy>
+bool lexical_conversion(const std::vector<std ::string> &strings, T &output) {
+
+    if(strings.size() > 1 || strings.size() == 1 && !strings[0].empty()) {
+        XC val;
+        auto retval = lexical_conversion<XC, XC>(strings, val);
+        output = T{val};
+        return retval;
+    }
+    output = T{};
+    return true;
 }
 
 /// Lexical conversion if there is only one element but the conversion type is for two call a two element constructor

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -325,14 +325,14 @@ class IPV4Validator : public Validator {
         func_ = [](std::string &ip_addr) {
             auto result = CLI::detail::split(ip_addr, '.');
             if(result.size() != 4) {
-                return "Invalid IPV4 address must have four parts " + ip_addr;
+                return "Invalid IPV4 address must have four parts (" + ip_addr + ')';
             }
             int num;
             bool retval = true;
             for(const auto &var : result) {
                 retval &= detail::lexical_cast(var, num);
                 if(!retval) {
-                    return "Failed parsing number " + var;
+                    return "Failed parsing number (" + var + ')';
                 }
                 if(num < 0 || num > 255) {
                     return "Each IP number must be between 0 and 255 " + var;
@@ -350,10 +350,10 @@ class PositiveNumber : public Validator {
         func_ = [](std::string &number_str) {
             int number;
             if(!detail::lexical_cast(number_str, number)) {
-                return "Failed parsing number " + number_str;
+                return "Failed parsing number: (" + number_str + ')';
             }
             if(number < 0) {
-                return "Number less then 0 " + number_str;
+                return "Number less then 0: (" + number_str + ')';
             }
             return std::string();
         };
@@ -367,7 +367,7 @@ class Number : public Validator {
         func_ = [](std::string &number_str) {
             double number;
             if(!detail::lexical_cast(number_str, number)) {
-                return "Failed parsing as a number " + number_str;
+                return "Failed parsing as a number (" + number_str + ')';
             }
             return std::string();
         };

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -415,6 +415,17 @@ TEST_F(TApp, OneStringFlagLike) {
     EXPECT_TRUE(str.empty());
 }
 
+TEST_F(TApp, OneIntFlagLike) {
+    int val;
+    auto opt = app.add_option("-i", val)->expected(0, 1);
+    args = {"-i"};
+    run();
+    EXPECT_EQ(1u, app.count("-i"));
+    opt->default_str("7");
+    run();
+    EXPECT_EQ(val, 7);
+}
+
 TEST_F(TApp, TogetherInt) {
     int i;
     app.add_option("-i,--int", i);

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -405,6 +405,16 @@ TEST_F(TApp, OneStringEqualVersionSingleStringQuotedMultipleWithEqualAndProgram)
     EXPECT_EQ(str4, "Unquoted");
 }
 
+TEST_F(TApp, OneStringFlagLike) {
+    std::string str{"something"};
+    app.add_option("-s,--string", str)->expected(0, 1);
+    args = {"--string"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, app.count("--string"));
+    EXPECT_TRUE(str.empty());
+}
+
 TEST_F(TApp, TogetherInt) {
     int i;
     app.add_option("-i,--int", i);

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1740,7 +1740,7 @@ TEST_F(TApp, VectorUnlimString) {
 
     CLI::Option *opt = app.add_option("-s,--string", strvec);
     EXPECT_EQ(1, opt->get_expected());
-    EXPECT_EQ(1 << 30, opt->get_expected_max());
+    EXPECT_EQ(CLI::detail::expected_max_vector_size, opt->get_expected_max());
 
     args = {"--string", "mystring", "mystring2", "mystring3"};
     run();

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -882,7 +882,7 @@ TEST_F(TApp, vectorDefaults) {
     res = app["--long"]->as<std::vector<int>>();
     EXPECT_EQ(res, std::vector<int>({4}));
 
-    opt->take_last();
+    opt->expected(0, 1)->take_last();
     run();
 
     EXPECT_EQ(res, std::vector<int>({4}));

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2277,6 +2277,68 @@ TEST_F(TApp, vectorPair) {
     EXPECT_THROW(run(), CLI::ValidationError);
 }
 
+// now with independent type sizes and expected this is possible
+TEST_F(TApp, vectorTuple) {
+
+    std::vector<std::tuple<int, std::string, double>> custom_opt;
+
+    auto opt = app.add_option("--dict", custom_opt);
+
+    args = {"--dict", "1", "str1", "4.3", "--dict", "3", "str3", "2.7"};
+
+    run();
+    EXPECT_EQ(custom_opt.size(), 2u);
+    EXPECT_EQ(std::get<0>(custom_opt[0]), 1);
+    EXPECT_EQ(std::get<1>(custom_opt[1]), "str3");
+    EXPECT_EQ(std::get<2>(custom_opt[1]), 2.7);
+
+    args = {"--dict", "1", "str1", "4.3", "--dict", "3", "str3", "2.7", "--dict", "-1", "str4", "-1.87"};
+    run();
+    EXPECT_EQ(custom_opt.size(), 3u);
+    EXPECT_EQ(std::get<0>(custom_opt[2]), -1);
+    EXPECT_EQ(std::get<1>(custom_opt[2]), "str4");
+    EXPECT_EQ(std::get<2>(custom_opt[2]), -1.87);
+    opt->check(CLI::PositiveNumber.application_index(0));
+
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args.back() = "haha";
+    args[9] = "45";
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
+// now with independent type sizes and expected this is possible
+TEST_F(TApp, vectorVector) {
+
+    std::vector<std::vector<int>> custom_opt;
+
+    auto opt = app.add_option("--dict", custom_opt);
+
+    args = {"--dict", "1", "2", "4", "--dict", "3", "1"};
+
+    run();
+    EXPECT_EQ(custom_opt.size(), 2u);
+    EXPECT_EQ(custom_opt[0].size(), 3u);
+    EXPECT_EQ(custom_opt[1].size(), 2u);
+
+    args = {"--dict", "1", "2", "4", "--dict", "3", "1", "--dict", "3", "--dict",
+            "3",      "3", "3", "3", "3",      "3", "3", "3",      "3", "-3"};
+    run();
+    EXPECT_EQ(custom_opt.size(), 4u);
+    EXPECT_EQ(custom_opt[0].size(), 3u);
+    EXPECT_EQ(custom_opt[1].size(), 2u);
+    EXPECT_EQ(custom_opt[2].size(), 1u);
+    EXPECT_EQ(custom_opt[3].size(), 10u);
+    opt->check(CLI::PositiveNumber.application_index(9));
+
+    EXPECT_THROW(run(), CLI::ValidationError);
+    args.pop_back();
+    EXPECT_NO_THROW(run());
+
+    args.back() = "haha";
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
 // #128
 TEST_F(TApp, RepeatingMultiArgumentOptions) {
     std::vector<std::string> entries;

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -828,7 +828,7 @@ TEST_F(TApp, TakeFirstOptMulti) {
 
 TEST_F(TApp, ComplexOptMulti) {
     std::complex<double> val;
-    app.add_complex("--long", val)->take_first();
+    app.add_complex("--long", val)->take_first()->allow_extra_args();
 
     args = {"--long", "1", "2", "3", "4"};
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1657,7 +1657,7 @@ TEST_F(TApp, pair_check) {
 }
 
 // this will require that modifying the multi-option policy for tuples be allowed which it isn't at present
-/*
+
 TEST_F(TApp, pair_check_take_first) {
     std::string myfile{"pair_check_file2.txt"};
     bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a')); // create file
@@ -1682,7 +1682,7 @@ TEST_F(TApp, pair_check_take_first) {
 
     EXPECT_THROW(run(), CLI::ValidationError);
 }
-*/
+
 TEST_F(TApp, VectorFixedString) {
     std::vector<std::string> strvec;
     std::vector<std::string> answer{"mystring", "mystring2", "mystring3"};
@@ -1785,6 +1785,12 @@ TEST_F(TApp, VectorExpectedRange) {
     opt->expected(4, 2); // just test the handling of reversed arguments
     EXPECT_EQ(opt->get_expected_max(), 4);
     EXPECT_EQ(opt->get_expected_min(), 2);
+    opt->expected(-5);
+    EXPECT_EQ(opt->get_expected_max(), 5);
+    EXPECT_EQ(opt->get_expected_min(), 5);
+    opt->expected(-5, 7);
+    EXPECT_EQ(opt->get_expected_max(), 7);
+    EXPECT_EQ(opt->get_expected_min(), 5);
 }
 
 TEST_F(TApp, VectorFancyOpts) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -631,7 +631,7 @@ TEST_F(TApp, BoolOnlyFlag) {
     EXPECT_TRUE(bflag);
 
     args = {"-b", "-b"};
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
 TEST_F(TApp, BoolOption) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -40,8 +40,8 @@ TEST_F(TApp, OneFlagShortValuesAs) {
     flg->take_last();
     EXPECT_EQ(opt->as<int>(), 2);
     flg->multi_option_policy(CLI::MultiOptionPolicy::Throw);
-    EXPECT_THROW(opt->as<int>(), CLI::ConversionError);
-
+    EXPECT_THROW(opt->as<int>(), CLI::ArgumentMismatch);
+    flg->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     auto vec = opt->as<std::vector<int>>();
     EXPECT_EQ(vec[0], 1);
     EXPECT_EQ(vec[1], 2);
@@ -1749,7 +1749,7 @@ TEST_F(TApp, DefaultedResult) {
     opts->results(nString);
     EXPECT_EQ(nString, "NA");
     int newIval;
-    EXPECT_THROW(optv->results(newIval), CLI::ConversionError);
+    // EXPECT_THROW(optv->results(newIval), CLI::ConversionError);
     optv->default_str("442");
     optv->results(newIval);
     EXPECT_EQ(newIval, 442);

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -812,6 +812,33 @@ TEST_F(TApp, TakeLastOptMulti) {
     EXPECT_EQ(vals, std::vector<int>({2, 3}));
 }
 
+TEST_F(TApp, vectorDefaults) {
+    std::vector<int> vals{4, 5};
+    auto opt = app.add_option("--long", vals, "", true);
+
+    args = {"--long", "[1,2,3]"};
+
+    run();
+
+    EXPECT_EQ(vals, std::vector<int>({1, 2, 3}));
+
+    args.clear();
+    run();
+    auto res = app["--long"]->as<std::vector<int>>();
+    EXPECT_EQ(res, std::vector<int>({4, 5}));
+
+    app.clear();
+    opt->expected(1)->take_last();
+    res = app["--long"]->as<std::vector<int>>();
+    EXPECT_EQ(res, std::vector<int>({5}));
+    opt->take_first();
+    res = app["--long"]->as<std::vector<int>>();
+    EXPECT_EQ(res, std::vector<int>({4}));
+
+    run();
+    EXPECT_EQ(res, std::vector<int>({4}));
+}
+
 TEST_F(TApp, TakeLastOptMulti_alternative_path) {
     std::vector<int> vals;
     app.add_option("--long", vals)->expected(2, -1)->take_last();

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2348,6 +2348,17 @@ TEST_F(TApp, vectorPair) {
     EXPECT_THROW(run(), CLI::ValidationError);
 }
 
+TEST_F(TApp, vectorPairFail) {
+
+    std::vector<std::pair<int, std::string>> custom_opt;
+
+    app.add_option("--dict", custom_opt);
+
+    args = {"--dict", "1", "str1", "--dict", "str3", "1"};
+
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
 // now with independent type sizes and expected this is possible
 TEST_F(TApp, vectorTuple) {
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1143,7 +1143,7 @@ TEST_F(TApp, RequiredOptsUnlimited) {
 
     app.allow_extras(false);
     std::vector<std::string> remain;
-    app.add_option("positional", remain);
+    auto popt = app.add_option("positional", remain);
     run();
     EXPECT_EQ(strs, std::vector<std::string>({"one", "two"}));
     EXPECT_EQ(remain, std::vector<std::string>());
@@ -1159,6 +1159,12 @@ TEST_F(TApp, RequiredOptsUnlimited) {
     run();
     EXPECT_EQ(strs, std::vector<std::string>({"two"}));
     EXPECT_EQ(remain, std::vector<std::string>({"one"}));
+
+    args = {"--str", "one", "two"};
+    popt->required();
+    run();
+    EXPECT_EQ(strs, std::vector<std::string>({"one"}));
+    EXPECT_EQ(remain, std::vector<std::string>({"two"}));
 }
 
 TEST_F(TApp, RequiredOptsUnlimitedShort) {
@@ -1219,9 +1225,9 @@ TEST_F(TApp, OptsUnlimitedEnd) {
 TEST_F(TApp, RequireOptPriority) {
 
     std::vector<std::string> strs;
-    app.add_option("--str", strs)->required();
+    app.add_option("--str", strs);
     std::vector<std::string> remain;
-    app.add_option("positional", remain)->expected(2);
+    app.add_option("positional", remain)->expected(2)->required();
 
     args = {"--str", "one", "two", "three"};
     run();
@@ -1241,7 +1247,7 @@ TEST_F(TApp, RequireOptPriorityShort) {
     std::vector<std::string> strs;
     app.add_option("-s", strs)->required();
     std::vector<std::string> remain;
-    app.add_option("positional", remain)->expected(2);
+    app.add_option("positional", remain)->expected(2)->required();
 
     args = {"-s", "one", "two", "three"};
     run();
@@ -1332,7 +1338,7 @@ TEST_F(TApp, CallbackBoolFlags) {
     EXPECT_THROW(app.add_flag_callback("hi", func), CLI::IncorrectConstruction);
     cback->multi_option_policy(CLI::MultiOptionPolicy::Throw);
     args = {"--val", "--val=false"};
-    EXPECT_THROW(run(), CLI::ConversionError);
+    EXPECT_THROW(run(), CLI::ArgumentMismatch);
 }
 
 TEST_F(TApp, CallbackFlagsFalse) {
@@ -1733,7 +1739,8 @@ TEST_F(TApp, VectorUnlimString) {
     std::vector<std::string> answer{"mystring", "mystring2", "mystring3"};
 
     CLI::Option *opt = app.add_option("-s,--string", strvec);
-    EXPECT_EQ(-1, opt->get_expected());
+    EXPECT_EQ(1, opt->get_expected());
+    EXPECT_EQ(1 << 30, opt->get_expected_max());
 
     args = {"--string", "mystring", "mystring2", "mystring3"};
     run();

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -802,9 +802,20 @@ TEST_F(TApp, TakeLastOptMulti) {
     EXPECT_EQ(vals, std::vector<int>({2, 3}));
 }
 
+TEST_F(TApp, TakeLastOptMulti_alternative_path) {
+    std::vector<int> vals;
+    app.add_option("--long", vals)->expected(2, -1)->take_last();
+
+    args = {"--long", "1", "2", "3"};
+
+    run();
+
+    EXPECT_EQ(vals, std::vector<int>({2, 3}));
+}
+
 TEST_F(TApp, TakeLastOptMultiCheck) {
     std::vector<int> vals;
-    auto opt = app.add_option("--long", vals)->expected(2)->take_last();
+    auto opt = app.add_option("--long", vals)->expected(-2)->take_last();
 
     opt->check(CLI::Validator(CLI::PositiveNumber).application_index(0));
     opt->check((!CLI::PositiveNumber).application_index(1));
@@ -1768,6 +1779,12 @@ TEST_F(TApp, VectorExpectedRange) {
 
     args = {"--string", "mystring", "mystring2", "string2", "--string", "string4", "string5"};
     EXPECT_THROW(run(), CLI::ArgumentMismatch);
+
+    EXPECT_EQ(opt->get_expected_max(), 4);
+    EXPECT_EQ(opt->get_expected_min(), 2);
+    opt->expected(4, 2); // just test the handling of reversed arguments
+    EXPECT_EQ(opt->get_expected_max(), 4);
+    EXPECT_EQ(opt->get_expected_min(), 2);
 }
 
 TEST_F(TApp, VectorFancyOpts) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -46,6 +46,8 @@ TEST_F(TApp, OneFlagShortValuesAs) {
     EXPECT_EQ(vec[0], 1);
     EXPECT_EQ(vec[1], 2);
     flg->multi_option_policy(CLI::MultiOptionPolicy::Join);
+    EXPECT_EQ(opt->as<std::string>(), "1\n2");
+    flg->delimiter(',');
     EXPECT_EQ(opt->as<std::string>(), "1,2");
 }
 

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -173,46 +173,6 @@ TEST_F(TApp, IncorrectConstructionFlagPositional3) {
     EXPECT_THROW(app.add_flag("cat", x), CLI::IncorrectConstruction);
 }
 
-TEST_F(TApp, IncorrectConstructionFlagExpected) {
-    auto cat = app.add_flag("--cat");
-    EXPECT_THROW(cat->expected(0), CLI::IncorrectConstruction);
-    EXPECT_THROW(cat->expected(1), CLI::IncorrectConstruction);
-}
-
-TEST_F(TApp, IncorrectConstructionOptionAsFlag) {
-    int x;
-    auto cat = app.add_option("--cat", x);
-    EXPECT_NO_THROW(cat->expected(1));
-    EXPECT_THROW(cat->expected(0), CLI::IncorrectConstruction);
-    EXPECT_THROW(cat->expected(2), CLI::IncorrectConstruction);
-}
-
-TEST_F(TApp, IncorrectConstructionOptionAsVector) {
-    int x;
-    auto cat = app.add_option("--cat", x);
-    EXPECT_THROW(cat->expected(2), CLI::IncorrectConstruction);
-}
-
-TEST_F(TApp, IncorrectConstructionVectorAsFlag) {
-    std::vector<int> x;
-    auto cat = app.add_option("--cat", x);
-    EXPECT_THROW(cat->expected(0), CLI::IncorrectConstruction);
-}
-
-TEST_F(TApp, IncorrectConstructionVectorTakeLast) {
-    std::vector<int> vec;
-    auto cat = app.add_option("--vec", vec);
-    EXPECT_THROW(cat->multi_option_policy(CLI::MultiOptionPolicy::TakeLast), CLI::IncorrectConstruction);
-}
-
-TEST_F(TApp, IncorrectConstructionTakeLastExpected) {
-    std::vector<int> vec;
-    auto cat = app.add_option("--vec", vec);
-    cat->expected(1);
-    ASSERT_NO_THROW(cat->multi_option_policy(CLI::MultiOptionPolicy::TakeLast));
-    EXPECT_THROW(cat->expected(2), CLI::IncorrectConstruction);
-}
-
 TEST_F(TApp, IncorrectConstructionNeedsCannotFind) {
     auto cat = app.add_flag("--cat");
     EXPECT_THROW(cat->needs("--nothing"), CLI::IncorrectConstruction);

--- a/tests/DeprecatedTest.cpp
+++ b/tests/DeprecatedTest.cpp
@@ -458,7 +458,7 @@ TEST_F(TApp, DefaultedResult) {
     opts->results(nString);
     EXPECT_EQ(nString, "NA");
     int newIval;
-    EXPECT_THROW(optv->results(newIval), CLI::ConversionError);
+    // EXPECT_THROW(optv->results(newIval), CLI::ConversionError);
     optv->default_str("442");
     optv->results(newIval);
     EXPECT_EQ(newIval, 442);

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <string>
 #include <tuple>
+#include <utility>
 
 class NotStreamable {};
 
@@ -831,6 +832,13 @@ TEST(Types, TypeName) {
 
     vector_name = CLI::detail::type_name<std::vector<double>>();
     EXPECT_EQ("FLOAT", vector_name);
+
+    static_assert(CLI::detail::classify_object<std::pair<int, std::string>>::value ==
+                      CLI::detail::objCategory::tuple_value,
+                  "pair<int,string> does not read like a tuple");
+
+    std::string pair_name = CLI::detail::type_name<std::vector<std::pair<int, std::string>>>();
+    EXPECT_EQ("[INT,TEXT]", pair_name);
 
     vector_name = CLI::detail::type_name<std::vector<std::vector<unsigned char>>>();
     EXPECT_EQ("UINT", vector_name);

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -297,6 +297,8 @@ TEST(Validators, IPValidate1) {
     EXPECT_FALSE(CLI::ValidIPV4(ip).empty());
     ip = "aaa";
     EXPECT_FALSE(CLI::ValidIPV4(ip).empty());
+    ip = "1.2.3.abc";
+    EXPECT_FALSE(CLI::ValidIPV4(ip).empty());
     ip = "11.22";
     EXPECT_FALSE(CLI::ValidIPV4(ip).empty());
 }

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -42,13 +42,32 @@ TEST(TypeTools, type_size) {
     V = CLI::detail::type_count<void>::value;
     EXPECT_EQ(V, 0);
     V = CLI::detail::type_count<std::vector<double>>::value;
-    EXPECT_EQ(V, -1);
+    EXPECT_EQ(V, 1);
     V = CLI::detail::type_count<std::tuple<double, int>>::value;
     EXPECT_EQ(V, 2);
     V = CLI::detail::type_count<std::tuple<std::string, double, int>>::value;
     EXPECT_EQ(V, 3);
     V = CLI::detail::type_count<std::array<std::string, 5>>::value;
     EXPECT_EQ(V, 5);
+    V = CLI::detail::type_count<std::vector<std::pair<std::string, double>>>::value;
+    EXPECT_EQ(V, 2);
+}
+
+TEST(TypeTools, expected_count) {
+    auto V = CLI::detail::expected_count<int>::value;
+    EXPECT_EQ(V, 1);
+    V = CLI::detail::expected_count<void>::value;
+    EXPECT_EQ(V, 0);
+    V = CLI::detail::expected_count<std::vector<double>>::value;
+    EXPECT_EQ(V, CLI::detail::expected_max_vector_size);
+    V = CLI::detail::expected_count<std::tuple<double, int>>::value;
+    EXPECT_EQ(V, 1);
+    V = CLI::detail::expected_count<std::tuple<std::string, double, int>>::value;
+    EXPECT_EQ(V, 1);
+    V = CLI::detail::expected_count<std::array<std::string, 5>>::value;
+    EXPECT_EQ(V, 1);
+    V = CLI::detail::expected_count<std::vector<std::pair<std::string, double>>>::value;
+    EXPECT_EQ(V, CLI::detail::expected_max_vector_size);
 }
 
 TEST(Split, SimpleByToken) {
@@ -815,8 +834,12 @@ TEST(Types, TypeName) {
 
     vector_name = CLI::detail::type_name<std::vector<std::vector<unsigned char>>>();
     EXPECT_EQ("UINT", vector_name);
-    auto vclass = CLI::detail::classify_object<std::tuple<double>>::value;
-    EXPECT_EQ(vclass, CLI::detail::objCategory::number_constructible);
+
+    auto vclass = CLI::detail::classify_object<std::vector<std::vector<unsigned char>>>::value;
+    EXPECT_EQ(vclass, CLI::detail::objCategory::vector_value);
+
+    auto tclass = CLI::detail::classify_object<std::tuple<double>>::value;
+    EXPECT_EQ(tclass, CLI::detail::objCategory::number_constructible);
 
     std::string tuple_name = CLI::detail::type_name<std::tuple<double>>();
     EXPECT_EQ("FLOAT", tuple_name);

--- a/tests/NewParseTest.cpp
+++ b/tests/NewParseTest.cpp
@@ -77,6 +77,26 @@ TEST_F(TApp, BuiltinComplex) {
     EXPECT_DOUBLE_EQ(3, comp.imag());
 }
 
+TEST_F(TApp, BuiltinComplexFloat) {
+    std::complex<float> comp{1, 2};
+    app.add_complex<std::complex<float>, float>("-c,--complex", comp, "", true);
+
+    args = {"-c", "4", "3"};
+
+    std::string help = app.help();
+    EXPECT_THAT(help, HasSubstr("1"));
+    EXPECT_THAT(help, HasSubstr("2"));
+    EXPECT_THAT(help, HasSubstr("COMPLEX"));
+
+    EXPECT_FLOAT_EQ(1, comp.real());
+    EXPECT_FLOAT_EQ(2, comp.imag());
+
+    run();
+
+    EXPECT_FLOAT_EQ(4, comp.real());
+    EXPECT_FLOAT_EQ(3, comp.imag());
+}
+
 TEST_F(TApp, BuiltinComplexWithDelimiter) {
     cx comp{1, 2};
     app.add_complex("-c,--complex", comp, "", true)->delimiter('+');
@@ -121,13 +141,61 @@ TEST_F(TApp, BuiltinComplexIgnoreI) {
     EXPECT_DOUBLE_EQ(3, comp.imag());
 }
 
-TEST_F(TApp, BuiltinComplexFail) {
+TEST_F(TApp, BuiltinComplexSingleArg) {
     cx comp{1, 2};
     app.add_complex("-c,--complex", comp);
 
     args = {"-c", "4"};
+    run();
+    EXPECT_DOUBLE_EQ(4, comp.real());
+    EXPECT_DOUBLE_EQ(0, comp.imag());
 
-    EXPECT_THROW(run(), CLI::ArgumentMismatch);
+    args = {"-c", "4-2i"};
+    run();
+    EXPECT_DOUBLE_EQ(4, comp.real());
+    EXPECT_DOUBLE_EQ(-2, comp.imag());
+    args = {"-c", "4+2i"};
+    run();
+    EXPECT_DOUBLE_EQ(4, comp.real());
+    EXPECT_DOUBLE_EQ(2, comp.imag());
+
+    args = {"-c", "-4+2j"};
+    run();
+    EXPECT_DOUBLE_EQ(-4, comp.real());
+    EXPECT_DOUBLE_EQ(2, comp.imag());
+
+    args = {"-c", "-4.2-2j"};
+    run();
+    EXPECT_DOUBLE_EQ(-4.2, comp.real());
+    EXPECT_DOUBLE_EQ(-2, comp.imag());
+
+    args = {"-c", "-4.2-2.7i"};
+    run();
+    EXPECT_DOUBLE_EQ(-4.2, comp.real());
+    EXPECT_DOUBLE_EQ(-2.7, comp.imag());
+}
+
+TEST_F(TApp, BuiltinComplexSingleImag) {
+    cx comp{1, 2};
+    app.add_complex("-c,--complex", comp);
+
+    args = {"-c", "4j"};
+    run();
+    EXPECT_DOUBLE_EQ(0, comp.real());
+    EXPECT_DOUBLE_EQ(4, comp.imag());
+
+    args = {"-c", "-4j"};
+    run();
+    EXPECT_DOUBLE_EQ(0, comp.real());
+    EXPECT_DOUBLE_EQ(-4, comp.imag());
+    args = {"-c", "-4"};
+    run();
+    EXPECT_DOUBLE_EQ(-4, comp.real());
+    EXPECT_DOUBLE_EQ(0, comp.imag());
+    args = {"-c", "+4"};
+    run();
+    EXPECT_DOUBLE_EQ(4, comp.real());
+    EXPECT_DOUBLE_EQ(0, comp.imag());
 }
 
 class spair {

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -104,6 +104,22 @@ TEST_F(TApp, BoostOptionalTest) {
     EXPECT_EQ(*opt, 3);
 }
 
+TEST_F(TApp, BoostOptionalTestZarg) {
+    boost::optional<int> opt;
+    app.add_option("-c,--count", opt)->expected(0, 1);
+    run();
+    EXPECT_FALSE(opt);
+
+    args = {"-c", "1"};
+    run();
+    EXPECT_TRUE(opt);
+    EXPECT_EQ(*opt, 1);
+    opt = {};
+    args = {"--count"};
+    run();
+    EXPECT_FALSE(opt);
+}
+
 TEST_F(TApp, BoostOptionalint64Test) {
     boost::optional<int64_t> opt;
     app.add_option("-c,--count", opt);

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -191,6 +191,22 @@ TEST_F(TApp, BoostOptionalVector) {
     EXPECT_EQ(*opt, expV);
 }
 
+TEST_F(TApp, BoostOptionalVectorEmpty) {
+    boost::optional<std::vector<int>> opt;
+    app.add_option<decltype(opt), std::vector<int>>("-v,--vec", opt)->expected(0, 3)->allow_extra_args();
+    run();
+    EXPECT_FALSE(opt);
+    args = {"-v"};
+    opt = std::vector<int>{4, 3};
+    run();
+    EXPECT_FALSE(opt);
+    args = {"-v", "1", "4", "5"};
+    run();
+    EXPECT_TRUE(opt);
+    std::vector<int> expV{1, 4, 5};
+    EXPECT_EQ(*opt, expV);
+}
+
 #endif
 
 #if !CLI11_OPTIONAL

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -101,6 +101,24 @@ TEST_F(TApp, EnumCheckedTransform) {
     EXPECT_THROW(run(), CLI::ValidationError);
 }
 
+// from jzakrzewski Issue #330
+TEST_F(TApp, EnumCheckedDefualtTransform) {
+    enum class existing : int16_t { abort, overwrite, remove };
+    app.add_option("--existing", "What to do if file already exists in the destination")
+        ->transform(
+            CLI::CheckedTransformer(std::unordered_map<std::string, existing>{{"abort", existing::abort},
+                                                                              {"overwrite", existing ::overwrite},
+                                                                              {"delete", existing::remove},
+                                                                              {"remove", existing::remove}}))
+        ->default_val("abort");
+    args = {"--existing", "overwrite"};
+    run();
+    EXPECT_EQ(app.get_option("--existing")->as<existing>(), existing::overwrite);
+    args.clear();
+    run();
+    EXPECT_EQ(app.get_option("--existing")->as<existing>(), existing::abort);
+}
+
 TEST_F(TApp, SimpleTransformFn) {
     int value;
     auto opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", "1"}}, CLI::ignore_case));

--- a/tests/app_helper.hpp
+++ b/tests/app_helper.hpp
@@ -9,7 +9,7 @@
 #include "gtest/gtest.h"
 #include <iostream>
 
-using input_t= std::vector<std::string>;
+using input_t = std::vector<std::string>;
 
 struct TApp : public ::testing::Test {
     CLI::App app{"My Test Program"};

--- a/tests/app_helper.hpp
+++ b/tests/app_helper.hpp
@@ -9,7 +9,7 @@
 #include "gtest/gtest.h"
 #include <iostream>
 
-typedef std::vector<std::string> input_t;
+using input_t= std::vector<std::string>;
 
 struct TApp : public ::testing::Test {
     CLI::App app{"My Test Program"};
@@ -27,7 +27,7 @@ class TempFile {
     std::string _name;
 
   public:
-    explicit TempFile(std::string name) : _name(name) {
+    explicit TempFile(std::string name) : _name(std::move(name)) {
         if(!CLI::NonexistentPath(_name).empty())
             throw std::runtime_error(_name);
     }


### PR DESCRIPTION
If merged this PR will refactor the type_size and expected size and the multiOptionPolicy so they work independently and allow more flexible types in add_option. 

Also rework add_complex to actually allow things like `--comp 4+2i`  or `--comp -1.7-5j` in addition to the current pair of doubles support.  