### PR TITLE
Return empty string in Option::get_name() for hidden options

### DIFF
--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -652,7 +652,7 @@ class Option : public OptionBase<Option> {
     std::string get_name(bool positional = false, //<[input] Show the positional name
                          bool all_options = false //<[input] Show every option
                          ) const {
-        if (detail::to_lower(get_group()).empty())
+        if (get_group().empty())
             return {}; // Hidden
 
         if(all_options) {

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -652,7 +652,7 @@ class Option : public OptionBase<Option> {
     std::string get_name(bool positional = false, //<[input] Show the positional name
                          bool all_options = false //<[input] Show every option
                          ) const {
-        if (get_group().empty())
+        if(get_group().empty())
             return {}; // Hidden
 
         if(all_options) {

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -652,6 +652,8 @@ class Option : public OptionBase<Option> {
     std::string get_name(bool positional = false, //<[input] Show the positional name
                          bool all_options = false //<[input] Show every option
                          ) const {
+        if (detail::to_lower(get_group()).empty())
+            return {}; // Hidden
 
         if(all_options) {
 

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -92,7 +92,7 @@ TEST(THelp, Hidden) {
     EXPECT_THAT(help, HasSubstr("My prog"));
     EXPECT_THAT(help, HasSubstr("-h,--help"));
     EXPECT_THAT(help, HasSubstr("Options:"));
-    EXPECT_THAT(help, HasSubstr("[something]"));
+    EXPECT_THAT(help, Not(HasSubstr("[something]")));
     EXPECT_THAT(help, Not(HasSubstr("something ")));
     EXPECT_THAT(help, Not(HasSubstr("another")));
 }


### PR DESCRIPTION
Fixes https://github.com/CLIUtils/CLI11/issues/332