### PR TITLE
Filedir checks

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2080,7 +2080,7 @@ class App {
                         std::vector<ConfigItem> values = config_formatter_->from_file(config_name_);
                         _parse_config(values);
                     } else if(config_required_) {
-                        throw FileError("Unable to find required config file");
+                        throw FileError::Missing(config_name_);
                     }
                 } catch(const FileError &) {
                     if(config_required_)

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2075,8 +2075,8 @@ class App {
             }
             if(!config_name_.empty()) {
                 try {
-                    auto path_result = detail::check_path(config_name_.c_str(), true);
-                    if(path_result == detail::path_exists::file) {
+                    auto path_result = detail::check_path(config_name_.c_str());
+                    if(path_result == detail::path_type::file) {
                         std::vector<ConfigItem> values = config_formatter_->from_file(config_name_);
                         _parse_config(values);
                     } else if(config_required_) {

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2075,8 +2075,13 @@ class App {
             }
             if(!config_name_.empty()) {
                 try {
-                    std::vector<ConfigItem> values = config_formatter_->from_file(config_name_);
-                    _parse_config(values);
+                    auto path_result = detail::check_path(config_name_.c_str(), true);
+                    if(path_result == detail::path_exists::file) {
+                        std::vector<ConfigItem> values = config_formatter_->from_file(config_name_);
+                        _parse_config(values);
+                    } else if(config_required_) {
+                        throw FileError("Unable to find required config file");
+                    }
                 } catch(const FileError &) {
                     if(config_required_)
                         throw;

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -715,7 +715,7 @@ class Option : public OptionBase<Option> {
     /// Use `get_name(true)` to get the positional name (replaces `get_pname`)
     std::string get_name(bool positional = false, //<[input] Show the positional name
                          bool all_options = false //<[input] Show every option
-                         ) const {
+    ) const {
         if(get_group().empty())
             return {}; // Hidden
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -715,7 +715,7 @@ class Option : public OptionBase<Option> {
     /// Use `get_name(true)` to get the positional name (replaces `get_pname`)
     std::string get_name(bool positional = false, //<[input] Show the positional name
                          bool all_options = false //<[input] Show every option
-    ) const {
+                         ) const {
         if(get_group().empty())
             return {}; // Hidden
 

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <string>
 
+// [CLI11:verbatim]
 #if(defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1)
 #define CLI11_CPP17
 #endif
@@ -31,6 +32,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #endif
+
+// [CLI11:verbatim]
 
 namespace CLI {
 

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -266,7 +266,7 @@ class CustomValidator : public Validator {
 // Therefore, this is in detail.
 namespace detail {
 
-    /// CLI enumeration of different file types
+/// CLI enumeration of different file types
 enum class path_type { nonexistant, file, directory };
 
 #if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
@@ -286,7 +286,6 @@ inline path_type check_path(const char *file) {
     } catch(const std::filesystem::filesystem_error &) {
         return path_type::nonexistant;
     }
-   
 }
 #else
 /// get the type of the path from a file name
@@ -299,7 +298,7 @@ inline path_type check_path(const char *file) {
 #else
     struct stat buffer;
     if(stat(file, &buffer) == 0) {
-       return ((buffer.st_mode & S_IFDIR) != 0) ? path_type::directory : path_type::file;
+        return ((buffer.st_mode & S_IFDIR) != 0) ? path_type::directory : path_type::file;
     }
 #endif
     return path_type::nonexistant;
@@ -523,9 +522,10 @@ template <typename T> std::string generate_set(const T &set) {
     using element_t = typename detail::element_type<T>::type;
     using iteration_type_t = typename detail::pair_adaptor<element_t>::value_type; // the type of the object pair
     std::string out(1, '{');
-    out.append(detail::join(detail::smart_deref(set),
-                            [](const iteration_type_t &v) { return detail::pair_adaptor<element_t>::first(v); },
-                            ","));
+    out.append(detail::join(
+        detail::smart_deref(set),
+        [](const iteration_type_t &v) { return detail::pair_adaptor<element_t>::first(v); },
+        ","));
     out.push_back('}');
     return out;
 }
@@ -535,17 +535,18 @@ template <typename T> std::string generate_map(const T &map, bool key_only = fal
     using element_t = typename detail::element_type<T>::type;
     using iteration_type_t = typename detail::pair_adaptor<element_t>::value_type; // the type of the object pair
     std::string out(1, '{');
-    out.append(detail::join(detail::smart_deref(map),
-                            [key_only](const iteration_type_t &v) {
-                                std::string res{detail::to_string(detail::pair_adaptor<element_t>::first(v))};
+    out.append(detail::join(
+        detail::smart_deref(map),
+        [key_only](const iteration_type_t &v) {
+            std::string res{detail::to_string(detail::pair_adaptor<element_t>::first(v))};
 
-                                if(!key_only) {
-                                    res.append("->");
-                                    res += detail::to_string(detail::pair_adaptor<element_t>::second(v));
-                                }
-                                return res;
-                            },
-                            ","));
+            if(!key_only) {
+                res.append("->");
+                res += detail::to_string(detail::pair_adaptor<element_t>::second(v));
+            }
+            return res;
+        },
+        ","));
     out.push_back('}');
     return out;
 }
@@ -706,9 +707,10 @@ class IsMember : public Validator {
     /// You can pass in as many filter functions as you like, they nest (string only currently)
     template <typename T, typename... Args>
     IsMember(T &&set, filter_fn_t filter_fn_1, filter_fn_t filter_fn_2, Args &&... other)
-        : IsMember(std::forward<T>(set),
-                   [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
-                   other...) {}
+        : IsMember(
+              std::forward<T>(set),
+              [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
+              other...) {}
 };
 
 /// definition of the default transformation object
@@ -766,9 +768,10 @@ class Transformer : public Validator {
     /// You can pass in as many filter functions as you like, they nest
     template <typename T, typename... Args>
     Transformer(T &&mapping, filter_fn_t filter_fn_1, filter_fn_t filter_fn_2, Args &&... other)
-        : Transformer(std::forward<T>(mapping),
-                      [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
-                      other...) {}
+        : Transformer(
+              std::forward<T>(mapping),
+              [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
+              other...) {}
 };
 
 /// translate named items to other or a value set
@@ -842,9 +845,10 @@ class CheckedTransformer : public Validator {
     /// You can pass in as many filter functions as you like, they nest
     template <typename T, typename... Args>
     CheckedTransformer(T &&mapping, filter_fn_t filter_fn_1, filter_fn_t filter_fn_2, Args &&... other)
-        : CheckedTransformer(std::forward<T>(mapping),
-                             [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
-                             other...) {}
+        : CheckedTransformer(
+              std::forward<T>(mapping),
+              [filter_fn_1, filter_fn_2](std::string a) { return filter_fn_2(filter_fn_1(a)); },
+              other...) {}
 };
 
 /// Helper function to allow ignore_case to be passed to IsMember or Transform

--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -167,6 +167,10 @@ TEST(StringBased, SpacesSections) {
     EXPECT_EQ("four", output.at(1).inputs.at(0));
 }
 
+TEST(StringBased, file_error) {
+    EXPECT_THROW(std::vector<CLI::ConfigItem> output = CLI::ConfigINI().from_file("nonexist_file"), CLI::FileError);
+}
+
 TEST_F(TApp, IniNotRequired) {
 
     TempFile tmpini{"TestIniTmp.ini"};


### PR DESCRIPTION
This PR stems from an issue in our application about using an optional default ini file.  That is sometimes present, but often not.    In the current code this generated an internal exception that was caught but would clutter up trapping exceptions from other parts of the program and made debugging difficult in some cases.  

This PR splits out the detection of the file and directory types into a separate function and uses that in a couple locations instead of using the Validators.  This prevents any exception from being thrown for non-required config files.    

Since I was working with that code anyway,  I added the detection for C++17 and filesystem and the 64 bit operations on visual studio which should address #312.  

use of \<filesystem\> can be turned off by defining CLI11_HAS_FILESYSTEM to 0