### PR TITLE
Handle float type in positive number (CLIUtils#328) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,8 @@ CLI11 has several Validators built-in that perform some common checks
 -   `CLI::NonexistentPath`: Requires that the path does not exist.
 -   `CLI::Range(min,max)`: Requires that the option be between min and max (make sure to use floating point if needed). Min defaults to 0.
 -   `CLI::Bounded(min,max)`: 🆕 Modify the input such that it is always between min and max (make sure to use floating point if needed). Min defaults to 0.  Will produce an error if conversion is not possible.
--   `CLI::PositiveNumber`: 🆕 Requires the number be greater or equal to 0
+-   `CLI::PositiveNumber`: 🆕 Requires the number be greater to 0
+-   `CLI::NonNegativeNumber`: 🆕 Requires the number be greater or equal to 0
 -   `CLI::Number`: 🆕 Requires the input be a number.
 -   `CLI::ValidIPV4`: 🆕 Requires that the option be a valid IPv4 string e.g. `'255.255.255.255'`, `'10.1.1.7'`.
 
@@ -404,7 +405,7 @@ will produce a check to ensure a value is between 0 and 10 or 20 and 30.
 ->check(!CLI::PositiveNumber);
 ```
 
-will produce a check for a number less than 0.
+will produce a check for a number less than or equal to 0.
 
 ##### Transforming Validators
 There are a few built in Validators that let you transform values if used with the `transform` function.  If they also do some checks then they can be used `check` but some may do nothing in that case.

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ CLI11 has several Validators built-in that perform some common checks
 -   `CLI::NonexistentPath`: Requires that the path does not exist.
 -   `CLI::Range(min,max)`: Requires that the option be between min and max (make sure to use floating point if needed). Min defaults to 0.
 -   `CLI::Bounded(min,max)`: 🆕 Modify the input such that it is always between min and max (make sure to use floating point if needed). Min defaults to 0.  Will produce an error if conversion is not possible.
--   `CLI::PositiveNumber`: 🆕 Requires the number be greater to 0
+-   `CLI::PositiveNumber`: 🆕 Requires the number be greater than 0
 -   `CLI::NonNegativeNumber`: 🆕 Requires the number be greater or equal to 0
 -   `CLI::Number`: 🆕 Requires the input be a number.
 -   `CLI::ValidIPV4`: 🆕 Requires that the option be a valid IPv4 string e.g. `'255.255.255.255'`, `'10.1.1.7'`.

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -343,10 +343,26 @@ class IPV4Validator : public Validator {
     }
 };
 
-/// Validate the argument is a number and greater than or equal to 0
+/// Validate the argument is a number and greater than 0
 class PositiveNumber : public Validator {
   public:
     PositiveNumber() : Validator("POSITIVE") {
+        func_ = [](std::string &number_str) {
+            double number;
+            if(!detail::lexical_cast(number_str, number)) {
+                return "Failed parsing number: (" + number_str + ')';
+            }
+            if(number <= 0) {
+                return "Number less or equal to 0: (" + number_str + ')';
+            }
+            return std::string();
+        };
+    }
+};
+/// Validate the argument is a number and greater than or equal to 0
+class NonNegativeNumber : public Validator {
+  public:
+    NonNegativeNumber() : Validator("NONNEGATIVE") {
         func_ = [](std::string &number_str) {
             double number;
             if(!detail::lexical_cast(number_str, number)) {
@@ -395,6 +411,9 @@ const detail::IPV4Validator ValidIPV4;
 
 /// Check for a positive number
 const detail::PositiveNumber PositiveNumber;
+
+/// Check for a non-negative number
+const detail::NonNegativeNumber NonNegativeNumber;
 
 /// Check for a number
 const detail::Number Number;

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -348,7 +348,7 @@ class PositiveNumber : public Validator {
   public:
     PositiveNumber() : Validator("POSITIVE") {
         func_ = [](std::string &number_str) {
-            int number;
+            double number;
             if(!detail::lexical_cast(number_str, number)) {
                 return "Failed parsing number: (" + number_str + ')';
             }

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -353,7 +353,7 @@ class PositiveNumber : public Validator {
                 return "Failed parsing number: (" + number_str + ')';
             }
             if(number < 0) {
-                return "Number less then 0: (" + number_str + ')';
+                return "Number less than 0: (" + number_str + ')';
             }
             return std::string();
         };

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -360,7 +360,7 @@ class PositiveNumber : public Validator {
     }
 };
 
-/// Validate the argument is a number and greater than or equal to 0
+/// Validate the argument is a number
 class Number : public Validator {
   public:
     Number() : Validator("NUMBER") {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -312,7 +312,11 @@ TEST(Validators, PositiveValidator) {
     EXPECT_TRUE(CLI::PositiveNumber(num).empty());
     num = "0";
     EXPECT_TRUE(CLI::PositiveNumber(num).empty());
+    num = "+0.5";
+    EXPECT_TRUE(CLI::PositiveNumber(num).empty());
     num = "-1";
+    EXPECT_FALSE(CLI::PositiveNumber(num).empty());
+    num = "-1.5";
     EXPECT_FALSE(CLI::PositiveNumber(num).empty());
     num = "a";
     EXPECT_FALSE(CLI::PositiveNumber(num).empty());

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -311,7 +311,7 @@ TEST(Validators, PositiveValidator) {
     num = "10000";
     EXPECT_TRUE(CLI::PositiveNumber(num).empty());
     num = "0";
-    EXPECT_TRUE(CLI::PositiveNumber(num).empty());
+    EXPECT_FALSE(CLI::PositiveNumber(num).empty());
     num = "+0.5";
     EXPECT_TRUE(CLI::PositiveNumber(num).empty());
     num = "-1";
@@ -320,6 +320,25 @@ TEST(Validators, PositiveValidator) {
     EXPECT_FALSE(CLI::PositiveNumber(num).empty());
     num = "a";
     EXPECT_FALSE(CLI::PositiveNumber(num).empty());
+}
+
+TEST(Validators, NonNegativeValidator) {
+    std::string num = "1.1.1.1";
+    EXPECT_FALSE(CLI::NonNegativeNumber(num).empty());
+    num = "1";
+    EXPECT_TRUE(CLI::NonNegativeNumber(num).empty());
+    num = "10000";
+    EXPECT_TRUE(CLI::NonNegativeNumber(num).empty());
+    num = "0";
+    EXPECT_TRUE(CLI::NonNegativeNumber(num).empty());
+    num = "+0.5";
+    EXPECT_TRUE(CLI::NonNegativeNumber(num).empty());
+    num = "-1";
+    EXPECT_FALSE(CLI::NonNegativeNumber(num).empty());
+    num = "-1.5";
+    EXPECT_FALSE(CLI::NonNegativeNumber(num).empty());
+    num = "a";
+    EXPECT_FALSE(CLI::NonNegativeNumber(num).empty());
 }
 
 TEST(Validators, NumberValidator) {


### PR DESCRIPTION
This PR enables checking positivity of float types , providing a fix to  CLIUtils#328.
Numbers are handled as `double`s in the same way that `CLI:Number` is structured https://github.com/CLIUtils/CLI11/blob/418b7175f5223aa28ab65744c76132fd05fd8f39/include/CLI/Validators.hpp#L364-L369
Also, a`CLI:NonNegative` is added and checks if  `number <=0` while `CLI:Positive` is modified to check whether `number>0`