### PR TITLE
Issue #339

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -202,7 +202,7 @@ add_test(NAME enum_pass COMMAND enum -l 1)
 add_test(NAME enum_fail COMMAND enum -l 4)
 set_property(TEST enum_fail PROPERTY PASS_REGULAR_EXPRESSION
     "--level: Check 4 value in {" "FAILED")
-	
+
 add_cli_exe(enum_ostream enum_ostream.cpp)
 add_test(NAME enum_ostream_pass COMMAND enum_ostream --level medium)
 set_property(TEST enum_ostream_pass PROPERTY PASS_REGULAR_EXPRESSION

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -202,6 +202,11 @@ add_test(NAME enum_pass COMMAND enum -l 1)
 add_test(NAME enum_fail COMMAND enum -l 4)
 set_property(TEST enum_fail PROPERTY PASS_REGULAR_EXPRESSION
     "--level: Check 4 value in {" "FAILED")
+	
+add_cli_exe(enum_ostream enum_ostream.cpp)
+add_test(NAME enum_ostream_pass COMMAND enum_ostream --level medium)
+set_property(TEST enum_ostream_pass PROPERTY PASS_REGULAR_EXPRESSION
+    "Enum received: Medium")
 
 add_cli_exe(digit_args digit_args.cpp)
 add_test(NAME digit_args COMMAND digit_args -h)

--- a/examples/enum_ostream.cpp
+++ b/examples/enum_ostream.cpp
@@ -1,0 +1,41 @@
+#include <CLI/CLI.hpp>
+
+enum class Level : int { High, Medium, Low };
+
+// this breaks the code
+inline std::ostream &operator<<(std::ostream &o, const Level &l) {
+    switch(l) {
+    case Level::High:
+        o << "High";
+        break;
+    case Level::Medium:
+        o << "Medium";
+        break;
+    case Level::Low:
+        o << "Low";
+        break;
+    }
+    return o;
+}
+
+int main(int argc, char **argv) {
+    CLI::App app;
+
+    Level level;
+    // specify string->value mappings
+    std::vector<std::pair<std::string, Level>> map{
+        {"high", Level::High}, {"medium", Level::Medium}, {"low", Level::Low}};
+    // checked Transform does the translation and checks the results are either in one of the strings or one of the
+    // translations already
+    app.add_option("-l,--level", level, "Level settings")
+        ->required()
+        ->transform(CLI::CheckedTransformer(map, CLI::ignore_case));
+
+    CLI11_PARSE(app, argc, argv);
+
+    // CLI11's built in enum streaming can be used outside CLI11 like this:
+    using namespace CLI::enums;
+    std::cout << "Enum received: " << level << std::endl;
+
+    return 0;
+}

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -272,7 +272,7 @@ std::string value_string(const T &value) {
 /// for other types just use the regular to_string function
 template <typename T,
           enable_if_t<!std::is_enum<T>::value && !std::is_arithmetic<T>::value, detail::enabler> = detail::dummy>
-std::string value_string(const T &value) {
+auto value_string(const T &value) -> decltype(to_string(value)) {
     return to_string(value);
 }
 

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -259,6 +259,27 @@ template <typename T1,
 std::string checked_to_string(T &&) {
     return std::string{};
 }
+/// get a string as a convertible value for arithmetic types
+template <typename T,
+          enable_if_t<std::is_arithmetic<typename std::remove_reference<T>::type>::value, detail::enabler> = detail::dummy>
+std::string value_string(T &&value) {
+    return std::to_string(std::forward<T>(value));
+}
+/// get a string as a convertible value for enumerations
+template <typename T,
+          enable_if_t<std::is_enum<typename std::remove_reference<T>::type>::value, detail::enabler> = detail::dummy>
+std::string value_string(T &&value) {
+    return std::to_string(static_cast<std::underlying_type<typename std::remove_reference<T>::type>::type>
+                          (value));
+}
+/// for other types just use the regular to_string function
+template <typename T,
+          enable_if_t<!std::is_enum<typename std::remove_reference<T>::type>::value &&
+                          !std::is_arithmetic<typename std::remove_reference<T>::type>::value,
+                      detail::enabler> = detail::dummy>
+std::string value_string(T &&value) {
+    return to_string(std::forward<T>(value));
+}
 
 /// This will only trigger for actual void type
 template <typename T, typename Enable = void> struct type_count { static const int value{0}; };

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -260,8 +260,9 @@ std::string checked_to_string(T &&) {
     return std::string{};
 }
 /// get a string as a convertible value for arithmetic types
-template <typename T,
-          enable_if_t<std::is_arithmetic<typename std::remove_reference<T>::type>::value, detail::enabler> = detail::dummy>
+template <
+    typename T,
+    enable_if_t<std::is_arithmetic<typename std::remove_reference<T>::type>::value, detail::enabler> = detail::dummy>
 std::string value_string(T &&value) {
     return std::to_string(std::forward<T>(value));
 }
@@ -269,8 +270,8 @@ std::string value_string(T &&value) {
 template <typename T,
           enable_if_t<std::is_enum<typename std::remove_reference<T>::type>::value, detail::enabler> = detail::dummy>
 std::string value_string(T &&value) {
-    return std::to_string(static_cast<std::underlying_type<typename std::remove_reference<T>::type>::type>
-                          (value));
+    return std::to_string(
+        static_cast<typename std::underlying_type<typename std::remove_reference<T>::type>::type>(value));
 }
 /// for other types just use the regular to_string function
 template <typename T,

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -260,26 +260,20 @@ std::string checked_to_string(T &&) {
     return std::string{};
 }
 /// get a string as a convertible value for arithmetic types
-template <
-    typename T,
-    enable_if_t<std::is_arithmetic<typename std::remove_reference<T>::type>::value, detail::enabler> = detail::dummy>
-std::string value_string(T &&value) {
-    return std::to_string(std::forward<T>(value));
+template <typename T, enable_if_t<std::is_arithmetic<T>::value, detail::enabler> = detail::dummy>
+std::string value_string(const T &value) {
+    return std::to_string(value);
 }
 /// get a string as a convertible value for enumerations
-template <typename T,
-          enable_if_t<std::is_enum<typename std::remove_reference<T>::type>::value, detail::enabler> = detail::dummy>
-std::string value_string(T &&value) {
-    return std::to_string(
-        static_cast<typename std::underlying_type<typename std::remove_reference<T>::type>::type>(value));
+template <typename T, enable_if_t<std::is_enum<T>::value, detail::enabler> = detail::dummy>
+std::string value_string(const T &value) {
+    return std::to_string(static_cast<typename std::underlying_type<T>::type>(value));
 }
 /// for other types just use the regular to_string function
 template <typename T,
-          enable_if_t<!std::is_enum<typename std::remove_reference<T>::type>::value &&
-                          !std::is_arithmetic<typename std::remove_reference<T>::type>::value,
-                      detail::enabler> = detail::dummy>
-std::string value_string(T &&value) {
-    return to_string(std::forward<T>(value));
+          enable_if_t<!std::is_enum<T>::value && !std::is_arithmetic<T>::value, detail::enabler> = detail::dummy>
+std::string value_string(const T &value) {
+    return to_string(value);
 }
 
 /// This will only trigger for actual void type

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -709,7 +709,7 @@ class IsMember : public Validator {
             if(res.first) {
                 // Make sure the version in the input string is identical to the one in the set
                 if(filter_fn) {
-                    input = detail::to_string(detail::pair_adaptor<element_t>::first(*(res.second)));
+                    input = detail::value_string(detail::pair_adaptor<element_t>::first(*(res.second)));
                 }
 
                 // Return empty error string (success)
@@ -778,7 +778,7 @@ class Transformer : public Validator {
             }
             auto res = detail::search(mapping, b, filter_fn);
             if(res.first) {
-                input = detail::to_string(detail::pair_adaptor<element_t>::second(*res.second));
+                input = detail::value_string(detail::pair_adaptor<element_t>::second(*res.second));
             }
             return std::string{};
         };
@@ -846,12 +846,12 @@ class CheckedTransformer : public Validator {
                 }
                 auto res = detail::search(mapping, b, filter_fn);
                 if(res.first) {
-                    input = detail::to_string(detail::pair_adaptor<element_t>::second(*res.second));
+                    input = detail::value_string(detail::pair_adaptor<element_t>::second(*res.second));
                     return std::string{};
                 }
             }
             for(const auto &v : detail::smart_deref(mapping)) {
-                auto output_string = detail::to_string(detail::pair_adaptor<element_t>::second(v));
+                auto output_string = detail::value_string(detail::pair_adaptor<element_t>::second(v));
                 if(output_string == input) {
                     return std::string();
                 }


### PR DESCRIPTION
add an example where the name of the enum is printed through a stream output function, which subverted the checkTransformer conversion and prevented conversion of the enumeration.

This PR deals with this situation for enumerations and other numeric types.    It does it by discriminating between to_string situations in which a value is needed vs one where the converted string is needed, by adding a value_string overload which routes to the to_string unless the value is numeric or an enumeration.  