### PR TITLE
allow transform to work with arrays.  

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -83,8 +83,7 @@ namespace detail {
 template <typename T, typename Enable = void> struct element_type { using type = T; };
 
 template <typename T> struct element_type<T, typename std::enable_if<is_copyable_ptr<T>::value>::type> {
-    using type =
-         typename std::pointer_traits<T>::element_type;
+    using type = typename std::pointer_traits<T>::element_type;
 };
 
 /// Combination of the element type and value type - remove pointer (including smart pointers) and get the value_type of

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -74,13 +74,17 @@ template <> struct IsMemberType<const char *> { using type = std::string; };
 
 namespace detail {
 
-// These are utilities for IsMember
+// These are utilities for IsMember and other transforming objects
 
 /// Handy helper to access the element_type generically. This is not part of is_copyable_ptr because it requires that
 /// pointer_traits<T> be valid.
-template <typename T> struct element_type {
+
+/// not a pointer
+template <typename T, typename Enable = void> struct element_type { using type = T; };
+
+template <typename T> struct element_type<T, typename std::enable_if<is_copyable_ptr<T>::value>::type> {
     using type =
-        typename std::conditional<is_copyable_ptr<T>::value, typename std::pointer_traits<T>::element_type, T>::type;
+         typename std::pointer_traits<T>::element_type;
 };
 
 /// Combination of the element type and value type - remove pointer (including smart pointers) and get the value_type of

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -156,8 +156,7 @@ TEST_F(TApp, SimpleNumericalTransformFn) {
 }
 
 TEST_F(TApp, SimpleNumericalTransformFnVector) {
-    std::vector<std::pair<std::string, int>> conversions{std::make_pair(std::string("one"), 1),
-                                                         std::make_pair(std::string("two"), 2)};
+    std::vector<std::pair<std::string, int>> conversions{{"one", 1}, {"two", 2}};
     int value;
     auto opt = app.add_option("-s", value)->transform(CLI::Transformer(conversions, CLI::ignore_case));
     args = {"-s", "ONe"};
@@ -168,8 +167,9 @@ TEST_F(TApp, SimpleNumericalTransformFnVector) {
 }
 
 TEST_F(TApp, SimpleNumericalTransformFnArray) {
-    std::array<std::pair<std::string, int>, 2> conversions{std::make_pair(std::string("one"), 1),
-                                                           std::make_pair(std::string("two"), 2)};
+    std::array<std::pair<std::string, int>, 2> conversions;
+    conversions[0] = std::make_pair(std::string("one"), 1);
+    conversions[1] = std::make_pair(std::string("two"), 2);
 
     int value;
     auto opt = app.add_option("-s", value)->transform(CLI::Transformer(conversions, CLI::ignore_case));

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -184,7 +184,7 @@ TEST_F(TApp, SimpleNumericalTransformFnArray) {
 TEST_F(TApp, SimpleNumericalTransformFnconstexprArray) {
     constexpr std::pair<const char *, int> p1{"one", 1};
     constexpr std::pair<const char *, int> p2{"two", 2};
-    constexpr std::array<std::pair<const char *, int>, 2> conversions_c{p1, p2};
+    constexpr std::array<std::pair<const char *, int>, 2> conversions_c{{p1, p2}};
 
     int value;
     auto opt = app.add_option("-s", value)->transform(CLI::Transformer(&conversions_c, CLI::ignore_case));
@@ -193,6 +193,12 @@ TEST_F(TApp, SimpleNumericalTransformFnconstexprArray) {
     EXPECT_EQ(1u, app.count("-s"));
     EXPECT_EQ(1u, opt->count());
     EXPECT_EQ(value, 1);
+
+    args = {"-s", "twO"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, 2);
 }
 
 TEST_F(TApp, EnumTransformFn) {

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -180,6 +180,21 @@ TEST_F(TApp, SimpleNumericalTransformFnArray) {
     EXPECT_EQ(value, 1);
 }
 
+// zero copy constexpr array operation with transformer example and test
+TEST_F(TApp, SimpleNumericalTransformFnconstexprArray) {
+    constexpr std::pair<const char *, int> p1{"one", 1};
+    constexpr std::pair<const char *, int> p2{"two", 2};
+    constexpr std::array<std::pair<const char *, int>, 2> conversions_c{p1, p2};
+
+    int value;
+    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(&conversions_c, CLI::ignore_case));
+    args = {"-s", "ONe"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, 1);
+}
+
 TEST_F(TApp, EnumTransformFn) {
     enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17 };
     test value;

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -1,5 +1,6 @@
 #include "app_helper.hpp"
 
+#include <array>
 #include <unordered_map>
 
 #if defined(CLI11_CPP17)
@@ -147,6 +148,31 @@ TEST_F(TApp, SimpleNumericalTransformFn) {
     auto opt =
         app.add_option("-s", value)
             ->transform(CLI::Transformer(std::vector<std::pair<std::string, int>>{{"one", 1}}, CLI::ignore_case));
+    args = {"-s", "ONe"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, 1);
+}
+
+TEST_F(TApp, SimpleNumericalTransformFnVector) {
+    std::vector<std::pair<std::string, int>> conversions{std::make_pair(std::string("one"), 1),
+                                                         std::make_pair(std::string("two"), 2)};
+    int value;
+    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(conversions, CLI::ignore_case));
+    args = {"-s", "ONe"};
+    run();
+    EXPECT_EQ(1u, app.count("-s"));
+    EXPECT_EQ(1u, opt->count());
+    EXPECT_EQ(value, 1);
+}
+
+TEST_F(TApp, SimpleNumericalTransformFnArray) {
+    std::array<std::pair<std::string, int>, 2> conversions{std::make_pair(std::string("one"), 1),
+                                                           std::make_pair(std::string("two"), 2)};
+
+    int value;
+    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(conversions, CLI::ignore_case));
     args = {"-s", "ONe"};
     run();
     EXPECT_EQ(1u, app.count("-s"));


### PR DESCRIPTION
The element_type trait require pointer_traits<T> to be defined for the type which it was for vector but not for array due to decay rules in C++, even though it was not used.  So Element type had to be split into two templates instead of a conditional.

Fix Gitter chat issue [November 25, 2019 10:09 AM](https://gitter.im/CLI11gitter/Lobby?at=5ddc18c155bbed7ade433f5b)