### PR TITLE
allow hidden option groups for help.

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ The subcommand method
 .add_option_group(name,description)
 ```
 
-Will create an option group, and return a pointer to it.  An option group allows creation of a collection of options, similar to the groups function on options, but with additional controls and requirements.  They allow specific sets of options to be composed and controlled as a collective.  For an example see [range example](https://github.com/CLIUtils/CLI11/blob/master/examples/ranges.cpp).  Option groups are a specialization of an App so all [functions](#subcommand-options) that work with an App or subcommand also work on option groups.  Options can be created as part of an option group using the add functions just like a subcommand, or previously created options can be added through
+Will create an option group, and return a pointer to it. The argument for `description` is optional and can be omitted.  An option group allows creation of a collection of options, similar to the groups function on options, but with additional controls and requirements.  They allow specific sets of options to be composed and controlled as a collective.  For an example see [range example](https://github.com/CLIUtils/CLI11/blob/master/examples/ranges.cpp).  Option groups are a specialization of an App so all [functions](#subcommand-options) that work with an App or subcommand also work on option groups.  Options can be created as part of an option group using the add functions just like a subcommand, or previously created options can be added through
 
 ```cpp
 ogroup->add_option(option_pointer);
@@ -660,6 +660,12 @@ CLI::TriggerOff(group2_pointer, disabled_group);
 
 These functions make use of `preparse_callback`, `enabled_by_default()` and `disabled_by_default`.  The triggered group may be a vector of group pointers.  These methods should only be used once per group and will override any previous use of the underlying functions.  More complex arrangements can be accomplished using similar methodology with a custom preparse_callback function that does more.
 
+If an empty string is passed the option group name the entire group will be hidden in the help results.  For example.
+
+```cpp
+auto hidden_group=app.add_option_group("");
+```
+will create a group such that no options in that group are displayed in the help string.
 
 ### Configuration file
 

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -164,7 +164,7 @@ inline std::string Formatter::make_subcommands(const App *app, AppFormatMode mod
     // Make a list in definition order of the groups seen
     std::vector<std::string> subcmd_groups_seen;
     for(const App *com : subcommands) {
-        if(com->get_name().empty()) {
+        if(com->get_name().empty() && !com->get_group().empty()) {
             out << make_expanded(com);
             continue;
         }

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -164,8 +164,10 @@ inline std::string Formatter::make_subcommands(const App *app, AppFormatMode mod
     // Make a list in definition order of the groups seen
     std::vector<std::string> subcmd_groups_seen;
     for(const App *com : subcommands) {
-        if(com->get_name().empty() && !com->get_group().empty()) {
-            out << make_expanded(com);
+        if(com->get_name().empty()) {
+            if(!com->get_group().empty()) {
+                out << make_expanded(com);
+            }
             continue;
         }
         std::string group_key = com->get_group();

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -97,6 +97,32 @@ TEST(THelp, Hidden) {
     EXPECT_THAT(help, Not(HasSubstr("another")));
 }
 
+TEST(THelp, HiddenGroup) {
+    CLI::App app{"My prog"};
+    //empty option group name should be hidden
+    auto hgroup=app.add_option_group("");
+    std::string x;
+    hgroup->add_option("something", x, "My option here");
+    std::string y;
+    hgroup->add_option("--another", y);
+
+    std::string help = app.help();
+
+    EXPECT_THAT(help, HasSubstr("My prog"));
+    EXPECT_THAT(help, HasSubstr("-h,--help"));
+    EXPECT_THAT(help, HasSubstr("Options:"));
+    EXPECT_THAT(help, Not(HasSubstr("[something]")));
+    EXPECT_THAT(help, Not(HasSubstr("something ")));
+    EXPECT_THAT(help, Not(HasSubstr("another")));
+
+    hgroup->group("ghidden");
+
+    help = app.help();
+
+    EXPECT_THAT(help, HasSubstr("something "));
+    EXPECT_THAT(help, HasSubstr("another"));
+}
+
 TEST(THelp, OptionalPositionalAndOptions) {
     CLI::App app{"My prog", "AnotherProgram"};
     app.add_flag("-q,--quick");

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -99,8 +99,8 @@ TEST(THelp, Hidden) {
 
 TEST(THelp, HiddenGroup) {
     CLI::App app{"My prog"};
-    //empty option group name should be hidden
-    auto hgroup=app.add_option_group("");
+    // empty option group name should be hidden
+    auto hgroup = app.add_option_group("");
     std::string x;
     hgroup->add_option("something", x, "My option here");
     std::string y;


### PR DESCRIPTION

If merged this PR will recognize option_groups with no name and hide them, similar to specifying `group("")`  

Adds a test that verifies this functionality.  

Fixes #327