### PR TITLE
Test correctness of config write-read loop

### DIFF
--- a/tests/IniTest.cpp
+++ b/tests/IniTest.cpp
@@ -915,3 +915,25 @@ TEST_F(TApp, StopReadingConfigOnClear) {
 
     EXPECT_EQ(volume, 0);
 }
+
+TEST_F(TApp, ConfigWriteReadWrite) {
+
+    TempFile tmpini{"TestIniTmp.ini"};
+
+    app.add_flag("--flag");
+    run();
+
+    // Save config, with default values too
+    std::string config1 = app.config_to_str(true, true);
+    {
+        std::ofstream out{tmpini};
+        out << config1 << std::endl;
+    }
+
+    app.set_config("--config", "TestIniTmp.ini", "Read an ini file", true);
+    run();
+
+    std::string config2 = app.config_to_str(true, true);
+
+    EXPECT_EQ(config1, config2);
+}


### PR DESCRIPTION
One would expect that if config saving and loading is correctly done, saving then loading then saving again should result in the same string?
It seems not to be the case currently due to some logic errors in the save/load logic.

This is a very hacky quick test, to start discussion. We can cleanup and land later if you think this kind of check is valuable.