### PR TITLE
Bug fix for issue 369.

### DIFF
--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -1075,6 +1075,7 @@ class Option : public OptionBase<Option> {
         add_result(val);
         run_callback();
         results_ = std::move(old_results);
+        current_option_state_ = option_state::parsing;
         return this;
     }
 

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -120,6 +120,26 @@ TEST_F(TApp, EnumCheckedDefualtTransform) {
     EXPECT_EQ(app.get_option("--existing")->as<existing>(), existing::abort);
 }
 
+TEST_F(TApp, EnumCheckedDefaultTransformCallback) {
+    enum class existing : int16_t { abort, overwrite, remove };
+    auto cmd = std::make_shared<CLI::App>("deploys the repository somewhere", "deploy");
+    cmd->add_option("--existing", "What to do if file already exists in the destination")
+        ->transform(
+            CLI::CheckedTransformer(std::unordered_map<std::string, existing>{ {"abort", existing::abort},
+                { "overwrite", existing::overwrite },
+                { "delete", existing::remove },
+                { "remove", existing::remove }}))
+        ->default_val("abort");
+
+    cmd->callback([cmd]() {
+        EXPECT_EQ(cmd->get_option("--existing")->as<existing>(), existing::abort);
+        });
+    app.add_subcommand(cmd);
+
+    args = { "deploy" };
+    run();
+}
+
 TEST_F(TApp, SimpleTransformFn) {
     int value;
     auto opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", "1"}}, CLI::ignore_case));

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -126,18 +126,16 @@ TEST_F(TApp, EnumCheckedDefaultTransformCallback) {
     auto cmd = std::make_shared<CLI::App>("deploys the repository somewhere", "deploy");
     cmd->add_option("--existing", "What to do if file already exists in the destination")
         ->transform(
-            CLI::CheckedTransformer(std::unordered_map<std::string, existing>{ {"abort", existing::abort},
-                { "overwrite", existing::overwrite },
-                { "delete", existing::remove },
-                { "remove", existing::remove }}))
+            CLI::CheckedTransformer(std::unordered_map<std::string, existing>{{"abort", existing::abort},
+                                                                              {"overwrite", existing::overwrite},
+                                                                              {"delete", existing::remove},
+                                                                              {"remove", existing::remove}}))
         ->default_val("abort");
 
-    cmd->callback([cmd]() {
-        EXPECT_EQ(cmd->get_option("--existing")->as<existing>(), existing::abort);
-        });
+    cmd->callback([cmd]() { EXPECT_EQ(cmd->get_option("--existing")->as<existing>(), existing::abort); });
     app.add_subcommand(cmd);
 
-    args = { "deploy" };
+    args = {"deploy"};
     run();
 }
 

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -120,6 +120,7 @@ TEST_F(TApp, EnumCheckedDefualtTransform) {
     EXPECT_EQ(app.get_option("--existing")->as<existing>(), existing::abort);
 }
 
+// test from https://github.com/CLIUtils/CLI11/issues/369  [Jakub Zakrzewski](https://github.com/jzakrzewski)
 TEST_F(TApp, EnumCheckedDefaultTransformCallback) {
     enum class existing : int16_t { abort, overwrite, remove };
     auto cmd = std::make_shared<CLI::App>("deploys the repository somewhere", "deploy");


### PR DESCRIPTION
  The default_val call was not resetting the option state after it had executed the callback and reset the results vector, allowing the possibility of an empty results getting passed to some conversions functions.

If merged this pull request will add the test described in issue #369 and a fix to the default_val function which correctly resets the option state after evaluating the internal callback. 

Closes #369.