### PR TITLE
Minor fixes in enum examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,7 @@ Several short examples of different features are included in the repository. A b
  - [callback_passthrough](https://github.com/CLIUtils/CLI11/blob/master/examples/callback_passthrough.cpp): Example of directly passing remaining arguments through to a callback function which generates a CLI11 application based on existing arguments.
  - [digit_args](https://github.com/CLIUtils/CLI11/blob/master/examples/digit_args.cpp):  Based on [Issue #123](https://github.com/CLIUtils/CLI11/issues/123), uses digit flags to pass a value
  - [enum](https://github.com/CLIUtils/CLI11/blob/master/examples/enum.cpp):  Using enumerations in an option, and the use of [CheckedTransformer](#transforming-validators)
+ - [enum_ostream](https://github.com/CLIUtils/CLI11/blob/master/examples/enum_ostream.cpp):  In addition to the contents of example enum.cpp, this example shows how a custom ostream operator overrides CLI11's enum streaming.
  - [formatter](https://github.com/CLIUtils/CLI11/blob/master/examples/formatter.cpp): Illustrating usage of a custom formatter
  - [groups](https://github.com/CLIUtils/CLI11/blob/master/examples/groups.cpp):  Example using groups of options for help grouping and a the timer helper class
  - [inter_argument_order](https://github.com/CLIUtils/CLI11/blob/master/examples/inter_argument_order.cpp): An app to practice mixing unlimited arguments, but still recover the original order.
@@ -833,7 +834,7 @@ Several short examples of different features are included in the repository. A b
 
 ## Contribute
 
-To contribute, open an [issue][github issues] or [pull request][github pull requests] on GitHub, or ask a question on [gitter][]. The is also a short note to contributors [here](./.github/CONTRIBUTING.md).
+To contribute, open an [issue][github issues] or [pull request][github pull requests] on GitHub, or ask a question on [gitter][]. There is also a short note to contributors [here](./.github/CONTRIBUTING.md).
 This readme roughly follows the [Standard Readme Style][] and includes a mention of almost every feature of the library. More complex features are documented in more detail in the [CLI11 tutorial GitBook][gitbook].
 
 This project was created by [Henry Schreiner](https://github.com/henryiii).

--- a/examples/enum.cpp
+++ b/examples/enum.cpp
@@ -1,15 +1,15 @@
 #include <CLI/CLI.hpp>
+#include <map>
 
 enum class Level : int { High, Medium, Low };
 
 int main(int argc, char **argv) {
     CLI::App app;
 
-    Level level;
+    Level level{Level::Low};
     // specify string->value mappings
-    std::vector<std::pair<std::string, Level>> map{
-        {"high", Level::High}, {"medium", Level::Medium}, {"low", Level::Low}};
-    // checked Transform does the translation and checks the results are either in one of the strings or one of the
+    std::map<std::string, Level> map{{"high", Level::High}, {"medium", Level::Medium}, {"low", Level::Low}};
+    // CheckedTransformer translates and checks whether the results are either in one of the strings or in one of the
     // translations already
     app.add_option("-l,--level", level, "Level settings")
         ->required()

--- a/examples/enum_ostream.cpp
+++ b/examples/enum_ostream.cpp
@@ -2,30 +2,30 @@
 
 enum class Level : int { High, Medium, Low };
 
-// this breaks the code
-inline std::ostream &operator<<(std::ostream &o, const Level &l) {
-    switch(l) {
+// Defining operator<<() for your enum class (in this case for 'Level') overrides CLI11's enum streaming
+inline std::ostream &operator<<(std::ostream &os, const Level &level) {
+    switch(level) {
     case Level::High:
-        o << "High";
+        os << "High";
         break;
     case Level::Medium:
-        o << "Medium";
+        os << "Medium";
         break;
     case Level::Low:
-        o << "Low";
+        os << "Low";
         break;
     }
-    return o;
+    os << " (from custom ostream)";
+    return os;
 }
 
 int main(int argc, char **argv) {
     CLI::App app;
 
-    Level level;
+    Level level{Level::Low};
     // specify string->value mappings
-    std::vector<std::pair<std::string, Level>> map{
-        {"high", Level::High}, {"medium", Level::Medium}, {"low", Level::Low}};
-    // checked Transform does the translation and checks the results are either in one of the strings or one of the
+    std::map<std::string, Level> map{{"high", Level::High}, {"medium", Level::Medium}, {"low", Level::Low}};
+    // CheckedTransformer translates and checks whether the results are either in one of the strings or in one of the
     // translations already
     app.add_option("-l,--level", level, "Level settings")
         ->required()

--- a/examples/enum_ostream.cpp
+++ b/examples/enum_ostream.cpp
@@ -15,7 +15,7 @@ inline std::ostream &operator<<(std::ostream &os, const Level &level) {
         os << "Low";
         break;
     }
-    os << " (from custom ostream)";
+    os << " (ft rom custom ostream)";
     return os;
 }
 


### PR DESCRIPTION
- Initialize level variable (uninitialized before)
- Use std::map instead of std::vector<std::pair>
- Update comments
- Add enum_ostream to readme