### PR TITLE
clang-tidy correctly run by CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ In general, make sure the addition is well thought out and does not increase the
 * Once you make the PR, tests will run to make sure your code works on all supported platforms
 * The test coverage is also measured, and that should remain 100%
 * Formatting should be done with pre-commit, otherwise the format check will not pass. However, it is trivial to apply this to your PR, so don't worry about this check. If you do want to run it, see below.
-* Everything must pass clang-tidy as well, run with `-DCLANG_TIDY_FIX-ON` (make sure you use a single threaded build process!)
+* Everything must pass clang-tidy as well, run with `-DCLI11_CLANG_TIDY=ON` (if you set `-DCLI11_CLANG_TIDY_OPTIONS="-fix"`, make sure you use a single threaded build process, or just build one example target).
 
 
 ## Pre-commit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,21 +75,19 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
         endif()
     endif()
 
-    if(NOT CMAKE_VERSION VERSION_LESS 3.6 AND CLANG_TIDY)
-        # Add clang-tidy if available
-        option(CLANG_TIDY_FIX "Perform fixes for Clang-Tidy" OFF)
-        find_program(
-            CLANG_TIDY_EXE
-            NAMES "clang-tidy"
-            DOC "Path to clang-tidy executable"
-        )
+    if(NOT CMAKE_VERSION VERSION_LESS 3.6)
+        option(CLI11_CLANG_TIDY "Look for and use Clang-Tidy")
+        set(CLI11_CLANG_TIDY_OPTIONS "" CACHE STRING "Clang tidy option, such as -fix")
+        if(CLI11_CLANG_TIDY)
 
-        if(CLANG_TIDY_EXE)
-            if(CLANG_TIDY_FIX)
-                set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-fix")
-            else()
-                set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}")
-            endif()
+            find_program(
+                CLANG_TIDY_EXE
+                NAMES "clang-tidy"
+                DOC "Path to clang-tidy executable"
+                REQUIRED
+            )
+
+        set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" ${CLI11_CLANG_TIDY_OPTIONS})
         endif()
     endif()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,13 +18,13 @@ jobs:
 - job: ClangTidy
   variables:
     CXX_FLAGS: "-Werror -Wcast-align -Wfloat-equal -Wimplicit-atomic-properties -Wmissing-declarations -Woverlength-strings -Wshadow -Wstrict-selector-match -Wundeclared-selector -Wunreachable-code -std=c++11"
-    cli11.options: -DCLANG_TIDY_FIX=ON
+    cli11.options: -DCLI11_CLANG_TIDY=ON -DCLI11_CLANG_TIDY_OPTIONS="-fix"
     cli11.std: 11
     cli11.single: OFF
     CMAKE_BUILD_PARALLEL_LEVEL: 1
   pool:
-    vmImage: 'ubuntu-16.04'
-  container: silkeh/clang:5
+    vmImage: 'ubuntu-latest'
+  container: silkeh/clang:8
   steps:
     - template: .ci/azure-cmake.yml
     - template: .ci/azure-build.yml

--- a/book/README.md
+++ b/book/README.md
@@ -53,8 +53,6 @@ Reading/producing `.ini` files for configuration is also supported, as is using 
 
 CLI11 was developed at the [University of Cincinnati] in support of the [GooFit] library under [NSF Award 1414736][NSF 1414736]. It was featured in a [DIANA/HEP] meeting at CERN. Please give it a try! Feedback is always welcome.
 
-This guide was based on CLI11 1.7.
-
 [GooFit]: https://github.com/GooFit/GooFit
 [DIANA/HEP]: http://diana-hep.org
 [CLI11]: https://github.com/CLIUtils/CLI11

--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -86,6 +86,7 @@ For the curious, the CMake options and defaults are listed below. Most options d
 | `CLI11_SINGLE_FILE_TESTS=OFF` | Run the tests on the generated single file version as well |
 | `CLI11_EXAMPLES=ON` | Build the example programs. |
 | `CLI11_TESTING=ON` | Build the tests. |
-| `CLANG_TIDY_FIX=OFF` | Run `clang-tidy` on the examples and headers and apply fixes. (Changes source code!) Requires LLVM and CMake 3.6+. |
+| `CLI11_CLANG_TIDY=OFF` | Run `clang-tidy` on the examples and headers. Requires CMake 3.6+. |
+| `CLI11_CLANG_TIDY_OPTIONS=""` | Options to pass to `clang-tidy`, such as `-fix` (single threaded build only if applying fixes!) |
 
 [^1]: Docker is being used to create a pristine disposable environment; there is nothing special about this container. Alpine is being used because it is small, modern, and fast. Commands are similar on any other platform.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1178,7 +1178,7 @@ class App {
 
     /// Check to see if this subcommand was parsed, true only if received on command line.
     /// This allows the subcommand to be directly checked.
-    operator bool() const { return parsed_ > 0; }
+    explicit operator bool() const { return parsed_ > 0; }
 
     ///@}
     /// @name Extras for subclassing

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -112,7 +112,7 @@ inline void checkParentSegments(std::vector<ConfigItem> &output, const std::stri
 
     std::string estring;
     auto parents = detail::generate_parents(currentSection, estring);
-    if(output.size() > 0 && output.back().name == "--") {
+    if(!output.empty() && output.back().name == "--") {
         std::size_t msize = (parents.size() > 1U) ? parents.size() : 2;
         while(output.back().parents.size() >= msize) {
             output.push_back(output.back());
@@ -279,7 +279,7 @@ ConfigBase::to_config(const App *app, bool default_also, bool write_description,
             // Only process option with a long-name and configurable
             if(!opt->get_lnames().empty() && opt->get_configurable()) {
                 if(opt->get_group() != group) {
-                    if(!(group == "Options" && opt->get_group() == "")) {
+                    if(!(group == "Options" && opt->get_group().empty())) {
                         continue;
                     }
                 }

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -671,7 +671,7 @@ class IsMember : public Validator {
 
     /// This allows in-place construction using an initializer list
     template <typename T, typename... Args>
-    explicit IsMember(std::initializer_list<T> values, Args &&... args)
+    IsMember(std::initializer_list<T> values, Args &&... args)
         : IsMember(std::vector<T>(values), std::forward<Args>(args)...) {}
 
     /// This checks to see if an item is in a set (empty function)
@@ -742,7 +742,7 @@ class Transformer : public Validator {
 
     /// This allows in-place construction
     template <typename... Args>
-    explicit Transformer(std::initializer_list<std::pair<std::string, std::string>> values, Args &&... args)
+    Transformer(std::initializer_list<std::pair<std::string, std::string>> values, Args &&... args)
         : Transformer(TransformPairs<std::string>(values), std::forward<Args>(args)...) {}
 
     /// direct map of std::string to std::string
@@ -800,7 +800,7 @@ class CheckedTransformer : public Validator {
 
     /// This allows in-place construction
     template <typename... Args>
-    explicit CheckedTransformer(std::initializer_list<std::pair<std::string, std::string>> values, Args &&... args)
+    CheckedTransformer(std::initializer_list<std::pair<std::string, std::string>> values, Args &&... args)
         : CheckedTransformer(TransformPairs<std::string>(values), std::forward<Args>(args)...) {}
 
     /// direct map of std::string to std::string


### PR DESCRIPTION
Helping with #389, orthogonal changes. Clang-tidy now run by CI, warnings are shown. Will fix two errors as well in preparation for CLI11 1.9. `CLANG_TIDY_FIX` reworked into `CLI11_CLANG_TIDY` and `CLI11_CLANG_TIDY_OPTIONS`.