### PR TITLE
Fix spelling of `option_defaults()`

### DIFF
--- a/book/chapters/options.md
+++ b/book/chapters/options.md
@@ -120,7 +120,7 @@ One of CLI11's systems to allow customizability without high levels of verbosity
 An example of usage:
 
 ```
-app.option_defauts()->ignore_case()->group("Required");
+app.option_defaults()->ignore_case()->group("Required");
 
 app.add_flag("--CaSeLeSs");
 app.get_group() // is "Required"


### PR DESCRIPTION
In `book/chapters/options.md`, `app.option_defauts()` should read `app.option_defaults()`