### PR TITLE
Add cstdint and std::prefix to its symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ app.add_flag(option_name,
              help_string="")
 
 app.add_flag_function(option_name, // 🆕
-             function <void(int64_t count)>,
+             function <void(std::int64_t count)>,
              help_string="")
 
 app.add_flag_callback(option_name,function<void(void)>,help_string="") // 🆕

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -4,6 +4,7 @@
 // file LICENSE or https://github.com/CLIUtils/CLI11 for details.
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <iterator>
@@ -759,8 +760,9 @@ class App {
     }
 
     /// Vector version to capture multiple flags.
-    template <typename T,
-              enable_if_t<!std::is_assignable<std::function<void(int64_t)>, T>::value, detail::enabler> = detail::dummy>
+    template <
+        typename T,
+        enable_if_t<!std::is_assignable<std::function<void(std::int64_t)>, T>::value, detail::enabler> = detail::dummy>
     Option *add_flag(std::string flag_name,
                      std::vector<T> &flag_results, ///< A vector of values with the flag results
                      std::string flag_description = "") {
@@ -795,11 +797,11 @@ class App {
 
     /// Add option for callback with an integer value
     Option *add_flag_function(std::string flag_name,
-                              std::function<void(int64_t)> function, ///< A function to call, void(int)
+                              std::function<void(std::int64_t)> function, ///< A function to call, void(int)
                               std::string flag_description = "") {
 
         CLI::callback_t fun = [function](const CLI::results_t &res) {
-            int64_t flag_count = 0;
+            std::int64_t flag_count = 0;
             detail::sum_flag_vector(res, flag_count);
             function(flag_count);
             return true;
@@ -811,7 +813,7 @@ class App {
 #ifdef CLI11_CPP14
     /// Add option for callback (C++14 or better only)
     Option *add_flag(std::string flag_name,
-                     std::function<void(int64_t)> function, ///< A function to call, void(int64_t)
+                     std::function<void(std::int64_t)> function, ///< A function to call, void(std::int64_t)
                      std::string flag_description = "") {
         return add_flag_function(std::move(flag_name), std::move(function), std::move(flag_description));
     }

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -548,7 +548,7 @@ inline std::string type_name() {
 // Lexical cast
 
 /// Convert a flag into an integer value  typically binary flags
-inline int64_t to_flag_value(std::string val) {
+inline std::int64_t to_flag_value(std::string val) {
     static const std::string trueString("true");
     static const std::string falseString("false");
     if(val == trueString) {
@@ -558,10 +558,10 @@ inline int64_t to_flag_value(std::string val) {
         return -1;
     }
     val = detail::to_lower(val);
-    int64_t ret;
+    std::int64_t ret;
     if(val.size() == 1) {
         if(val[0] >= '1' && val[0] <= '9') {
-            return (static_cast<int64_t>(val[0]) - '0');
+            return (static_cast<std::int64_t>(val[0]) - '0');
         }
         switch(val[0]) {
         case '0':
@@ -972,7 +972,7 @@ bool lexical_conversion(const std::vector<std ::string> &strings, T &output) {
 template <typename T,
           enable_if_t<std::is_integral<T>::value && std::is_unsigned<T>::value, detail::enabler> = detail::dummy>
 void sum_flag_vector(const std::vector<std::string> &flags, T &output) {
-    int64_t count{0};
+    std::int64_t count{0};
     for(auto &flag : flags) {
         count += detail::to_flag_value(flag);
     }
@@ -987,7 +987,7 @@ void sum_flag_vector(const std::vector<std::string> &flags, T &output) {
 template <typename T,
           enable_if_t<std::is_integral<T>::value && std::is_signed<T>::value, detail::enabler> = detail::dummy>
 void sum_flag_vector(const std::vector<std::string> &flags, T &output) {
-    int64_t count{0};
+    std::int64_t count{0};
     for(auto &flag : flags) {
         count += detail::to_flag_value(flag);
     }

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -7,6 +7,7 @@
 #include "CLI/TypeTools.hpp"
 
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -1042,7 +1043,7 @@ class AsNumberWithUnit : public Validator {
 ///   "2 EiB" => 2^61 // Units up to exibyte are supported
 class AsSizeValue : public AsNumberWithUnit {
   public:
-    using result_t = uint64_t;
+    using result_t = std::uint64_t;
 
     /// If kb_is_1000 is true,
     /// interpret 'kb', 'k' as 1000 and 'kib', 'ki' as 1024

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1,5 +1,6 @@
 #include "app_helper.hpp"
 #include <complex>
+#include <cstdint>
 #include <cstdlib>
 
 #include "gmock/gmock.h"
@@ -1431,9 +1432,9 @@ TEST_F(TApp, RequiredFlags) {
 
 TEST_F(TApp, CallbackFlags) {
 
-    int64_t value = 0;
+    std::int64_t value = 0;
 
-    auto func = [&value](int64_t x) { value = x; };
+    auto func = [&value](std::int64_t x) { value = x; };
 
     app.add_flag_function("-v", func);
 
@@ -1473,9 +1474,9 @@ TEST_F(TApp, CallbackBoolFlags) {
 }
 
 TEST_F(TApp, CallbackFlagsFalse) {
-    int64_t value = 0;
+    std::int64_t value = 0;
 
-    auto func = [&value](int64_t x) { value = x; };
+    auto func = [&value](std::int64_t x) { value = x; };
 
     app.add_flag_function("-v,-f{false},--val,--fval{false}", func);
 
@@ -1502,9 +1503,9 @@ TEST_F(TApp, CallbackFlagsFalse) {
 }
 
 TEST_F(TApp, CallbackFlagsFalseShortcut) {
-    int64_t value = 0;
+    std::int64_t value = 0;
 
-    auto func = [&value](int64_t x) { value = x; };
+    auto func = [&value](std::int64_t x) { value = x; };
 
     app.add_flag_function("-v,!-f,--val,!--fval", func);
 
@@ -1533,9 +1534,9 @@ TEST_F(TApp, CallbackFlagsFalseShortcut) {
 #if __cplusplus >= 201402L || _MSC_VER >= 1900
 TEST_F(TApp, CallbackFlagsAuto) {
 
-    int64_t value = 0;
+    std::int64_t value = 0;
 
-    auto func = [&value](int64_t x) { value = x; };
+    auto func = [&value](std::int64_t x) { value = x; };
 
     app.add_flag("-v", func);
 
@@ -2562,8 +2563,8 @@ TEST_F(TApp, EmptyOptionFail) {
 }
 
 TEST_F(TApp, BeforeRequirements) {
-    app.add_flag_function("-a", [](int64_t) { throw CLI::Success(); });
-    app.add_flag_function("-b", [](int64_t) { throw CLI::CallForHelp(); });
+    app.add_flag_function("-a", [](std::int64_t) { throw CLI::Success(); });
+    app.add_flag_function("-b", [](std::int64_t) { throw CLI::CallForHelp(); });
 
     args = {"extra"};
     EXPECT_THROW(run(), CLI::ExtrasError);

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1013,7 +1013,7 @@ TEST(Types, LexicalCastEnum) {
     EXPECT_EQ(output, v5);
 
     EXPECT_FALSE(CLI::detail::lexical_cast("invalid", output));
-    enum class t2 : uint64_t { enum1 = 65, enum2 = 45667, enum3 = 9999999999999 };
+    enum class t2 : std::uint64_t { enum1 = 65, enum2 = 45667, enum3 = 9999999999999 };
     t2 output2;
     EXPECT_TRUE(CLI::detail::lexical_cast("65", output2));
     EXPECT_EQ(output2, t2::enum1);

--- a/tests/NewParseTest.cpp
+++ b/tests/NewParseTest.cpp
@@ -1,6 +1,7 @@
 #include "app_helper.hpp"
 #include "gmock/gmock.h"
 #include <complex>
+#include <cstdint>
 
 using ::testing::HasSubstr;
 
@@ -499,12 +500,12 @@ template <class X> class AobjWrapper {
     X val_{};
 };
 
-static_assert(std::is_assignable<AobjWrapper<uint16_t> &, uint16_t>::value,
+static_assert(std::is_assignable<AobjWrapper<std::uint16_t> &, std::uint16_t>::value,
               "AobjWrapper not assignable like it should be ");
 
 TEST_F(TApp, uint16Wrapper) {
-    AobjWrapper<uint16_t> sWrapper;
-    app.add_option<AobjWrapper<uint16_t>, uint16_t>("-v", sWrapper);
+    AobjWrapper<std::uint16_t> sWrapper;
+    app.add_option<AobjWrapper<std::uint16_t>, std::uint16_t>("-v", sWrapper);
     args = {"-v", "9"};
 
     run();

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 
@@ -132,7 +133,7 @@ TEST_F(TApp, BoostOptionalTestZarg) {
 }
 
 TEST_F(TApp, BoostOptionalint64Test) {
-    boost::optional<int64_t> opt;
+    boost::optional<std::int64_t> opt;
     app.add_option("-c,--count", opt);
     run();
     EXPECT_FALSE(opt);

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -1,6 +1,7 @@
 #include "app_helper.hpp"
 
 #include <array>
+#include <cstdint>
 #include <unordered_map>
 
 #if defined(CLI11_CPP17)
@@ -43,7 +44,7 @@ TEST_F(TApp, SimpleNumericalTransform) {
 }
 
 TEST_F(TApp, EnumTransform) {
-    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17 };
+    enum class test : std::int16_t { val1 = 3, val2 = 4, val3 = 17 };
     test value;
     auto opt = app.add_option("-s", value)
                    ->transform(CLI::Transformer(
@@ -68,11 +69,11 @@ TEST_F(TApp, EnumTransform) {
     // transformer doesn't do any checking so this still works
     args = {"-s", "5"};
     run();
-    EXPECT_EQ(static_cast<int16_t>(value), int16_t(5));
+    EXPECT_EQ(static_cast<std::int16_t>(value), std::int16_t(5));
 }
 
 TEST_F(TApp, EnumCheckedTransform) {
-    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17 };
+    enum class test : std::int16_t { val1 = 3, val2 = 4, val3 = 17 };
     test value;
     auto opt = app.add_option("-s", value)
                    ->transform(CLI::CheckedTransformer(
@@ -104,7 +105,7 @@ TEST_F(TApp, EnumCheckedTransform) {
 
 // from jzakrzewski Issue #330
 TEST_F(TApp, EnumCheckedDefualtTransform) {
-    enum class existing : int16_t { abort, overwrite, remove };
+    enum class existing : std::int16_t { abort, overwrite, remove };
     app.add_option("--existing", "What to do if file already exists in the destination")
         ->transform(
             CLI::CheckedTransformer(std::unordered_map<std::string, existing>{{"abort", existing::abort},
@@ -122,7 +123,7 @@ TEST_F(TApp, EnumCheckedDefualtTransform) {
 
 // test from https://github.com/CLIUtils/CLI11/issues/369  [Jakub Zakrzewski](https://github.com/jzakrzewski)
 TEST_F(TApp, EnumCheckedDefaultTransformCallback) {
-    enum class existing : int16_t { abort, overwrite, remove };
+    enum class existing : std::int16_t { abort, overwrite, remove };
     auto cmd = std::make_shared<CLI::App>("deploys the repository somewhere", "deploy");
     cmd->add_option("--existing", "What to do if file already exists in the destination")
         ->transform(
@@ -223,7 +224,7 @@ TEST_F(TApp, SimpleNumericalTransformFnconstexprArray) {
 #endif
 
 TEST_F(TApp, EnumTransformFn) {
-    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17 };
+    enum class test : std::int16_t { val1 = 3, val2 = 4, val3 = 17 };
     test value;
     auto opt = app.add_option("-s", value)
                    ->transform(CLI::Transformer(
@@ -249,7 +250,7 @@ TEST_F(TApp, EnumTransformFn) {
 }
 
 TEST_F(TApp, EnumTransformFnMap) {
-    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17 };
+    enum class test : std::int16_t { val1 = 3, val2 = 4, val3 = 17 };
     std::map<std::string, test> map{{"val1", test::val1}, {"val2", test::val2}, {"val3", test::val3}};
     test value;
     auto opt = app.add_option("-s", value)->transform(CLI::Transformer(map, CLI::ignore_case, CLI::ignore_underscore));
@@ -272,7 +273,7 @@ TEST_F(TApp, EnumTransformFnMap) {
 }
 
 TEST_F(TApp, EnumTransformFnPtrMap) {
-    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17, val4 = 37 };
+    enum class test : std::int16_t { val1 = 3, val2 = 4, val3 = 17, val4 = 37 };
     std::map<std::string, test> map{{"val1", test::val1}, {"val2", test::val2}, {"val3", test::val3}};
     test value;
     auto opt = app.add_option("-s", value)->transform(CLI::Transformer(&map, CLI::ignore_case, CLI::ignore_underscore));
@@ -299,7 +300,7 @@ TEST_F(TApp, EnumTransformFnPtrMap) {
 }
 
 TEST_F(TApp, EnumTransformFnSharedPtrMap) {
-    enum class test : int16_t { val1 = 3, val2 = 4, val3 = 17, val4 = 37 };
+    enum class test : std::int16_t { val1 = 3, val2 = 4, val3 = 17, val4 = 37 };
     auto map = std::make_shared<std::unordered_map<std::string, test>>();
     auto &mp = *map;
     mp["val1"] = test::val1;
@@ -698,7 +699,7 @@ TEST_F(TApp, NumberWithUnitBadInput) {
 TEST_F(TApp, NumberWithUnitIntOverflow) {
     std::map<std::string, int> mapping{{"a", 1000000}, {"b", 100}, {"c", 101}};
 
-    int32_t value;
+    std::int32_t value;
     app.add_option("-n", value)->transform(CLI::AsNumberWithUnit(mapping));
 
     args = {"-n", "1000 a"};
@@ -738,7 +739,7 @@ TEST_F(TApp, NumberWithUnitFloatOverflow) {
 }
 
 TEST_F(TApp, AsSizeValue1000_1024) {
-    uint64_t value;
+    std::uint64_t value;
     app.add_option("-s", value)->transform(CLI::AsSizeValue(true));
 
     args = {"-s", "10240"};
@@ -749,8 +750,8 @@ TEST_F(TApp, AsSizeValue1000_1024) {
     run();
     EXPECT_EQ(value, 1u);
 
-    uint64_t k_value = 1000u;
-    uint64_t ki_value = 1024u;
+    std::uint64_t k_value = 1000u;
+    std::uint64_t ki_value = 1024u;
     args = {"-s", "1k"};
     run();
     EXPECT_EQ(value, k_value);
@@ -844,7 +845,7 @@ TEST_F(TApp, AsSizeValue1000_1024) {
 }
 
 TEST_F(TApp, AsSizeValue1024) {
-    uint64_t value;
+    std::uint64_t value;
     app.add_option("-s", value)->transform(CLI::AsSizeValue(false));
 
     args = {"-s", "10240"};
@@ -855,7 +856,7 @@ TEST_F(TApp, AsSizeValue1024) {
     run();
     EXPECT_EQ(value, 1u);
 
-    uint64_t ki_value = 1024u;
+    std::uint64_t ki_value = 1024u;
     args = {"-s", "1k"};
     run();
     EXPECT_EQ(value, ki_value);


### PR DESCRIPTION
As discussed in #400 ([this comment](https://github.com/CLIUtils/CLI11/pull/400#issuecomment-575889325)), this PR moves references to symbols from `cstdint` into the `std::` namespace and adds `#include <cstding>` to files in which those symbols are used.

I found all uses via `git grep int.._t`; feel free to check that on your side.