### PR TITLE
Add include_what_you_use to cpplint checks

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -9,6 +9,6 @@ filter=-whitespace/blank_line  # Unnecessarily strict with blank lines that othe
 filter=-whitespace/parens,-whitespace/braces  # Conflict with clang-format
 
 # Filters to be included in future
-filter=-whitespace/indent,-whitespace/comments,-readability/braces,-build/include_what_you_use
+filter=-whitespace/indent,-whitespace/comments,-readability/braces
 filter=-legal/copyright  # Remove this line after Version 1.9
 

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -10,6 +10,7 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <set>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -7,6 +7,8 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "CLI/App.hpp"
 #include "CLI/ConfigFwd.hpp"

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "CLI/Error.hpp"
 #include "CLI/StringTools.hpp"

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
 
 // CLI library includes
 #include "CLI/StringTools.hpp"

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -3,7 +3,9 @@
 // Distributed under the 3-Clause BSD License.  See accompanying
 // file LICENSE or https://github.com/CLIUtils/CLI11 for details.
 
+#include <algorithm>
 #include <string>
+#include <vector>
 
 #include "CLI/App.hpp"
 #include "CLI/FormatterFwd.hpp"

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "CLI/StringTools.hpp"
 

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "CLI/Error.hpp"

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace CLI {

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -15,6 +15,8 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 // [CLI11:verbatim]
 


### PR DESCRIPTION
Continuing #378 and #400: this PR enables the cpplint check `build/include_what_you_use` and fixes corresponding issues.