### PR TITLE
String conversions

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -219,15 +219,24 @@ template <typename S> class is_tuple_like {
 };
 
 /// Convert an object to a string (directly forward if this can become a string)
-template <typename T, enable_if_t<std::is_constructible<std::string, T>::value, detail::enabler> = detail::dummy>
+template <typename T, enable_if_t<std::is_convertible<T, std::string>::value, detail::enabler> = detail::dummy>
 auto to_string(T &&value) -> decltype(std::forward<T>(value)) {
     return std::forward<T>(value);
 }
 
+/// Construct a string from the object
+template <typename T,
+          enable_if_t<std::is_constructible<std::string, T>::value && !std::is_convertible<T, std::string>::value,
+                      detail::enabler> = detail::dummy>
+std::string to_string(const T &value) {
+    return std::string(value);
+}
+
 /// Convert an object to a string (streaming must be supported for that type)
 template <typename T,
-          enable_if_t<!std::is_constructible<std::string, T>::value && is_ostreamable<T>::value, detail::enabler> =
-              detail::dummy>
+          enable_if_t<!std::is_convertible<std::string, T>::value && !std::is_constructible<std::string, T>::value &&
+                          is_ostreamable<T>::value,
+                      detail::enabler> = detail::dummy>
 std::string to_string(T &&value) {
     std::stringstream stream;
     stream << value;

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1885,6 +1885,29 @@ TEST_F(TApp, VectorUnlimString) {
     EXPECT_EQ(answer, strvec);
 }
 
+// From https://github.com/CLIUtils/CLI11/issues/420
+TEST_F(TApp, stringLikeTests)
+{
+    struct nType
+    {
+        explicit nType(const std::string& a_value) : m_value{ a_value }
+        {}
+
+       operator std::string() const
+        {
+            return std::string{ "op str" };
+        }
+
+        std::string m_value;
+    };
+
+    nType m_type{ "abc" };
+    app.add_option("--type", m_type, "type")->capture_default_str();
+    args = { "--type", "bca" };
+    run();
+    EXPECT_EQ(std::string(m_type), "bca");
+}
+
 TEST_F(TApp, VectorExpectedRange) {
     std::vector<std::string> strvec;
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1886,26 +1886,24 @@ TEST_F(TApp, VectorUnlimString) {
 }
 
 // From https://github.com/CLIUtils/CLI11/issues/420
-TEST_F(TApp, stringLikeTests)
-{
-    struct nType
-    {
-        explicit nType(const std::string& a_value) : m_value{ a_value }
-        {}
+TEST_F(TApp, stringLikeTests) {
+    struct nType {
+        explicit nType(const std::string &a_value) : m_value{a_value} {}
 
-       operator std::string() const
-        {
-            return std::string{ "op str" };
-        }
+        explicit operator std::string() const { return std::string{"op str"}; }
 
         std::string m_value;
     };
 
-    nType m_type{ "abc" };
+    nType m_type{"abc"};
     app.add_option("--type", m_type, "type")->capture_default_str();
-    args = { "--type", "bca" };
     run();
-    EXPECT_EQ(std::string(m_type), "bca");
+
+    EXPECT_EQ(app["--type"]->as<std::string>(), "op str");
+    args = {"--type", "bca"};
+    run();
+    EXPECT_EQ(std::string(m_type), "op str");
+    EXPECT_EQ(m_type.m_value, "bca");
 }
 
 TEST_F(TApp, VectorExpectedRange) {


### PR DESCRIPTION
Fix for Issue #420.  

The issue appears to be that we were checking for `is_constructible<std::string, T>` from a type, but then using a implicit conversion.    So that code path was changed to use is_convertible.    A separate path was used for cases with `!is_convertible` and `is_constructible`  

A test of the situation from #420 was created to verify.  

@henryiii  you might want to check if this resolves #410 as well.  