### PR TITLE
Add copyright and copyright check

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -10,5 +10,4 @@ filter=-whitespace/parens,-whitespace/braces  # Conflict with clang-format
 
 # Filters to be included in future
 filter=-whitespace/indent,-whitespace/comments,-readability/braces
-filter=-legal/copyright  # Remove this line after Version 1.9
 

--- a/examples/callback_passthrough.cpp
+++ b/examples/callback_passthrough.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>

--- a/examples/digit_args.cpp
+++ b/examples/digit_args.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 

--- a/examples/enum.cpp
+++ b/examples/enum.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <map>

--- a/examples/enum_ostream.cpp
+++ b/examples/enum_ostream.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <map>

--- a/examples/formatter.cpp
+++ b/examples/formatter.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <memory>

--- a/examples/groups.cpp
+++ b/examples/groups.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <CLI/Timer.hpp>
 #include <iostream>

--- a/examples/inter_argument_order.cpp
+++ b/examples/inter_argument_order.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <algorithm>
 #include <iostream>

--- a/examples/json.cpp
+++ b/examples/json.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <memory>

--- a/examples/modhelp.cpp
+++ b/examples/modhelp.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>

--- a/examples/nested.cpp
+++ b/examples/nested.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <string>
 

--- a/examples/option_groups.cpp
+++ b/examples/option_groups.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>

--- a/examples/positional_arity.cpp
+++ b/examples/positional_arity.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>

--- a/examples/positional_validation.cpp
+++ b/examples/positional_validation.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>

--- a/examples/prefix_command.cpp
+++ b/examples/prefix_command.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>

--- a/examples/ranges.cpp
+++ b/examples/ranges.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <vector>

--- a/examples/retired.cpp
+++ b/examples/retired.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <utility>

--- a/examples/shapes.cpp
+++ b/examples/shapes.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <vector>

--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>

--- a/examples/subcom_help.cpp
+++ b/examples/subcom_help.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>

--- a/examples/subcom_in_files/subcommand_a.cpp
+++ b/examples/subcom_in_files/subcommand_a.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "subcommand_a.hpp"
 #include <iostream>
 #include <memory>

--- a/examples/subcom_in_files/subcommand_a.hpp
+++ b/examples/subcom_in_files/subcommand_a.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <CLI/CLI.hpp>

--- a/examples/subcom_in_files/subcommand_main.cpp
+++ b/examples/subcom_in_files/subcommand_main.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "subcommand_a.hpp"
 #include <CLI/CLI.hpp>
 

--- a/examples/subcom_partitioned.cpp
+++ b/examples/subcom_partitioned.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <CLI/Timer.hpp>
 #include <iostream>

--- a/examples/subcommands.cpp
+++ b/examples/subcommands.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>

--- a/examples/validators.cpp
+++ b/examples/validators.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include <algorithm>
 #include <cstdint>
 #include <functional>

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <algorithm>

--- a/include/CLI/CLI.hpp
+++ b/include/CLI/CLI.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 // CLI Library includes

--- a/include/CLI/CLI.hpp
+++ b/include/CLI/CLI.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 // CLI Library includes
 // Order is important for combiner script
 

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <algorithm>

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include <algorithm>
 #include <fstream>
 #include <iostream>

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <algorithm>

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include <algorithm>
 #include <fstream>
 #include <iostream>

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include <exception>
 #include <stdexcept>
 #include <string>

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <exception>

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <algorithm>

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include <algorithm>
 #include <string>
 #include <vector>

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include <map>
 #include <string>
 #include <utility>

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <map>

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 // [CLI11:verbatim]
 
 // The following version macro is very similar to the one in PyBind11

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 // [CLI11:verbatim]

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include <algorithm>
 #include <functional>
 #include <memory>

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <algorithm>

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include <string>
 #include <tuple>
 #include <utility>

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <string>

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <algorithm>

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include <algorithm>
 #include <iomanip>
 #include <locale>

--- a/include/CLI/Timer.hpp
+++ b/include/CLI/Timer.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 // On GCC < 4.8, the following define is often missing. Due to the
 // fact that this library only uses sleep_for, this should be safe
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5 && __GNUC_MINOR__ < 8

--- a/include/CLI/Timer.hpp
+++ b/include/CLI/Timer.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 // On GCC < 4.8, the following define is often missing. Due to the

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include "StringTools.hpp"

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include "StringTools.hpp"
 #include <cstdint>
 #include <exception>

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include "CLI/Macros.hpp"

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 #include "CLI/Macros.hpp"
 #include "CLI/StringTools.hpp"
 #include "CLI/TypeTools.hpp"

--- a/include/CLI/Version.hpp
+++ b/include/CLI/Version.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-// Distributed under the 3-Clause BSD License.  See accompanying
-// file LICENSE or https://github.com/CLIUtils/CLI11 for details.
-
 // [CLI11:verbatim]
 
 #define CLI11_VERSION_MAJOR 1

--- a/include/CLI/Version.hpp
+++ b/include/CLI/Version.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2017-2020, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 // [CLI11:verbatim]


### PR DESCRIPTION
Continuing #378 and #400: this PR enables the cpplint check `legal/copyright` and prepends the copyright message agreed on in #378 to each `hpp` and `cpp` file in `include/CLI/` and in `examples/`.

Feel free to be pedantic about the copyright message; I have a script to automatically prepend a message to all above files.