### PR TITLE
conan: Do not run tests when cross compiling

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,5 @@
 from conans import ConanFile, CMake
-from conans.tools import load, get_env
+from conans.tools import load, cross_building
 import re
 
 
@@ -40,7 +40,7 @@ class CLI11Conan(ConanFile):
         cmake.definitions["CLI11_SINGLE_FILE"] = "OFF"
         cmake.configure()
         cmake.build()
-        if get_env("CONAN_RUN_TESTS", True):
+        if not cross_building(self.settings):
             cmake.test()
         cmake.install()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,7 +40,6 @@ class CLI11Conan(ConanFile):
         cmake.definitions["CLI11_SINGLE_FILE"] = "OFF"
         cmake.configure()
         cmake.build()
-        cmake.test()
         cmake.install()
 
     def package_id(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,5 @@
 from conans import ConanFile, CMake
-from conans.tools import load
+from conans.tools import load, get_env
 import re
 
 
@@ -40,6 +40,8 @@ class CLI11Conan(ConanFile):
         cmake.definitions["CLI11_SINGLE_FILE"] = "OFF"
         cmake.configure()
         cmake.build()
+        if get_env("CONAN_RUN_TESTS", True):
+            cmake.test()
         cmake.install()
 
     def package_id(self):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -16,5 +16,6 @@ class HelloTestConan(ConanFile):
         self.copy("*.dylib*", dst="bin", src="lib")
 
     def test(self):
-        os.chdir("bin")
-        self.run(".%sexample" % os.sep)
+        if not tools.cross_building(self.settings):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)


### PR DESCRIPTION
Running conan create with a profile made for cross compiling would fail since the tests is not compiled for build OS

Open to other ways of solving this issue