### PR TITLE
Add and fix cpplint readability/braces

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -9,5 +9,5 @@ filter=-whitespace/blank_line  # Unnecessarily strict with blank lines that othe
 filter=-whitespace/parens,-whitespace/braces  # Conflict with clang-format
 
 # Filters to be included in future
-filter=-whitespace/indent,-whitespace/comments,-readability/braces
+filter=-whitespace/indent,-whitespace/comments
 

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1246,8 +1246,9 @@ class App {
                 name_ = nstr.first;
             }
             commandline = std::move(nstr.second);
-        } else
+        } else {
             detail::trim(commandline);
+        }
         // the next section of code is to deal with quoted arguments after an '=' or ':' for windows like operations
         if(!commandline.empty()) {
             commandline = detail::find_and_modify(commandline, "=", detail::escape_detect);

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -42,9 +42,9 @@ constexpr int expected_max_vector_size{1 << 29};
 inline std::vector<std::string> split(const std::string &s, char delim) {
     std::vector<std::string> elems;
     // Check to see if empty string, give consistent result
-    if(s.empty())
+    if(s.empty()) {
         elems.emplace_back();
-    else {
+    } else {
         std::stringstream ss;
         ss.str(s);
         std::string item;
@@ -264,8 +264,9 @@ inline std::ptrdiff_t find_member(std::string name,
         it = std::find_if(std::begin(names), std::end(names), [&name](std::string local_name) {
             return detail::remove_underscore(local_name) == name;
         });
-    } else
+    } else {
         it = std::find(std::begin(names), std::end(names), name);
+    }
 
     return (it != std::end(names)) ? (it - std::begin(names)) : (-1);
 }

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -107,14 +107,14 @@ class Validator {
             }
         }
         return retstring;
-    };
+    }
 
     /// This is the required operator for a Validator - provided to help
     /// users (CLI11 uses the member `func` directly)
     std::string operator()(const std::string &str) const {
         std::string value = str;
         return (active_) ? func_(value) : std::string{};
-    };
+    }
 
     /// Specify the type string
     Validator &description(std::string validator_desc) {
@@ -168,13 +168,13 @@ class Validator {
     Validator &application_index(int app_index) {
         application_index_ = app_index;
         return *this;
-    };
+    }
     /// Specify the application index of a validator
     Validator application_index(int app_index) const {
         Validator newval(*this);
         newval.application_index_ = app_index;
         return newval;
-    };
+    }
     /// Get the current value of the application index
     int get_application_index() const { return application_index_; }
     /// Get a boolean if the validator is active


### PR DESCRIPTION
Continuing #378 and #400: this PR enables the cpplint check `readability/braces` and fixes existing issues.