### PR TITLE
Permanently remove cpplint's whitespace/indent check

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -6,8 +6,9 @@ filter=-build/include_order  # Requires unusual include order that encourages cr
 filter=-readability/nolint  # Conflicts with clang-tidy
 filter=-runtime/references  # Requires fundamental change of API, don't see need for this
 filter=-whitespace/blank_line  # Unnecessarily strict with blank lines that otherwise help with readability
+filter=-whitespace/indent  # Requires strange 3-space indent of private/protected/public markers
 filter=-whitespace/parens,-whitespace/braces  # Conflict with clang-format
 
 # Filters to be included in future
-filter=-whitespace/indent,-whitespace/comments
+filter=-whitespace/comments
 


### PR DESCRIPTION
Continuing #378: cpplint's `whitespace/indent` check requires a strange 3-space indent on private/protected/public markers. We would need to switch e.g. from

```cpp
// Current situation
class App {
  protected:
    std::string name_{};
    std::string description_{};
};
```
to
```cpp
// Indent required by whitespace/indent
class App {
   protected:
    std::string name_{};
    std::string description_{};
};
```
I think the current 2-space indent provides better readability, therefore I suggest disabling this check.