### PR TITLE
Add char type

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ While all options internally are the same type, there are several ways to add an
 app.add_option(option_name, help_str="")
 
 app.add_option(option_name,
-               variable_to_bind_to, // bool, int, float, vector, enum, or string-like, or anything with a defined conversion from a string or that takes an int 🆕, double 🆕, or string in a constructor. Also allowed are tuples 🆕, std::array 🆕 or std::pair 🆕. Also supported are complex numbers🚧, wrapper types🚧, and containers besides vector🚧 of any other supported type.
+               variable_to_bind_to, // bool, char(see note)🚧, int, float, vector, enum, or string-like, or anything with a defined conversion from a string or that takes an int 🆕, double 🆕, or string in a constructor. Also allowed are tuples 🆕, std::array 🆕 or std::pair 🆕. Also supported are complex numbers🚧, wrapper types🚧, and containers besides vector🚧 of any other supported type.
                help_string="")
 
 app.add_option_function<type>(option_name,
@@ -218,6 +218,8 @@ app.add_option_function<type>(option_name,
                help_string="")
 
 app.add_complex(... // Special case: support for complex numbers ⚠️. Complex numbers are now fully supported in the add_option so this function is redundant.
+
+// char as an option type is supported before 2.0 but in 2.0 it defaulted to allowing single non numerical characters in addition to the numeric values.
 
 // 🆕 There is a template overload which takes two template parameters the first is the type of object to assign the value to, the second is the conversion type.  The conversion type should have a known way to convert from a string, such as any of the types that work in the non-template version.  If XC is a std::pair and T is some non pair type.  Then a two argument constructor for T is called to assign the value.  For tuples or other multi element types, XC must be a single type or a tuple like object of the same size as the assignment type
 app.add_option<typename T, typename XC>(option_name,

--- a/book/chapters/options.md
+++ b/book/chapters/options.md
@@ -22,6 +22,7 @@ You can use any C++ int-like type, not just `int`. CLI11 understands the followi
 |-------------|-------|
 | number like    | Integers, floats, bools, or any type that can be constructed from an integer or floating point number |
 | string-like | std\::string, or anything that can be constructed from or assigned a std\::string |
+| char | For a single char, single string values are accepted, otherwise longer strings are treated as integral values and a conversion is attempted |
 | complex-number | std::complex or any type which has a real(), and imag() operations available, will allow 1 or 2 string definitions like "1+2j" or two arguments "1","2" |
 | enumeration | any enum or enum class type is supported through conversion from the underlying type(typically int, though it can be specified otherwise) |
 | container-like | a container(like vector) of any available types including other containers |

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -911,6 +911,9 @@ TEST(Types, TypeName) {
     std::string float_name = CLI::detail::type_name<double>();
     EXPECT_EQ("FLOAT", float_name);
 
+    std::string char_name = CLI::detail::type_name<char>();
+    EXPECT_EQ("CHAR", char_name);
+
     std::string vector_name = CLI::detail::type_name<std::vector<int>>();
     EXPECT_EQ("INT", vector_name);
 
@@ -1025,6 +1028,11 @@ TEST(Types, LexicalCastInt) {
 
     std::string extra_input = "912i";
     EXPECT_FALSE(CLI::detail::lexical_cast(extra_input, y));
+
+    std::string empty_input{};
+    EXPECT_FALSE(CLI::detail::lexical_cast(empty_input, x_signed));
+    EXPECT_FALSE(CLI::detail::lexical_cast(empty_input, x_unsigned));
+    EXPECT_FALSE(CLI::detail::lexical_cast(empty_input, y_signed));
 }
 
 TEST(Types, LexicalCastDouble) {
@@ -1037,10 +1045,14 @@ TEST(Types, LexicalCastDouble) {
     EXPECT_FALSE(CLI::detail::lexical_cast(bad_input, x));
 
     std::string overflow_input = "1" + std::to_string(LDBL_MAX);
-    EXPECT_FALSE(CLI::detail::lexical_cast(overflow_input, x));
+    EXPECT_TRUE(CLI::detail::lexical_cast(overflow_input, x));
+    EXPECT_FALSE(std::isfinite(x));
 
     std::string extra_input = "9.12i";
     EXPECT_FALSE(CLI::detail::lexical_cast(extra_input, x));
+
+    std::string empty_input{};
+    EXPECT_FALSE(CLI::detail::lexical_cast(empty_input, x));
 }
 
 TEST(Types, LexicalCastBool) {

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -167,6 +167,31 @@ TEST_F(TApp, BoolOption) {
     EXPECT_FALSE(bflag);
 }
 
+TEST_F(TApp, CharOption) {
+    char c1{'t'};
+    app.add_option("-c", c1);
+
+    args = {"-c", "g"};
+    run();
+    EXPECT_EQ(c1, 'g');
+
+    args = {"-c", "1"};
+    run();
+    EXPECT_EQ(c1, '1');
+
+    args = {"-c", "77"};
+    run();
+    EXPECT_EQ(c1, 77);
+
+    // convert hex for digit
+    args = {"-c", "0x44"};
+    run();
+    EXPECT_EQ(c1, 0x44);
+
+    args = {"-c", "751615654161688126132138844896646748852"};
+    EXPECT_THROW(run(), CLI::ConversionError);
+}
+
 TEST_F(TApp, vectorDefaults) {
     std::vector<int> vals{4, 5};
     auto opt = app.add_option("--long", vals, "", true);

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -218,6 +218,7 @@ TEST_F(TApp, BoostOptionalEnumTest) {
 
     enum class eval : char { val0 = 0, val1 = 1, val2 = 2, val3 = 3, val4 = 4 };
     boost::optional<eval> opt, opt2;
+
     auto optptr = app.add_option<decltype(opt), eval>("-v,--val", opt);
     app.add_option_no_stream("-e,--eval", opt2);
     optptr->capture_default_str();

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -691,7 +691,8 @@ TEST_F(TApp, NumberWithUnitBadInput) {
     args = {"-n", "13 c"};
     EXPECT_THROW(run(), CLI::ValidationError);
     args = {"-n", "a"};
-    EXPECT_THROW(run(), CLI::ValidationError);
+    // Assume 1.0 unit
+    EXPECT_NO_THROW(run());
     args = {"-n", "12.0a"};
     EXPECT_THROW(run(), CLI::ValidationError);
     args = {"-n", "a5"};


### PR DESCRIPTION
Add support for a char type in the options.  

This was technically supported before but in that the option type was accepted but it was always interpreted as an int, which is not necessarily what is desired.  The added conversion interprets single character strings as the character, and otherwise defaults to a numerical conversion.  

This issue came up a couple times in our usage, when character inputs unexpectedly produced errors when trying to define an option for a separation character or delimiter.  