### PR TITLE
fix issue with option defaults not propagating to option groups

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -993,7 +993,7 @@ class App {
     /// creates an option group as part of the given app
     template <typename T = Option_group>
     T *add_option_group(std::string group_name, std::string group_description = "") {
-        auto option_group = std::make_shared<T>(std::move(group_description), group_name, nullptr);
+        auto option_group = std::make_shared<T>(std::move(group_description), group_name, this);
         auto ptr = option_group.get();
         // move to App_p for overload resolution on older gcc versions
         App_p app_ptr = std::dynamic_pointer_cast<App>(option_group);

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -374,6 +374,18 @@ TEST_F(TApp, InvalidOptions) {
     EXPECT_THROW(ogroup->add_option(opt), CLI::OptionNotFound);
 }
 
+TEST_F(TApp, OptionGroupInheritedOptionDefaults) {
+    app.option_defaults()->ignore_case();
+    auto ogroup = app.add_option_group("clusters");
+    int res{0};
+    ogroup->add_option("--test1", res);
+
+    args = {"--Test1", "5"};
+    run();
+    EXPECT_EQ(res, 5);
+    EXPECT_EQ(app.count_all(), 1u);
+}
+
 struct ManyGroups : public TApp {
 
     CLI::Option_group *main{nullptr};


### PR DESCRIPTION
Closes #437 

Adds a test and use the parent contstructor for option groups to propagate the option_defaults like for subcommands.  