### PR TITLE
Fix clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ llvm-include-order,
 llvm-namespace-comment,
 misc-throw-by-value-catch-by-reference,
 modernize*,
+-modernize-use-trailing-return-type,
 readability-container-size-empty,
 '
 
@@ -22,6 +23,7 @@ llvm-include-order,
 llvm-namespace-comment,
 misc-throw-by-value-catch-by-reference,
 modernize*,
+-modernize-use-trailing-return-type,
 readability-container-size-empty,
 '
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,7 +6,6 @@ FormatStyle: file
 Checks: '
 -*,
 google-*,
--google-runtime-int,
 -google-runtime-references,
 llvm-include-order,
 llvm-namespace-comment,
@@ -18,7 +17,6 @@ readability-container-size-empty,
 WarningsAsErrors: '
 -*,
 google-*,
--google-runtime-int,
 -google-runtime-references,
 llvm-include-order,
 llvm-namespace-comment,


### PR DESCRIPTION
1. Add already passing test `google-runtime-int` (fails on old types such as `long long`). This is also checked by cpplint (see #400). Should we include this test in clang-tidy, then? I would prefer also having it in clang-tidy for cleanliness of `.clang-tidy`.
2. Remove test `modernize-use-trailing-return-type`, introduced with clang-tidy 9. Requires trailing return type for more than 300 functions, e.g.
    ```
    CLI11/include/CLI/Validators.hpp:1112:44: error: use a trailing return type for this function [modernize-use-trailing-return-type,-warnings-as-errors]
    inline std::pair<std::string, std::string> split_program_name(std::string commandline) {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
           auto                                                                            -> std::pair<std::string, std::string>
    ```
    This enables manually running clang-tidy on machines with clang-tidy 9 installed without issues.  Clang-tidy 8 still works.