### PR TITLE
fix for the cmake_config tests

### DIFF
--- a/.github/actions/cmake_config/Dockerfile
+++ b/.github/actions/cmake_config/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
         libidn11=1.33-2.1ubuntu1.2 \
         ca-certificates=20180409 \
         make=4.1-9.1ubuntu1 \
-        git=1:2.17.1-1ubuntu0.5 \
+        git=1:2.17.1-1ubuntu0.7 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
fix a repo change for git in ubuntu18.04 that impacted the cmake_config tests