### PR TITLE
Simplify clang tidy config file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,17 +15,7 @@ modernize*,
 readability-container-size-empty,
 '
 
-WarningsAsErrors: '
--*,
-google-*,
--google-runtime-references,
-llvm-include-order,
-llvm-namespace-comment,
-misc-throw-by-value-catch-by-reference,
-modernize*,
--modernize-use-trailing-return-type,
-readability-container-size-empty,
-'
+WarningsAsErrors: '*'
 
 HeaderFilterRegex: '.*hpp'
 


### PR DESCRIPTION
The current clang-tidy setup treats all enabled clang-tidy warnings as errors. Simplifying the clang-tidy config file to keep this behavior while improving readability and ease of maintenance.