### PR TITLE
Fix internal header include paths.

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -20,14 +20,14 @@
 #include <vector>
 
 // CLI Library includes
-#include "CLI/ConfigFwd.hpp"
-#include "CLI/Error.hpp"
-#include "CLI/FormatterFwd.hpp"
-#include "CLI/Macros.hpp"
-#include "CLI/Option.hpp"
-#include "CLI/Split.hpp"
-#include "CLI/StringTools.hpp"
-#include "CLI/TypeTools.hpp"
+#include "ConfigFwd.hpp"
+#include "Error.hpp"
+#include "FormatterFwd.hpp"
+#include "Macros.hpp"
+#include "Option.hpp"
+#include "Split.hpp"
+#include "StringTools.hpp"
+#include "TypeTools.hpp"
 
 namespace CLI {
 

--- a/include/CLI/CLI.hpp
+++ b/include/CLI/CLI.hpp
@@ -9,28 +9,28 @@
 // CLI Library includes
 // Order is important for combiner script
 
-#include "CLI/Version.hpp"
+#include "Version.hpp"
 
-#include "CLI/Macros.hpp"
+#include "Macros.hpp"
 
-#include "CLI/StringTools.hpp"
+#include "StringTools.hpp"
 
-#include "CLI/Error.hpp"
+#include "Error.hpp"
 
-#include "CLI/TypeTools.hpp"
+#include "TypeTools.hpp"
 
-#include "CLI/Split.hpp"
+#include "Split.hpp"
 
-#include "CLI/ConfigFwd.hpp"
+#include "ConfigFwd.hpp"
 
-#include "CLI/Validators.hpp"
+#include "Validators.hpp"
 
-#include "CLI/FormatterFwd.hpp"
+#include "FormatterFwd.hpp"
 
-#include "CLI/Option.hpp"
+#include "Option.hpp"
 
-#include "CLI/App.hpp"
+#include "App.hpp"
 
-#include "CLI/Config.hpp"
+#include "Config.hpp"
 
-#include "CLI/Formatter.hpp"
+#include "Formatter.hpp"

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -13,9 +13,9 @@
 #include <utility>
 #include <vector>
 
-#include "CLI/App.hpp"
-#include "CLI/ConfigFwd.hpp"
-#include "CLI/StringTools.hpp"
+#include "App.hpp"
+#include "ConfigFwd.hpp"
+#include "StringTools.hpp"
 
 namespace CLI {
 

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -12,8 +12,8 @@
 #include <string>
 #include <vector>
 
-#include "CLI/Error.hpp"
-#include "CLI/StringTools.hpp"
+#include "Error.hpp"
+#include "StringTools.hpp"
 
 namespace CLI {
 

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 // CLI library includes
-#include "CLI/StringTools.hpp"
+#include "StringTools.hpp"
 
 namespace CLI {
 

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -10,8 +10,8 @@
 #include <string>
 #include <vector>
 
-#include "CLI/App.hpp"
-#include "CLI/FormatterFwd.hpp"
+#include "App.hpp"
+#include "FormatterFwd.hpp"
 
 namespace CLI {
 

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#include "CLI/StringTools.hpp"
+#include "StringTools.hpp"
 
 namespace CLI {
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -15,11 +15,11 @@
 #include <utility>
 #include <vector>
 
-#include "CLI/Error.hpp"
-#include "CLI/Macros.hpp"
-#include "CLI/Split.hpp"
-#include "CLI/StringTools.hpp"
-#include "CLI/Validators.hpp"
+#include "Error.hpp"
+#include "Macros.hpp"
+#include "Split.hpp"
+#include "StringTools.hpp"
+#include "Validators.hpp"
 
 namespace CLI {
 

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -11,8 +11,8 @@
 #include <utility>
 #include <vector>
 
-#include "CLI/Error.hpp"
-#include "CLI/StringTools.hpp"
+#include "Error.hpp"
+#include "StringTools.hpp"
 
 namespace CLI {
 namespace detail {

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "CLI/Macros.hpp"
-#include "CLI/StringTools.hpp"
-#include "CLI/TypeTools.hpp"
+#include "Macros.hpp"
+#include "StringTools.hpp"
+#include "TypeTools.hpp"
 
 #include <cmath>
 #include <cstdint>

--- a/scripts/MakeSingleHeader.py
+++ b/scripts/MakeSingleHeader.py
@@ -128,6 +128,7 @@ def MakeHeader(
 
     base_dir = os.path.abspath(os.path.join(DIR, include_dir))
     main_header = os.path.join(base_dir, main_header)
+    header_dir = os.path.dirname(main_header)
     licence_file = os.path.abspath(os.path.join(DIR, "../LICENSE"))
 
     with open(licence_file) as f:
@@ -138,7 +139,7 @@ def MakeHeader(
 
     include_files = includes_local.findall(header)
 
-    headers = [HeaderFile(base_dir, inc) for inc in include_files]
+    headers = [HeaderFile(header_dir, inc) for inc in include_files]
     single_header = reduce(add, headers)
 
     if macro is not None:


### PR DESCRIPTION
The extra leading "CLI/" part of include directives prevents the inclusion
of CLI.hpp from a relative directory without an extra -I or /I compiler
directive.