### PR TITLE
Fix default --version help message capitalisation.

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -719,7 +719,7 @@ class App {
             version_ptr_ = add_flag_callback(
                 flag_name,
                 [versionString]() { throw(CLI::CallForVersion(versionString, 0)); },
-                "display program version information and exit");
+                "Display program version information and exit");
             version_ptr_->configurable(false);
         }
 
@@ -738,7 +738,7 @@ class App {
             version_ptr_ = add_flag_callback(
                 flag_name,
                 [vfunc]() { throw(CLI::CallForVersion(vfunc(), 0)); },
-                "display program version information and exit");
+                "Display program version information and exit");
             version_ptr_->configurable(false);
         }
 


### PR DESCRIPTION
The default help message for “--help” is capitalised, whereas the one
for “--version” was not:

    -h,--help                   Print this help message and exit
    -V,--version                display program version information and exit