### PR TITLE
Add an ability to handle multiple config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,14 @@ Spaces before and after the name and argument are ignored. Multiple arguments ar
 To print a configuration file from the passed
 arguments, use `.config_to_str(default_also=false, write_description=false)`, where `default_also` will also show any defaulted arguments, and `write_description` will include the app and option descriptions.  See [Config files](https://cliutils.github.io/CLI11/book/chapters/config.html) for some additional details.
 
+If it is desired that multiple configuration be allowed.  Use
+
+```cpp
+app.set_config("--config")->expected(1, X);
+```
+
+Where X is some positive number and will allow up to `X` configuration files to be specified by separate `--config` arguments.
+
 ### Inheriting defaults
 
 Many of the defaults for subcommands and even options are inherited from their creators. The inherited default values for subcommands are `allow_extras`, `prefix_command`, `ignore_case`, `ignore_underscore`, `fallthrough`, `group`, `footer`,`immediate_callback` and maximum number of required subcommands. The help flag existence, name, and description are inherited, as well.

--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -78,6 +78,16 @@ sub.subcommand = true
 
 The main differences are in vector notation and comment character.  Note: CLI11 is not a full TOML parser as it just reads values as strings.  It is possible (but not recommended) to mix notation.
 
+## Multiple configuration files
+
+If it is desired that multiple configuration be allowed.  Use
+
+```cpp
+app.set_config("--config")->expected(1, X);
+```
+
+Where X is some positive integer and will allow up to `X` configuration files to be specified by separate `--config` arguments.
+
 ## Writing out a configure file
 
 To print a configuration file from the passed arguments, use `.config_to_str(default_also=false, write_description=false)`, where `default_also` will also show any defaulted arguments, and `write_description` will include option descriptions and the App description

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -7,6 +7,7 @@
 #include "app_helper.hpp"
 
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <unordered_map>
 
@@ -848,6 +849,22 @@ TEST_F(TApp, AsSizeValue1000_1024) {
     args = {"-s", "1eib"};
     run();
     EXPECT_EQ(value, ki_value);
+}
+
+TEST_F(TApp, duration_test) {
+    std::chrono::seconds duration{1};
+
+    app.option_defaults()->ignore_case();
+    app.add_option_function<std::size_t>(
+           "--duration",
+           [&](size_t a_value) { duration = std::chrono::seconds{a_value}; },
+           "valid units: sec, min, h, day.")
+        ->capture_default_str()
+        ->transform(CLI::AsNumberWithUnit(
+            std::map<std::string, std::size_t>{{"sec", 1}, {"min", 60}, {"h", 3600}, {"day", 24 * 3600}}));
+    EXPECT_NO_THROW(app.parse(std::vector<std::string>{"1 day", "--duration"}));
+
+    EXPECT_EQ(duration, std::chrono::seconds(86400));
 }
 
 TEST_F(TApp, AsSizeValue1024) {


### PR DESCRIPTION
Address Issue #486 

Allow support for multiple config files

```
set_config("--config")->expected(1, 3);
```
will allow upto expected max config files.  