### PR TITLE
fix name of make make option opts function

### DIFF
--- a/book/chapters/formatting.md
+++ b/book/chapters/formatting.md
@@ -30,7 +30,7 @@ You can further configure pieces of the code while still keeping most of the for
 ```cpp
 class MyFormatter : public CLI::Formatter {
   public:
-    std::string make_opts(const CLI::Option *) const override {return "";}
+    std::string make_option_opts(const CLI::Option *) const override {return "";}
 };
 app.formatter(std::make_shared<MyFormatter>());
 ```


### PR DESCRIPTION
The function `make_opts` does not exist. I think what the docs were implying though was `make_option_opts`? At least using that name gave me the functionality the docs were talking about.