### PR TITLE
Support for Atomic types in flags and options

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -789,7 +789,8 @@ class App {
     /// Add option for flag with integer result - defaults to allowing multiple passings, but can be forced to one
     /// if `multi_option_policy(CLI::MultiOptionPolicy::Throw)` is used.
     template <typename T,
-              enable_if_t<std::is_integral<T>::value && !is_bool<T>::value, detail::enabler> = detail::dummy>
+              enable_if_t<std::is_constructible<T, std::int64_t>::value && !is_bool<T>::value, detail::enabler> =
+                  detail::dummy>
     Option *add_flag(std::string flag_name,
                      T &flag_count,  ///< A variable holding the count
                      std::string flag_description = "") {
@@ -810,7 +811,7 @@ class App {
     /// that can be converted from a string
     template <typename T,
               enable_if_t<!detail::is_mutable_container<T>::value && !std::is_const<T>::value &&
-                              (!std::is_integral<T>::value || is_bool<T>::value) &&
+                              (!std::is_constructible<T, std::int64_t>::value || is_bool<T>::value) &&
                               !std::is_constructible<std::function<void(int)>, T>::value,
                           detail::enabler> = detail::dummy>
     Option *add_flag(std::string flag_name,
@@ -824,9 +825,9 @@ class App {
     }
 
     /// Vector version to capture multiple flags.
-    template <
-        typename T,
-        enable_if_t<!std::is_assignable<std::function<void(std::int64_t)>, T>::value, detail::enabler> = detail::dummy>
+    template <typename T,
+              enable_if_t<!std::is_assignable<std::function<void(std::int64_t)> &, T>::value, detail::enabler> =
+                  detail::dummy>
     Option *add_flag(std::string flag_name,
                      std::vector<T> &flag_results,  ///< A vector of values with the flag results
                      std::string flag_description = "") {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -7,6 +7,7 @@
 #include "app_helper.hpp"
 
 #include <array>
+#include <atomic>
 #include <climits>
 #include <complex>
 #include <cstdint>
@@ -991,6 +992,8 @@ TEST(Types, TypeName) {
     EXPECT_EQ("ENUM", enum_name2);
     std::string umapName = CLI::detail::type_name<std::unordered_map<int, std::tuple<std::string, double>>>();
     EXPECT_EQ("[INT,[TEXT,FLOAT]]", umapName);
+
+    vclass = CLI::detail::classify_object<std::atomic<int>>::value;
 }
 
 TEST(Types, OverflowSmall) {


### PR DESCRIPTION
Fixes #496 

dealing with atomic types is kind of a pain.  

This PR add support for them.  And add the tests for them as well.  

The main issue is that atomic types don't support direct assignment only assignment of the underlying type so there was a need to distinguish between the two type in a couple different locations that utilize the wrapper type.