### PR TITLE
add a type validator 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Add wget
       run: apt-get update && apt-get install -y wget
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.3
+      uses: jwlawson/actions-setup-cmake@v1.4
     - name: Configure
       run: cmake -S . -B build -DCLI11_CUDA_TESTS=ON
     - name: Build

--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ CLI11 has several Validators built-in that perform some common checks
 -   `CLI::NonNegativeNumber`: Requires the number be greater or equal to 0
 -   `CLI::Number`: Requires the input be a number.
 -   `CLI::ValidIPV4`: Requires that the option be a valid IPv4 string e.g. `'255.255.255.255'`, `'10.1.1.7'`.
+-   `CLI::TypeValidator<TYPE>`:🚧 Requires that the option be convertible to the specified type e.g.  `CLI::TypeValidator<unsigned int>()` would require that the input be convertible to an `unsigned int` regardless of the end conversion.
 
 These Validators can be used by simply passing the name into the `check` or `transform` methods on an option
 
@@ -715,7 +716,7 @@ app.set_config(option_name="",
 
 If this is called with no arguments, it will remove the configuration file option (like `set_help_flag`). Setting a configuration option is special. If it is present, it will be read along with the normal command line arguments. The file will be read if it exists, and does not throw an error unless `required` is `true`. Configuration files are in [TOML] format by default 🚧, though the default reader can also accept files in INI format as well 🆕. It should be noted that CLI11 does not contain a full TOML parser but can read strings from most TOML file and run them through the CLI11 parser. Other formats can be added by an adept user, some variations are available through customization points in the default formatter. An example of a TOML file 🆕:
 
-```ini
+```toml
 # Comments are supported, using a #
 # The default section is [default], case insensitive
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1815,6 +1815,24 @@ TEST_F(TApp, RangeDouble) {
     run();
 }
 
+TEST_F(TApp, typeCheck) {
+
+    /// Note that this must be a double in Range, too
+    app.add_option("--one")->check(CLI::TypeValidator<unsigned int>());
+
+    args = {"--one=1"};
+    EXPECT_NO_THROW(run());
+
+    args = {"--one=-7"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--one=error"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+
+    args = {"--one=4.568"};
+    EXPECT_THROW(run(), CLI::ValidationError);
+}
+
 // Check to make sure programmatic access to left over is available
 TEST_F(TApp, AllowExtras) {
 


### PR DESCRIPTION
add a typed Validator that checks for specific types conversion.  This could be useful if a storage variable was not used for the option but the result needs to be a specific type.

This is to address the issue raised in #492

Also move the number validator to use the typed checker instead of a separate class.  