### PR TITLE
add an optional help message string to the version_add flag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ There are several options that are supported on the main app and subcommands and
 -   `.footer(message)`: Set text to appear at the bottom of the help string.
 -   `.footer(std::string())`: 🆕 Set a callback to generate a string that will appear at the end of the help string.
 -   `.set_help_flag(name, message)`: Set the help flag name and message, returns a pointer to the created option.
+-   `.set_version_flag(name, versionString or callback, help_message)`: 🆕 Set the version flag name and version string or callback and optional help message, returns a pointer to the created option.
 -   `.set_help_all_flag(name, message)`: Set the help all flag name and message, returns a pointer to the created option. Expands subcommands.
 -   `.failure_message(func)`: Set the failure message function. Two provided: `CLI::FailureMessage::help` and `CLI::FailureMessage::simple` (the default).
 -   `.group(name)`: Set a group name, defaults to `"Subcommands"`. Setting `""` will be hide the subcommand.

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -732,7 +732,9 @@ class App {
     }
 
     /// Set a version flag and version display string, replace the existing one if present
-    Option *set_version_flag(std::string flag_name = "", const std::string &versionString = "") {
+    Option *set_version_flag(std::string flag_name = "",
+                             const std::string &versionString = "",
+                             const std::string &version_help = "Display program version information and exit") {
         // take flag_description by const reference otherwise add_flag tries to assign to version_description
         if(version_ptr_ != nullptr) {
             remove_option(version_ptr_);
@@ -742,17 +744,16 @@ class App {
         // Empty name will simply remove the version flag
         if(!flag_name.empty()) {
             version_ptr_ = add_flag_callback(
-                flag_name,
-                [versionString]() { throw(CLI::CallForVersion(versionString, 0)); },
-                "Display program version information and exit");
+                flag_name, [versionString]() { throw(CLI::CallForVersion(versionString, 0)); }, version_help);
             version_ptr_->configurable(false);
         }
 
         return version_ptr_;
     }
     /// Generate the version string through a callback function
-    Option *set_version_flag(std::string flag_name, std::function<std::string()> vfunc) {
-        // take flag_description by const reference otherwise add_flag tries to assign to version_description
+    Option *set_version_flag(std::string flag_name,
+                             std::function<std::string()> vfunc,
+                             const std::string &version_help = "Display program version information and exit") {
         if(version_ptr_ != nullptr) {
             remove_option(version_ptr_);
             version_ptr_ = nullptr;
@@ -761,9 +762,7 @@ class App {
         // Empty name will simply remove the version flag
         if(!flag_name.empty()) {
             version_ptr_ = add_flag_callback(
-                flag_name,
-                [vfunc]() { throw(CLI::CallForVersion(vfunc(), 0)); },
-                "Display program version information and exit");
+                flag_name, [vfunc]() { throw(CLI::CallForVersion(vfunc(), 0)); }, version_help);
             version_ptr_->configurable(false);
         }
 

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -1220,6 +1220,21 @@ TEST_CASE("TVersion: callback_flag", "[help]") {
     CHECK_THAT(vers, Contains("VERSION"));
 }
 
+TEST_CASE("TVersion: help", "[help]") {
+
+    CLI::App app;
+
+    app.set_version_flag("-v,--version", "version_string", "help_for_version");
+
+    auto hvers = app.help();
+    CHECK_THAT(hvers, Contains("help_for_version"));
+
+    app.set_version_flag(
+        "-v", []() { return std::string("VERSION2 " CLI11_VERSION); }, "help_for_version2");
+    hvers = app.help();
+    CHECK_THAT(hvers, Contains("help_for_version2"));
+}
+
 TEST_CASE("TVersion: parse_throw", "[help]") {
 
     CLI::App app;


### PR DESCRIPTION
add an optional help message string to the version_add flag, if desired to override

Issue #582