### PR TITLE
The help flag didn't get processed when a config file was required.

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2248,10 +2248,27 @@ class App {
 
     /// Process callbacks and such.
     void _process() {
-        _process_config_file();
-        _process_env();
+        CLI::FileError fe("ne");
+        bool caught_error{false};
+        try {
+            // the config file might generate a FileError but that should not be processed until later in the process
+            // to allow for help, version and other errors to generate first.
+            _process_config_file();
+            // process env shouldn't throw but no reason to process it if config generated an error
+            _process_env();
+        } catch(const CLI::FileError &fe2) {
+            fe = fe2;
+            caught_error = true;
+        }
+        // callbacks and help_flags can generate exceptions which should take priority over the config file error if one
+        // exists
         _process_callbacks();
         _process_help_flags();
+
+        if(caught_error) {
+            throw CLI::FileError(std::move(fe));
+        }
+
         _process_requirements();
     }
 

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -535,6 +535,10 @@ TEST_CASE_METHOD(TApp, "IniRequiredNoDefault", "[config]") {
     int two{0};
     app.add_option("--two", two);
     REQUIRE_THROWS_AS(run(), CLI::FileError);
+    // test to make sure help still gets called correctly
+    // Github issue #533 https://github.com/CLIUtils/CLI11/issues/553
+    args = {"--help"};
+    REQUIRE_THROWS_AS(run(), CLI::CallForHelp);
 }
 
 TEST_CASE_METHOD(TApp, "IniNotRequiredNoDefault", "[config]") {


### PR DESCRIPTION
This fixes issue #553