### PR TITLE
chore: bump CMake limits and catch2 verison

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 3.4)
 # Note: this is a header only library. If you have an older CMake than 3.4,
 # just add the CLI11/include directory and that's all you need to do.
 
-# Make sure users don't get warnings on a tested (3.4 to 3.16) version
+# Make sure users don't get warnings on a tested (3.4 to 3.20) version
 # of CMake. For most of the policies, the new version is better (hence the change).
-# We don't use the 3.4...3.17 syntax because of a bug in an older MSVC's
+# We don't use the 3.4...3.20 syntax because of a bug in an older MSVC's
 # built-in and modified CMake 3.11
-if(${CMAKE_VERSION} VERSION_LESS 3.17)
+if(${CMAKE_VERSION} VERSION_LESS 3.20)
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 else()
-  cmake_policy(VERSION 3.17)
+  cmake_policy(VERSION 3.20)
 endif()
 
 set(VERSION_REGEX "#define CLI11_VERSION[ \t]+\"(.+)\"")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,11 +70,11 @@ target_include_directories(catch_main PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 # that would require changing the includes. FetchContent would be better, but
 # requires newer CMake.
 
-set(url https://github.com/philsquared/Catch/releases/download/v2.13.4/catch.hpp)
+set(url https://github.com/philsquared/Catch/releases/download/v2.13.6/catch.hpp)
 file(
   DOWNLOAD ${url} "${CMAKE_CURRENT_BINARY_DIR}/catch.hpp"
   STATUS status
-  EXPECTED_HASH SHA256=6e0fa3dd160891a01c1f3b34e8bcd6e0140abe08eca022e390027f27dec2050b)
+  EXPECTED_HASH SHA256=681e7505a50887c9085539e5135794fc8f66d8e5de28eadf13a30978627b0f47)
 list(GET status 0 error)
 if(error)
   message(FATAL_ERROR "Could not download ${url}")


### PR DESCRIPTION
We are already testing every CMake version 3.4-3.20, let's make that explicit here too.