### PR TITLE
fix: single header file pragma missing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.0.0.{build}
+version: 2.0.1.{build}
 
 branches:
   only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Version 2.0.1: Single header fix
+
+The single header file was missing the include guard. #620
+
+
 ## Version 2.0: Simplification
 
 This version focuses on cleaning up deprecated functionality, and some minor

--- a/CLI11.hpp.in
+++ b/CLI11.hpp.in
@@ -31,6 +31,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#pragma once
+
 // Standard combined includes:
 {public_includes}
 

--- a/include/CLI/Version.hpp
+++ b/include/CLI/Version.hpp
@@ -10,7 +10,7 @@
 
 #define CLI11_VERSION_MAJOR 2
 #define CLI11_VERSION_MINOR 0
-#define CLI11_VERSION_PATCH 0
-#define CLI11_VERSION "2.0.0"
+#define CLI11_VERSION_PATCH 1
+#define CLI11_VERSION "2.0.1"
 
 // [CLI11:version_hpp:end]


### PR DESCRIPTION
Closes #619. Probably should release a 2.0.1 quickly afterward. :facepalm:
