### PR TITLE
add some capabilities to the config parser and a stream parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,7 +766,7 @@ sub.subcommand = true
 Spaces before and after the name and argument are ignored. Multiple arguments are separated by spaces. One set of quotes will be removed, preserving spaces (the same way the command line works). Boolean options can be `true`, `on`, `1`, `yes`, `enable`; or `false`, `off`, `0`, `no`, `disable` (case insensitive). Sections (and `.` separated names) are treated as subcommands (note: this does not necessarily mean that subcommand was passed, it just sets the "defaults"). You cannot set positional-only arguments.  Subcommands can be triggered from configuration files if the `configurable` flag was set on the subcommand.  Then the use of `[subcommand]` notation will trigger a subcommand and cause it to act as if it were on the command line.
 
 To print a configuration file from the passed
-arguments, use `.config_to_str(default_also=false, write_description=false)`, where `default_also` will also show any defaulted arguments, and `write_description` will include the app and option descriptions.  See [Config files](https://cliutils.github.io/CLI11/book/chapters/config.html) for some additional details.
+arguments, use `.config_to_str(default_also=false, write_description=false)`, where `default_also` will also show any defaulted arguments, and `write_description` will include the app and option descriptions.  See [Config files](https://cliutils.github.io/CLI11/book/chapters/config.html) for some additional details and customization points.
 
 If it is desired that multiple configuration be allowed.  Use
 

--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -163,7 +163,6 @@ These can be modified via setter functions
 * `ConfigBase *section(const std::string &sectionName)` : specify the section name to use to get the option values, only this section will be processed
 * `ConfigBase *index(uint16_t sectionIndex)` : specify an index section to use for processing if multiple TOML sections of the same name are present `[[section]]`
 
-
 For example, to specify reading a configure file that used `:` to separate name and values:
 
 ```cpp
@@ -198,21 +197,23 @@ app.config_formatter(std::make_shared<NewConfig>());
 
 See [`examples/json.cpp`](https://github.com/CLIUtils/CLI11/blob/master/examples/json.cpp) for a complete JSON config example.
 
-#### Trivial JSON configuration example
+### Trivial JSON configuration example
 
 ```JSON
 {
-	"test": 56,
-	"testb": "test",
-	"flag": true
+   "test": 56,
+   "testb": "test",
+   "flag": true
 }
 ```
+
 The parser can handle these structures with only a minor tweak
+
 ```cpp
 app.get_config_formatter_base()->valueSeparator(':');
 ```
-The open and close brackets must be on a separate line and the comma gets interpreted as an array separator but since no values are after the comma they get ignored as well.  This will not support multiple layers or sections or any other moderately complex JSON, but can work if the input file is simple.
 
+The open and close brackets must be on a separate line and the comma gets interpreted as an array separator but since no values are after the comma they get ignored as well.  This will not support multiple layers or sections or any other moderately complex JSON, but can work if the input file is simple.
 
 ## Triggering Subcommands
 

--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -211,7 +211,7 @@ The parser can handle these structures with only a minor tweak
 ```cpp
 app.get_config_formatter_base()->valueSeparator(':');
 ```
-The open and close brackets must be on a separate line and the comma gets interpreted as an array separator but since no values are after the comma they get ignored as well.  This will not support multiple layers or sections or any other moderately complex JSON, but can work if the input file is simple.  
+The open and close brackets must be on a separate line and the comma gets interpreted as an array separator but since no values are after the comma they get ignored as well.  This will not support multiple layers or sections or any other moderately complex JSON, but can work if the input file is simple.
 
 
 ## Triggering Subcommands
@@ -222,7 +222,7 @@ For custom configuration files this behavior can be triggered by specifying the 
 
 ## Stream parsing
 
-In addition to the regular parse functions a `parse_from_stream(std::istream &input)` is available to directly parse a stream operator.  For example to process some arguments in an already open file stream.  The stream is fed directly in the config parser so bypasses the normal command line parsing.  
+In addition to the regular parse functions a `parse_from_stream(std::istream &input)` is available to directly parse a stream operator.  For example to process some arguments in an already open file stream.  The stream is fed directly in the config parser so bypasses the normal command line parsing.
 
 ## Implementation Notes
 

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -103,7 +103,7 @@ inline std::vector<std::string> generate_parents(const std::string &section, std
             parents = {section};
         }
     }
-    if(name.find('.') != std::string::npos) {
+    if(name.find(parentSeparator) != std::string::npos) {
         std::vector<std::string> plist = detail::split(name, parentSeparator);
         name = plist.back();
         detail::remove_quotes(name);
@@ -119,10 +119,11 @@ inline std::vector<std::string> generate_parents(const std::string &section, std
 }
 
 /// assuming non default segments do a check on the close and open of the segments in a configItem structure
-inline void checkParentSegments(std::vector<ConfigItem> &output, const std::string &currentSection, char parentSeparator) {
+inline void
+checkParentSegments(std::vector<ConfigItem> &output, const std::string &currentSection, char parentSeparator) {
 
     std::string estring;
-    auto parents = detail::generate_parents(currentSection, estring,parentSeparator);
+    auto parents = detail::generate_parents(currentSection, estring, parentSeparator);
     if(!output.empty() && output.back().name == "--") {
         std::size_t msize = (parents.size() > 1U) ? parents.size() : 2;
         while(output.back().parents.size() >= msize) {
@@ -171,25 +172,30 @@ inline void checkParentSegments(std::vector<ConfigItem> &output, const std::stri
 inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) const {
     std::string line;
     std::string section = "default";
-
+    std::string previousSection = "default";
     std::vector<ConfigItem> output;
     bool isDefaultArray = (arrayStart == '[' && arrayEnd == ']' && arraySeparator == ',');
     bool isINIArray = (arrayStart == '\0' || arrayStart == ' ') && arrayStart == arrayEnd;
+    bool inSection{false};
     char aStart = (isINIArray) ? '[' : arrayStart;
     char aEnd = (isINIArray) ? ']' : arrayEnd;
     char aSep = (isINIArray && arraySeparator == ' ') ? ',' : arraySeparator;
-
+    int currentSectionIndex{0};
     while(getline(input, line)) {
         std::vector<std::string> items_buffer;
         std::string name;
 
         detail::trim(line);
         std::size_t len = line.length();
-        if(len > 1 && line.front() == '[' && line.back() == ']') {
+        // lines have to be at least 3 characters to have any meaning to CLI just skip the rest
+        if(len < 3) {
+            continue;
+        }
+        if(line.front() == '[' && line.back() == ']') {
             if(section != "default") {
                 // insert a section end which is just an empty items_buffer
                 output.emplace_back();
-                output.back().parents = detail::generate_parents(section, name,parentSeparatorChar);
+                output.back().parents = detail::generate_parents(section, name, parentSeparatorChar);
                 output.back().name = "--";
             }
             section = line.substr(1, len - 2);
@@ -200,13 +206,18 @@ inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) cons
             if(detail::to_lower(section) == "default") {
                 section = "default";
             } else {
-                detail::checkParentSegments(output, section,parentSeparatorChar);
+                detail::checkParentSegments(output, section, parentSeparatorChar);
+            }
+            inSection = false;
+            if(section == previousSection) {
+                ++currentSectionIndex;
+            } else {
+                currentSectionIndex = 0;
+                previousSection = section;
             }
             continue;
         }
-        if(len == 0) {
-            continue;
-        }
+
         // comment lines
         if(line.front() == ';' || line.front() == '#' || line.front() == commentChar) {
             continue;
@@ -245,7 +256,7 @@ inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) cons
 
             items_buffer = {"true"};
         }
-        if(name.find('.') == std::string::npos) {
+        if(name.find(parentSeparatorChar) == std::string::npos) {
             detail::remove_quotes(name);
         }
         // clean up quotes on the items
@@ -253,15 +264,19 @@ inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) cons
             detail::remove_quotes(it);
         }
 
-        std::vector<std::string> parents = detail::generate_parents(section, name,parentSeparatorChar);
+        std::vector<std::string> parents = detail::generate_parents(section, name, parentSeparatorChar);
         if(parents.size() > maximumLayers) {
             continue;
         }
-        if(!configSection.empty()) {
+        if(!configSection.empty() && !inSection) {
             if(parents.empty() || parents.front() != configSection) {
                 continue;
             }
+            if(configIndex >= 0 && currentSectionIndex != configIndex) {
+                continue;
+            }
             parents.erase(parents.begin());
+            inSection = true;
         }
         if(!output.empty() && name == output.back().name && parents == output.back().parents) {
             output.back().inputs.insert(output.back().inputs.end(), items_buffer.begin(), items_buffer.end());
@@ -276,7 +291,7 @@ inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) cons
         // insert a section end which is just an empty items_buffer
         std::string ename;
         output.emplace_back();
-        output.back().parents = detail::generate_parents(section, ename,parentSeparatorChar);
+        output.back().parents = detail::generate_parents(section, ename, parentSeparatorChar);
         output.back().name = "--";
         while(output.back().parents.size() > 1) {
             output.push_back(output.back());
@@ -358,17 +373,18 @@ ConfigBase::to_config(const App *app, bool default_also, bool write_description,
                 if(!prefix.empty() || app->get_parent() == nullptr) {
                     out << '[' << prefix << subcom->get_name() << "]\n";
                 } else {
-                    std::string subname = app->get_name() + "." + subcom->get_name();
+                    std::string subname = app->get_name() + parentSeparatorChar + subcom->get_name();
                     auto p = app->get_parent();
                     while(p->get_parent() != nullptr) {
-                        subname = p->get_name() + "." + subname;
+                        subname = p->get_name() + parentSeparatorChar + subname;
                         p = p->get_parent();
                     }
                     out << '[' << subname << "]\n";
                 }
                 out << to_config(subcom, default_also, write_description, "");
             } else {
-                out << to_config(subcom, default_also, write_description, prefix + subcom->get_name() + ".");
+                out << to_config(
+                    subcom, default_also, write_description, prefix + subcom->get_name() + parentSeparatorChar);
             }
         }
     }

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -91,6 +91,12 @@ class ConfigBase : public Config {
     char stringQuote = '"';
     /// the character to use around single characters
     char characterQuote = '\'';
+    /// the maximum number of layers to allow
+    uint8_t maxLayers_{255};
+    /// Specify the configuration index to use for arrayed sections
+    uint16_t configIndex{0};
+    /// Specify the configuration section that should be used
+    std::string configSection;
 
   public:
     std::string
@@ -122,6 +128,30 @@ class ConfigBase : public Config {
     ConfigBase *quoteCharacter(char qString, char qChar) {
         stringQuote = qString;
         characterQuote = qChar;
+        return this;
+    }
+    /// Specify the maximum number of parents
+    ConfigBase *maxLayers(uint8_t layers) {
+        maxLayers_ = layers;
+        return this;
+    }
+    /// get a reference to the configuration section
+    std::string &sectionRef() { return configSection; }
+    /// get the section
+    const std::string& section() const { return configSection; }
+    /// specify a particular section of the configuration file to use
+    ConfigBase *section(const std::string &sectionName) {
+        configSection = sectionName;
+        return this;
+    }
+
+    /// get a reference to the configuration index
+    uint16_t& indexRef() { return configIndex; }
+    /// get the section index
+    uint16_t index() const { return configIndex; }
+    /// specify a particular index in the section to use
+    ConfigBase *index(uint16_t sectionIndex) {
+        configIndex = sectionIndex;
         return this;
     }
 };

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -92,7 +92,9 @@ class ConfigBase : public Config {
     /// the character to use around single characters
     char characterQuote = '\'';
     /// the maximum number of layers to allow
-    uint8_t maxLayers_{255};
+    uint8_t maximumLayers{255};
+    /// the separator used to separator parent layers
+    char parentSeparatorChar{'.'};
     /// Specify the configuration index to use for arrayed sections
     uint16_t configIndex{0};
     /// Specify the configuration section that should be used
@@ -132,7 +134,12 @@ class ConfigBase : public Config {
     }
     /// Specify the maximum number of parents
     ConfigBase *maxLayers(uint8_t layers) {
-        maxLayers_ = layers;
+        maximumLayers = layers;
+        return this;
+    }
+    /// Specify the separator to use for parent layers
+    ConfigBase *parentSeparator(char sep) {
+        parentSeparatorChar = sep;
         return this;
     }
     /// get a reference to the configuration section
@@ -144,6 +151,8 @@ class ConfigBase : public Config {
         configSection = sectionName;
         return this;
     }
+    // The section index is more for extended parsers like JSON,  it is does not have
+    // an effect on the current TOML/INI parser
 
     /// get a reference to the configuration index
     uint16_t& indexRef() { return configIndex; }

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -96,7 +96,7 @@ class ConfigBase : public Config {
     /// the separator used to separator parent layers
     char parentSeparatorChar{'.'};
     /// Specify the configuration index to use for arrayed sections
-    uint16_t configIndex{0};
+    int16_t configIndex{-1};
     /// Specify the configuration section that should be used
     std::string configSection;
 
@@ -151,15 +151,13 @@ class ConfigBase : public Config {
         configSection = sectionName;
         return this;
     }
-    // The section index is more for extended parsers like JSON,  it is does not have
-    // an effect on the current TOML/INI parser
 
     /// get a reference to the configuration index
-    uint16_t& indexRef() { return configIndex; }
+    int16_t& indexRef() { return configIndex; }
     /// get the section index
-    uint16_t index() const { return configIndex; }
-    /// specify a particular index in the section to use
-    ConfigBase *index(uint16_t sectionIndex) {
+    int16_t index() const { return configIndex; }
+    /// specify a particular index in the section to use (-1) for all sections to use
+    ConfigBase *index(int16_t sectionIndex) {
         configIndex = sectionIndex;
         return this;
     }

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -98,7 +98,7 @@ class ConfigBase : public Config {
     /// Specify the configuration index to use for arrayed sections
     int16_t configIndex{-1};
     /// Specify the configuration section that should be used
-    std::string configSection;
+    std::string configSection{};
 
   public:
     std::string
@@ -145,7 +145,7 @@ class ConfigBase : public Config {
     /// get a reference to the configuration section
     std::string &sectionRef() { return configSection; }
     /// get the section
-    const std::string& section() const { return configSection; }
+    const std::string &section() const { return configSection; }
     /// specify a particular section of the configuration file to use
     ConfigBase *section(const std::string &sectionName) {
         configSection = sectionName;
@@ -153,7 +153,7 @@ class ConfigBase : public Config {
     }
 
     /// get a reference to the configuration index
-    int16_t& indexRef() { return configIndex; }
+    int16_t &indexRef() { return configIndex; }
     /// get the section index
     int16_t index() const { return configIndex; }
     /// specify a particular index in the section to use (-1) for all sections to use

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -208,7 +208,6 @@ TEST_CASE("StringBased: Spaces", "[config]") {
     CHECK(output.at(1).inputs.at(0) == "four");
 }
 
-
 TEST_CASE("StringBased: Sections", "[config]") {
     std::stringstream ofile;
 
@@ -799,7 +798,6 @@ TEST_CASE_METHOD(TApp, "IniRequired", "[config]") {
     CHECK_THROWS_AS(run(), CLI::RequiredError);
 }
 
-
 TEST_CASE_METHOD(TApp, "IniInlineComment", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};
@@ -885,29 +883,27 @@ TEST_CASE_METHOD(TApp, "TomlInlineComment", "[config]") {
     CHECK_THROWS_AS(run(), CLI::RequiredError);
 }
 
-
 TEST_CASE_METHOD(TApp, "ConfigModifiers", "[config]") {
-
 
     app.set_config("--config", "test.ini", "", true);
 
-   auto cfgptr = app.get_config_formatter_base();
+    auto cfgptr = app.get_config_formatter_base();
 
-   cfgptr->section("test");
-   CHECK(cfgptr->section()=="test");
+    cfgptr->section("test");
+    CHECK(cfgptr->section() == "test");
 
-   CHECK(cfgptr->sectionRef() == "test");
-   auto &sref = cfgptr->sectionRef();
-   sref= "this";
-   CHECK(cfgptr->section() == "this");
+    CHECK(cfgptr->sectionRef() == "test");
+    auto &sref = cfgptr->sectionRef();
+    sref = "this";
+    CHECK(cfgptr->section() == "this");
 
     cfgptr->index(5);
-   CHECK(cfgptr->index() == 5);
+    CHECK(cfgptr->index() == 5);
 
-   CHECK(cfgptr->indexRef() == 5);
-   auto &iref = cfgptr->indexRef();
-   iref = 7;
-   CHECK(cfgptr->index() == 7);
+    CHECK(cfgptr->indexRef() == 5);
+    auto &iref = cfgptr->indexRef();
+    iref = 7;
+    CHECK(cfgptr->index() == 7);
 }
 
 TEST_CASE_METHOD(TApp, "IniVector", "[config]") {
@@ -1152,7 +1148,6 @@ TEST_CASE_METHOD(TApp, "IniLayeredDotSection", "[config]") {
     app.get_config_formatter_base()->maxLayers(1);
     run();
     CHECK(three == 0);
-
 }
 
 TEST_CASE_METHOD(TApp, "IniLayeredCustomSectionSeparator", "[config]") {
@@ -1265,13 +1260,13 @@ TEST_CASE_METHOD(TApp, "IniSubcommandConfigurablePreParse", "[config]") {
 
 TEST_CASE_METHOD(TApp, "IniSection", "[config]") {
 
-    TempFile tmpini{ "TestIniTmp.ini" };
+    TempFile tmpini{"TestIniTmp.ini"};
 
     app.set_config("--config", tmpini);
     app.get_config_formatter_base()->section("config");
 
     {
-        std::ofstream out{ tmpini };
+        std::ofstream out{tmpini};
         out << "[config]" << std::endl;
         out << "val=2" << std::endl;
         out << "subsubcom.val=3" << std::endl;
@@ -1279,13 +1274,12 @@ TEST_CASE_METHOD(TApp, "IniSection", "[config]") {
         out << "val=1" << std::endl;
     }
 
-    int val{ 0 };
+    int val{0};
     app.add_option("--val", val);
 
     run();
 
-    CHECK(2==val);
-
+    CHECK(2 == val);
 }
 
 TEST_CASE_METHOD(TApp, "IniSection2", "[config]") {
@@ -1372,7 +1366,7 @@ TEST_CASE_METHOD(TApp, "TomlSectionNumber", "[config]") {
 
     CHECK(2 == val);
 
-    auto &index=app.get_config_formatter_base()->indexRef();
+    auto &index = app.get_config_formatter_base()->indexRef();
     index = 1;
     run();
 
@@ -1380,14 +1374,13 @@ TEST_CASE_METHOD(TApp, "TomlSectionNumber", "[config]") {
 
     index = -1;
     run();
-    //Take the first section in this case
+    // Take the first section in this case
     CHECK(2 == val);
     index = 2;
     run();
 
     CHECK(6 == val);
 }
-
 
 TEST_CASE_METHOD(TApp, "IniSubcommandConfigurableParseComplete", "[config]") {
 

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1111,6 +1111,39 @@ TEST_CASE_METHOD(TApp, "IniLayered", "[config]") {
     CHECK(!*subcom);
 }
 
+TEST_CASE_METHOD(TApp, "IniLayeredStream", "[config]") {
+
+    TempFile tmpini{"TestIniTmp.ini"};
+
+    app.set_config("--config", tmpini);
+
+    {
+        std::ofstream out{tmpini};
+        out << "[default]" << std::endl;
+        out << "val=1" << std::endl;
+        out << "[subcom]" << std::endl;
+        out << "val=2" << std::endl;
+        out << "subsubcom.val=3" << std::endl;
+    }
+
+    int one{0}, two{0}, three{0};
+    app.add_option("--val", one);
+    auto subcom = app.add_subcommand("subcom");
+    subcom->add_option("--val", two);
+    auto subsubcom = subcom->add_subcommand("subsubcom");
+    subsubcom->add_option("--val", three);
+
+    std::ifstream in{tmpini};
+    app.parse_from_stream(in);
+
+    CHECK(one == 1);
+    CHECK(two == 2);
+    CHECK(three == 3);
+
+    CHECK(0U == subcom->count());
+    CHECK(!*subcom);
+}
+
 TEST_CASE_METHOD(TApp, "IniLayeredDotSection", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1133,7 +1133,7 @@ TEST_CASE_METHOD(TApp, "IniSection", "[config]") {
     run();
 
     CHECK(2==val);
-    
+
 }
 TEST_CASE_METHOD(TApp, "IniSubcommandConfigurableParseComplete", "[config]") {
 

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1111,6 +1111,30 @@ TEST_CASE_METHOD(TApp, "IniSubcommandConfigurablePreParse", "[config]") {
     CHECK(0U == subcom2->count());
 }
 
+TEST_CASE_METHOD(TApp, "IniSection", "[config]") {
+
+    TempFile tmpini{ "TestIniTmp.ini" };
+
+    app.set_config("--config", tmpini);
+    app.get_config_formatter_base()->section("config");
+
+    {
+        std::ofstream out{ tmpini };
+        out << "[default]" << std::endl;
+        out << "val=1" << std::endl;
+        out << "[config]" << std::endl;
+        out << "val=2" << std::endl;
+        out << "subsubcom.val=3" << std::endl;
+    }
+
+    int val{ 0 };
+    app.add_option("--val", val);
+
+    run();
+
+    CHECK(2==val);
+    
+}
 TEST_CASE_METHOD(TApp, "IniSubcommandConfigurableParseComplete", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};


### PR DESCRIPTION
I needed the ability to parse a config file directory from a stream operator as it is part of a bigger processing chain.  And the config parser needed to be able to process a specific section and be able to handle inline comment characters.