### PR TITLE
fix and test some reported issues

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2825,7 +2825,7 @@ class App {
             }
         }
         // if we only partially completed a type then add an empty string if allowed for later processing
-        if(min_num > 0  && (collected % op->get_type_size_max()) != 0) {
+        if(min_num > 0 && (collected % op->get_type_size_max()) != 0) {
             if(op->get_type_size_max() != op->get_type_size_min()) {
                 op->add_result(std::string{});
             } else {

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2824,10 +2824,13 @@ class App {
                 parse_order_.push_back(op.get());
             }
         }
-
-        // if we only partially completed a type then add an empty string for later processing
-        if(min_num > 0 && op->get_type_size_max() != min_num && (collected % op->get_type_size_max()) != 0) {
-            op->add_result(std::string{});
+        // if we only partially completed a type then add an empty string if allowed for later processing
+        if(min_num > 0  && (collected % op->get_type_size_max()) != 0) {
+            if(op->get_type_size_max() != op->get_type_size_min()) {
+                op->add_result(std::string{});
+            } else {
+                throw ArgumentMismatch::PartialType(op->get_name(), op->get_type_size_min(), op->get_type_name());
+            }
         }
         if(op->get_trigger_on_parse()) {
             op->run_callback();

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -277,6 +277,10 @@ class ArgumentMismatch : public ParseError {
     static ArgumentMismatch FlagOverride(std::string name) {
         return ArgumentMismatch(name + " was given a disallowed flag override");
     }
+    static ArgumentMismatch PartialType(std::string name, int num, std::string type) {
+        return ArgumentMismatch(name + ": " + type + " only partially specified: " + std::to_string(num) +
+                                " required for each element");
+    }
 };
 
 /// Thrown when a requires option is missing

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -2103,6 +2103,19 @@ TEST_CASE_METHOD(TApp, "TomlOutputVector", "[config]") {
     CHECK(str == "vector=[1, 2, 3]\n");
 }
 
+TEST_CASE_METHOD(TApp, "TomlOutputTuple", "[config]") {
+
+    std::tuple<double, double, double, double> t;
+    app.add_option("--tuple", t);
+    app.config_formatter(std::make_shared<CLI::ConfigTOML>());
+    args = {"--tuple", "1", "2", "3", "4"};
+
+    run();
+
+    std::string str = app.config_to_str();
+    CHECK(str == "tuple=[1, 2, 3, 4]\n");
+}
+
 TEST_CASE_METHOD(TApp, "ConfigOutputVectorCustom", "[config]") {
 
     std::vector<int> v;

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -554,6 +554,27 @@ TEST_CASE_METHOD(TApp, "vectorPairFail", "[optiontype]") {
     CHECK_THROWS_AS(run(), CLI::ConversionError);
 }
 
+TEST_CASE_METHOD(TApp, "vectorPairFail2", "[optiontype]") {
+
+    std::vector<std::pair<int, int>> custom_opt;
+
+    auto opt = app.add_option("--pairs", custom_opt);
+
+    args = {"--pairs", "1", "2", "3", "4"};
+
+    run();
+    CHECK(custom_opt.size() == 2U);
+
+    args = {"--pairs", "1", "2", "3"};
+
+    CHECK_THROWS_AS(run(), CLI::ArgumentMismatch);
+    // now change the type size to explicitly allow 1 or 2
+    opt->type_size(1, 2);
+
+    run();
+    CHECK(custom_opt.size() == 2U);
+}
+
 TEST_CASE_METHOD(TApp, "vectorPairTypeRange", "[optiontype]") {
 
     std::vector<std::pair<int, std::string>> custom_opt;


### PR DESCRIPTION
This PR will add a test for #550 (no fixes required)

and a test and fix for #549.

It adds an additional check and related error message for partially supplied types if the type size is a single number and greater than 1.  

There is still an edge case where a vector of type with a range say 4 or 5  could be supplied with 6 arguments and would not generate an error.    Catching that is somewhat more complicated and I am not entirely sure it is worth the check as in that circumstance would probably be better and clearer to change the expected to 1 and only allow one block per option specification.  