### PR TITLE
fix: avoid a warning about useless move

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2256,7 +2256,7 @@ class App {
             // the config file might generate a FileError but that should not be processed until later in the process
             // to allow for help, version and other errors to generate first.
             _process_config_file();
-            
+
             // process env shouldn't throw but no reason to process it if config generated an error
             _process_env();
         } catch(const CLI::FileError &fe2) {

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2259,7 +2259,7 @@ class App {
 
             // process env shouldn't throw but no reason to process it if config generated an error
             _process_env();
-        } catch(const CLI::FileError &fe2) {
+        } catch(const CLI::FileError &) {
             // callbacks and help_flags can generate exceptions which should take priority
             // over the config file error if one exists.
             _process_callbacks();


### PR DESCRIPTION
Closes #677. This is a more straight forward way to do this, and not that much duplication (three lines shorter).