### PR TITLE
Add WASI build support

### DIFF
--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -32,6 +32,9 @@
 // Filesystem cannot be used if targeting macOS < 10.15
 #if defined __MAC_OS_X_VERSION_MIN_REQUIRED && __MAC_OS_X_VERSION_MIN_REQUIRED < 101500
 #define CLI11_HAS_FILESYSTEM 0
+#elif defined(__wasi__)
+// As of wasi-sdk-14, filesystem is not implemented
+#define CLI11_HAS_FILESYSTEM 0
 #else
 #include <filesystem>
 #if defined __cpp_lib_filesystem && __cpp_lib_filesystem >= 201703


### PR DESCRIPTION
Addresses:
```
  wasm-ld: error:
  CMakeFiles/WebAssemblyInterfaceHeaderTest1.dir/test/WebAssemblyInterfaceHeaderTest1.cxx.o:
  undefined symbol:
  std::__2::__fs::filesystem::__status(std::__2::__fs::filesystem::path
  const&, std::__2::error_code*)

  /usr/wasi-sdk-14.0/share/wasi-sysroot/include/c++/v1/filesystem:256:3:
  error: "The Filesystem library is not supported by this configuration
  of libc++"
  # error "The Filesystem library is not supported by this configuration
  of libc++"
```