### PR TITLE
Hide silent subcommands from the help.

### DIFF
--- a/book/chapters/subcommands.md
+++ b/book/chapters/subcommands.md
@@ -126,3 +126,5 @@ This would allow calling help such as:
 ./app help
 ./app help sub1
 ```
+
+Silent subcommands also don't appear in the help text.

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -118,8 +118,9 @@ inline std::string Formatter::make_usage(const App *app, std::string name) const
     }
 
     // Add a marker if subcommands are expected or optional
-    if(!app->get_subcommands(
-               [](const CLI::App *subc) { return ((!subc->get_disabled()) && (!subc->get_name().empty()) && (!subc->get_silent())); })
+    if(!app->get_subcommands([](const CLI::App *subc) {
+               return ((!subc->get_disabled()) && (!subc->get_name().empty()) && (!subc->get_silent()));
+           })
             .empty()) {
         out << " " << (app->get_require_subcommand_min() == 0 ? "[" : "")
             << get_label(app->get_require_subcommand_max() < 2 || app->get_require_subcommand_min() > 1 ? "SUBCOMMAND"

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -1273,3 +1273,27 @@ TEST_CASE("TVersion: parse_throw", "[help]") {
         CHECK(1U == cptr->count());
     }
 }
+
+TEST_CASE("Silent removes command from help", "[help]") {
+
+    CLI::App app;
+
+    app.add_subcommand("test")->silent();
+    auto help = app.help();
+    CHECK_THAT(help, !Contains("test"));
+    // If all subcommands are silent, don't show any
+    CHECK_THAT(help, !Contains("Subcommands"));
+}
+
+TEST_CASE("Silent removes only silent commands", "[help]") {
+
+    CLI::App app;
+
+    app.add_subcommand("foo")->silent();
+    app.add_subcommand("bar");
+    auto help = app.help();
+    CHECK_THAT(help, !Contains("foo"));
+    CHECK_THAT(help, Contains("bar"));
+
+    CHECK_THAT(help, Contains("Subcommands"));
+}


### PR DESCRIPTION
Right now there doesn't seem to be a way to hide a subcommand from the help list. `silent` is documented as removing it from `get_subcommands`, but because help calls that with a custom filter function (via `Formatter::make_subcommands`), every subcommand is included there. This PR hides `silent` subcommands from the help output. I hope that matches the original intent, if not, I guess a new option "hidden from help" or so could be added.