### PR TITLE
update the range error output 

### DIFF
--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -480,10 +480,12 @@ class Range : public Validator {
         func_ = [min_val, max_val](std::string &input) {
             T val;
             bool converted = detail::lexical_cast(input, val);
-            if((!converted) || (val < min_val || val > max_val))
-                return std::string("Value ") + input + " not in range " + std::to_string(min_val) + " to " +
-                       std::to_string(max_val);
-
+            if((!converted) || (val < min_val || val > max_val)) {
+                std::stringstream out;
+                out << "Value " << input << " not in range [";
+                out << min_val << " - " << max_val<<"]";
+                return out.str();
+            }
             return std::string{};
         };
     }

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -483,7 +483,7 @@ class Range : public Validator {
             if((!converted) || (val < min_val || val > max_val)) {
                 std::stringstream out;
                 out << "Value " << input << " not in range [";
-                out << min_val << " - " << max_val<<"]";
+                out << min_val << " - " << max_val << "]";
                 return out.str();
             }
             return std::string{};

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1869,12 +1869,10 @@ TEST_CASE_METHOD(TApp, "NonNegative", "[app]") {
         // this should throw
         run();
         CHECK(false);
-    }
-    catch(const CLI::ValidationError &e) {
+    } catch(const CLI::ValidationError &e) {
         std::string emess = e.what();
         CHECK(emess.size() < 40U);
     }
-    
 }
 
 TEST_CASE_METHOD(TApp, "typeCheck", "[app]") {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1871,7 +1871,7 @@ TEST_CASE_METHOD(TApp, "NonNegative", "[app]") {
         CHECK(false);
     } catch(const CLI::ValidationError &e) {
         std::string emess = e.what();
-        CHECK(emess.size() < 40U);
+        CHECK(emess.size() < 70U);
     }
 }
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1858,6 +1858,25 @@ TEST_CASE_METHOD(TApp, "RangeDouble", "[app]") {
     run();
 }
 
+TEST_CASE_METHOD(TApp, "NonNegative", "[app]") {
+
+    std::string res;
+    /// Note that this must be a double in Range, too
+    app.add_option("--one", res)->check(CLI::NonNegativeNumber);
+
+    args = {"--one=crazy"};
+    try {
+        // this should throw
+        run();
+        CHECK(false);
+    }
+    catch(const CLI::ValidationError &e) {
+        std::string emess = e.what();
+        CHECK(emess.size() < 40U);
+    }
+    
+}
+
 TEST_CASE_METHOD(TApp, "typeCheck", "[app]") {
 
     /// Note that this must be a double in Range, too


### PR DESCRIPTION
to be able to be used by more types, and better printouts in some situations.

the driver for this was getting something like this as an error.
```
not in range 0.000000 to 179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.000000
```  
which is descriptive but kind of ridiculous.  

and using std::to_string in a generic template is also potentially problematic is used for some unusual types.  