### PR TITLE
Add a transform/validator that checks for files on a default path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ CLI11 has several Validators built-in that perform some common checks
 * `CLI::ExistingDirectory`: Requires that the directory exists.
 * `CLI::ExistingPath`: Requires that the path (file or directory) exists.
 * `CLI::NonexistentPath`: Requires that the path does not exist.
-* `CLI::FileOnDefaultPath`: Best used as a transform, Will check that a file exists either directly or in a default path and update the path appropriately.  See [Transforming Validators](#transforming-validators) for more details
+* `CLI::FileOnDefaultPath`: 🚧 Best used as a transform, Will check that a file exists either directly or in a default path and update the path appropriately.  See [Transforming Validators](#transforming-validators) for more details
 * `CLI::Range(min,max)`: Requires that the option be between min and max (make sure to use floating point if needed). Min defaults to 0.
 * `CLI::Bounded(min,max)`: Modify the input such that it is always between min and max (make sure to use floating point if needed). Min defaults to 0.  Will produce an error if conversion is not possible.
 * `CLI::PositiveNumber`: Requires the number be greater than 0
@@ -485,7 +485,7 @@ of `Transformer`:
 
 NOTES:  If the container used in `IsMember`, `Transformer`, or `CheckedTransformer` has a `find` function like `std::unordered_map`  or `std::map` then that function is used to do the searching. If it does not have a `find` function a linear search is performed.  If there are filters present, the fast search is performed first, and if that fails a linear search with the filters on the key values is performed.
 
-* `CLI::FileOnDefaultPath(default_path)`: can be used to check for files in a default path.  If used as a transform it will first check that a file exists, if it does nothing further is done,  if it does not it tries to add a default Path to the file and search there again.  If the file does not exist an error is returned normally but this can be disabled using CLI::FileOnDefaultPath(default_path, false).  This allows multiple paths to be chained using multiple transform calls.
+* `CLI::FileOnDefaultPath(default_path)`: 🚧 can be used to check for files in a default path.  If used as a transform it will first check that a file exists, if it does nothing further is done,  if it does not it tries to add a default Path to the file and search there again.  If the file does not exist an error is returned normally but this can be disabled using CLI::FileOnDefaultPath(default_path, false).  This allows multiple paths to be chained using multiple transform calls.
 
 ##### Validator operations
 
@@ -804,7 +804,7 @@ NOTE:  Transforms and checks can be used with the option pointer returned from s
 app.set_config("--config")->transform(CLI::FileOnDefaultPath("/to/default/path/"));
 ```
 
-See [Transforming Validators](#transforming-validators) for additional details on this validator.
+See [Transforming Validators](#transforming-validators) for additional details on this validator. Multiple transforms or validators can be used either by multiple calls or using `|` operations with the transform.
 
 ### Inheriting defaults
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ CLI11 has several Validators built-in that perform some common checks
 * `CLI::ExistingDirectory`: Requires that the directory exists.
 * `CLI::ExistingPath`: Requires that the path (file or directory) exists.
 * `CLI::NonexistentPath`: Requires that the path does not exist.
+* `CLI::FileOnDefaultPath`: Best used as a transform, Will check that a file exists either directly or in a default path and update the path appropriately.  See [Transforming Validators](#transforming-validators) for more details
 * `CLI::Range(min,max)`: Requires that the option be between min and max (make sure to use floating point if needed). Min defaults to 0.
 * `CLI::Bounded(min,max)`: Modify the input such that it is always between min and max (make sure to use floating point if needed). Min defaults to 0.  Will produce an error if conversion is not possible.
 * `CLI::PositiveNumber`: Requires the number be greater than 0
@@ -483,6 +484,8 @@ of `Transformer`:
 * `auto p = std::make_shared<CLI::TransformPairs<std::string>>(std::initializer_list<std::pair<std::string,std::string>>({"key1", "map1"},{"key2","map2"})); CLI::Transformer(p)`: You can modify `p` later. `TransformPairs<T>` is an alias for `std::vector<std::pair<<std::string,T>>`
 
 NOTES:  If the container used in `IsMember`, `Transformer`, or `CheckedTransformer` has a `find` function like `std::unordered_map`  or `std::map` then that function is used to do the searching. If it does not have a `find` function a linear search is performed.  If there are filters present, the fast search is performed first, and if that fails a linear search with the filters on the key values is performed.
+
+* `CLI::FileOnDefaultPath(default_path)`: can be used to check for files in a default path.  If used as a transform it will first check that a file exists, if it does nothing further is done,  if it does not it tries to add a default Path to the file and search there again.  If the file does not exist an error is returned normally but this can be disabled using CLI::FileOnDefaultPath(default_path, false).  This allows multiple paths to be chained using multiple transform calls.
 
 ##### Validator operations
 
@@ -794,6 +797,13 @@ app.set_config("--config")->expected(1, X);
 ```
 
 Where X is some positive number and will allow up to `X` configuration files to be specified by separate `--config` arguments.  Value strings with quote characters in it will be printed with a single quote. All other arguments will use double quote.  Empty strings will use a double quoted argument. Numerical or boolean values are not quoted.
+
+NOTE:  Transforms and checks can be used with the option pointer returned from set_config like any other option to validate the input if needed.  It can also be used with the built in transform `CLI::FileOnDefaultPath` to look in a default path as well as the current one.  For example
+
+```cpp
+app.set_config("--config")->transform(CLI::FileOnDefaultPath("/to/default/path/"));  
+```
+See [Transforming Validators](#transforming-validators) for additional details on this validator.
 
 ### Inheriting defaults
 

--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ Where X is some positive number and will allow up to `X` configuration files to 
 NOTE:  Transforms and checks can be used with the option pointer returned from set_config like any other option to validate the input if needed.  It can also be used with the built in transform `CLI::FileOnDefaultPath` to look in a default path as well as the current one.  For example
 
 ```cpp
-app.set_config("--config")->transform(CLI::FileOnDefaultPath("/to/default/path/"));  
+app.set_config("--config")->transform(CLI::FileOnDefaultPath("/to/default/path/"));
 ```
 See [Transforming Validators](#transforming-validators) for additional details on this validator.
 

--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@ NOTE:  Transforms and checks can be used with the option pointer returned from s
 ```cpp
 app.set_config("--config")->transform(CLI::FileOnDefaultPath("/to/default/path/"));
 ```
+
 See [Transforming Validators](#transforming-validators) for additional details on this validator.
 
 ### Inheriting defaults

--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -18,7 +18,7 @@ This will allow specified files to either exist as given or on a specified defau
 app.set_config("--config")->transform(CLI::FileOnDefaultPath("/default_path/"))->transform(CLI::FileOnDefaultPath("/default_path2/",false));
 ```
 
-Multiple default paths can be specified through this mechanism.  The last transform given is executed first so the error return must be disabled so it can be chained to the first.  
+Multiple default paths can be specified through this mechanism.  The last transform given is executed first so the error return must be disabled so it can be chained to the first.
 
 ### Extra fields
 

--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -20,7 +20,12 @@ app.set_config("--config")
     ->transform(CLI::FileOnDefaultPath("/default_path2/",false));
 ```
 
-Multiple default paths can be specified through this mechanism.  The last transform given is executed first so the error return must be disabled so it can be chained to the first.
+Multiple default paths can be specified through this mechanism.  The last transform given is executed first so the error return must be disabled so it can be chained to the first. The same effect can be achieved though the or(`|`) operation with validators
+
+```cpp
+app.set_config("--config")
+    ->transform(CLI::FileOnDefaultPath("/default_path2/") | CLI::FileOnDefaultPath("/default_path/"));
+```
 
 ### Extra fields
 

--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -4,6 +4,22 @@
 
 You can tell your app to allow configure files with `set_config("--config")`. There are arguments: the first is the option name. If empty, it will clear the config flag. The second item is the default file name. If that is specified, the config will try to read that file. The third item is the help string, with a reasonable default, and the final argument is a boolean (default: false) that indicates that the configuration file is required and an error will be thrown if the file is not found and this is set to true.
 
+### Adding a default path
+
+if it is desired that config files be searched for a in a default path the `CLI::FileOnDefaultPath` transform can be used.
+
+```cpp
+app.set_config("--config")->transform(CLI::FileOnDefaultPath("/default_path/"));
+```
+
+This will allow specified files to either exist as given or on a specified default path.
+
+```cpp
+app.set_config("--config")->transform(CLI::FileOnDefaultPath("/default_path/"))->transform(CLI::FileOnDefaultPath("/default_path2/",false));
+```
+
+Multiple default paths can be specified through this mechanism.  The last transform given is executed first so the error return must be disabled so it can be chained to the first.  
+
 ### Extra fields
 
 Sometimes configuration files are used for multiple purposes so CLI11 allows options on how to deal with extra fields

--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -15,7 +15,9 @@ app.set_config("--config")->transform(CLI::FileOnDefaultPath("/default_path/"));
 This will allow specified files to either exist as given or on a specified default path.
 
 ```cpp
-app.set_config("--config")->transform(CLI::FileOnDefaultPath("/default_path/"))->transform(CLI::FileOnDefaultPath("/default_path2/",false));
+app.set_config("--config")
+    ->transform(CLI::FileOnDefaultPath("/default_path/"))
+    ->transform(CLI::FileOnDefaultPath("/default_path2/",false));
 ```
 
 Multiple default paths can be specified through this mechanism.  The last transform given is executed first so the error return must be disabled so it can be chained to the first.

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -462,11 +462,12 @@ template <typename DesiredType> class TypeValidator : public Validator {
 /// Check for a number
 const TypeValidator<double> Number("NUMBER");
 
-/// Modify a path if the file is a particular default location
+/// Modify a path if the file is a particular default location, can be used as Check or transform
+/// with the error return optionally disabled
 class FileOnDefaultPath : public Validator {
   public:
-    explicit FileOnDefaultPath(std::string default_path) : Validator("FILE") {
-        func_ = [default_path](std::string &filename) {
+    explicit FileOnDefaultPath(std::string default_path, bool enableErrorReturn=true) : Validator("FILE") {
+        func_ = [default_path,enableErrorReturn](std::string &filename) {
             auto path_result = detail::check_path(filename.c_str());
             if(path_result == detail::path_type::nonexistent) {
                 std::string test_file_path = default_path;
@@ -479,7 +480,11 @@ class FileOnDefaultPath : public Validator {
                 if(path_result == detail::path_type::file) {
                     filename = test_file_path;
                 } else {
-                    return "File does not exist: " + filename;
+                    if (enableErrorReturn)
+                    {
+                        return "File does not exist: " + filename;
+                    }
+                    
                 }
             }
             return std::string{};

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -466,8 +466,8 @@ const TypeValidator<double> Number("NUMBER");
 /// with the error return optionally disabled
 class FileOnDefaultPath : public Validator {
   public:
-    explicit FileOnDefaultPath(std::string default_path, bool enableErrorReturn=true) : Validator("FILE") {
-        func_ = [default_path,enableErrorReturn](std::string &filename) {
+    explicit FileOnDefaultPath(std::string default_path, bool enableErrorReturn = true) : Validator("FILE") {
+        func_ = [default_path, enableErrorReturn](std::string &filename) {
             auto path_result = detail::check_path(filename.c_str());
             if(path_result == detail::path_type::nonexistent) {
                 std::string test_file_path = default_path;
@@ -480,11 +480,9 @@ class FileOnDefaultPath : public Validator {
                 if(path_result == detail::path_type::file) {
                     filename = test_file_path;
                 } else {
-                    if (enableErrorReturn)
-                    {
+                    if(enableErrorReturn) {
                         return "File does not exist: " + filename;
                     }
-                    
                 }
             }
             return std::string{};

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -465,7 +465,7 @@ const TypeValidator<double> Number("NUMBER");
 /// Modify a path if the file is a particular default location
 class FileOnDefaultPath : public Validator {
   public:
-    FileOnDefaultPath(std::string default_path) : Validator("FILE") {
+    explicit FileOnDefaultPath(std::string default_path) : Validator("FILE") {
         func_ = [default_path](std::string &filename) {
             auto path_result = detail::check_path(filename.c_str());
             if(path_result == detail::path_type::nonexistent) {

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -462,6 +462,31 @@ template <typename DesiredType> class TypeValidator : public Validator {
 /// Check for a number
 const TypeValidator<double> Number("NUMBER");
 
+/// Modify a path if the file is a particular default location
+class FileOnDefaultPath : public Validator {
+  public:
+    FileOnDefaultPath(std::string default_path) : Validator("FILE") {
+        func_ = [default_path](std::string &filename) {
+            auto path_result = detail::check_path(filename.c_str());
+            if(path_result == detail::path_type::nonexistent) {
+                std::string test_file_path = default_path;
+                if(default_path.back() != '/' && default_path.back() != '\\') {
+                    // Add folder separator
+                    test_file_path += '/';
+                }
+                test_file_path.append(filename);
+                path_result = detail::check_path(test_file_path.c_str());
+                if(path_result == detail::path_type::file) {
+                    filename = test_file_path;
+                } else {
+                    return "File does not exist: " + filename;
+                }
+            }
+            return std::string{};
+        };
+    }
+};
+
 /// Produce a range (factory). Min and max are inclusive.
 class Range : public Validator {
   public:

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1746,6 +1746,26 @@ TEST_CASE_METHOD(TApp, "IniMultipleDefaultPath", "[config]") {
     CHECK(cfgOption->as<std::string>() == "../TestIniTmp.ini");
 }
 
+TEST_CASE_METHOD(TApp, "IniMultipleDefaultPathAlternate", "[config]") {
+
+    TempFile tmpini{"../TestIniTmp.ini"};
+
+    int key{0};
+    app.add_option("--flag,-f", key);
+    auto *cfgOption = app.set_config("--config", "doesnotexist.ini")
+                          ->transform(CLI::FileOnDefaultPath("../other") | CLI::FileOnDefaultPath("../"));
+
+    {
+        std::ofstream out{tmpini};
+        out << "f=3" << std::endl;
+    }
+
+    args = {"--config", "TestIniTmp.ini"};
+    REQUIRE_NOTHROW(run());
+    CHECK(3 == key);
+    CHECK(cfgOption->as<std::string>() == "../TestIniTmp.ini");
+}
+
 TEST_CASE_METHOD(TApp, "IniPositional", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1714,7 +1714,7 @@ TEST_CASE_METHOD(TApp, "IniDefaultPath", "[config]") {
 
     int key{0};
     app.add_option("--flag,-f", key);
-    app.set_config("--config", tmpini)->transform(CLI::FileOnDefaultPath("../"));
+    app.set_config("--config", "TestIniTmp.ini")->transform(CLI::FileOnDefaultPath("../"));
 
     {
         std::ofstream out{tmpini};
@@ -1723,6 +1723,25 @@ TEST_CASE_METHOD(TApp, "IniDefaultPath", "[config]") {
 
     REQUIRE_NOTHROW(run());
     CHECK(3 == key);
+}
+
+TEST_CASE_METHOD(TApp, "IniMultipleDefaultPath", "[config]") {
+
+    TempFile tmpini{"../TestIniTmp.ini"};
+
+    int key{0};
+    app.add_option("--flag,-f", key);
+    auto* cfgOption=app.set_config("--config", "doesnotexist.ini")->transform(CLI::FileOnDefaultPath("../"))->transform(CLI::FileOnDefaultPath("../other",false));
+
+    {
+        std::ofstream out{tmpini};
+        out << "f=3" << std::endl;
+    }
+
+    args = {"--config", "TestIniTmp.ini"};
+    REQUIRE_NOTHROW(run());
+    CHECK(3 == key);
+    CHECK(cfgOption->as<std::string>() == "../TestIniTmp.ini");
 }
 
 TEST_CASE_METHOD(TApp, "IniPositional", "[config]") {

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1731,7 +1731,9 @@ TEST_CASE_METHOD(TApp, "IniMultipleDefaultPath", "[config]") {
 
     int key{0};
     app.add_option("--flag,-f", key);
-    auto* cfgOption=app.set_config("--config", "doesnotexist.ini")->transform(CLI::FileOnDefaultPath("../"))->transform(CLI::FileOnDefaultPath("../other",false));
+    auto *cfgOption = app.set_config("--config", "doesnotexist.ini")
+                          ->transform(CLI::FileOnDefaultPath("../"))
+                          ->transform(CLI::FileOnDefaultPath("../other", false));
 
     {
         std::ofstream out{tmpini};

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1708,6 +1708,23 @@ TEST_CASE_METHOD(TApp, "IniShort", "[config]") {
     CHECK(3 == key);
 }
 
+TEST_CASE_METHOD(TApp, "IniDefaultPath", "[config]") {
+
+    TempFile tmpini{"../TestIniTmp.ini"};
+
+    int key{0};
+    app.add_option("--flag,-f", key);
+    app.set_config("--config", tmpini)->transform(CLI::FileOnDefaultPath("../"));
+
+    {
+        std::ofstream out{tmpini};
+        out << "f=3" << std::endl;
+    }
+
+    REQUIRE_NOTHROW(run());
+    CHECK(3 == key);
+}
+
 TEST_CASE_METHOD(TApp, "IniPositional", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -308,13 +308,13 @@ TEST_CASE("Validators: FilePathModifier", "[helpers]") {
     CHECK(filename == myfile);
     std::string filename2 = "nonexistingfile.csv";
     CHECK_FALSE(defPath(filename2).empty());
-    //check it didn't modify the string
+    // check it didn't modify the string
     CHECK(filename2 == "nonexistingfile.csv");
     CHECK(defPath(filename).empty());
     std::remove(myfile.c_str());
     CHECK_FALSE(defPath(myfile).empty());
     // now test the no error version
-    CLI::FileOnDefaultPath defPathNoFail("../",false);
+    CLI::FileOnDefaultPath defPathNoFail("../", false);
     CHECK(defPathNoFail(filename2).empty());
     CHECK(filename2 == "nonexistingfile.csv");
 }

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -308,9 +308,15 @@ TEST_CASE("Validators: FilePathModifier", "[helpers]") {
     CHECK(filename == myfile);
     std::string filename2 = "nonexistingfile.csv";
     CHECK_FALSE(defPath(filename2).empty());
+    //check it didn't modify the string
+    CHECK(filename2 == "nonexistingfile.csv");
     CHECK(defPath(filename).empty());
     std::remove(myfile.c_str());
     CHECK_FALSE(defPath(myfile).empty());
+    // now test the no error version
+    CLI::FileOnDefaultPath defPathNoFail("../",false);
+    CHECK(defPathNoFail(filename2).empty());
+    CHECK(filename2 == "nonexistingfile.csv");
 }
 
 TEST_CASE("Validators: FileIsDir", "[helpers]") {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -298,7 +298,6 @@ TEST_CASE("Validators: FileNotExists", "[helpers]") {
     CHECK(CLI::NonexistentPath(myfile).empty());
 }
 
-
 TEST_CASE("Validators: FilePathModifier", "[helpers]") {
     std::string myfile{"../TestFileNotUsed_1.txt"};
     bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a'));  // create file

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -298,6 +298,22 @@ TEST_CASE("Validators: FileNotExists", "[helpers]") {
     CHECK(CLI::NonexistentPath(myfile).empty());
 }
 
+
+TEST_CASE("Validators: FilePathModifier", "[helpers]") {
+    std::string myfile{"../TestFileNotUsed_1.txt"};
+    bool ok = static_cast<bool>(std::ofstream(myfile.c_str()).put('a'));  // create file
+    CHECK(ok);
+    std::string filename = "TestFileNotUsed_1.txt";
+    CLI::FileOnDefaultPath defPath("../");
+    CHECK(defPath(filename).empty());
+    CHECK(filename == myfile);
+    std::string filename2 = "nonexistingfile.csv";
+    CHECK_FALSE(defPath(filename2).empty());
+    CHECK(defPath(filename).empty());
+    std::remove(myfile.c_str());
+    CHECK_FALSE(defPath(myfile).empty());
+}
+
 TEST_CASE("Validators: FileIsDir", "[helpers]") {
     std::string mydir{"../tests"};
     CHECK("" != CLI::ExistingFile(mydir));


### PR DESCRIPTION
This is an alternative to #684 and closes #682. It add a transform/validator that checks for a file and on a default path.  
This if used with a config ptr can be used to add a default path, or any number of default paths for that matter.  

I think it has the same capabilities as #684 without adding any additional API calls and adding a new validator which may have other uses as well.    