### PR TITLE
meson: add support for testsuite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,22 @@ jobs:
       run: ctest --output-on-failure
       working-directory: build
 
+  meson-tests:
+    name: Meson tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Configure
+      run: pipx run meson setup build-meson . -Dtests=true
+
+    - name: Build
+      run: pipx run meson compile
+      working-directory: build-meson
+
+
   cmake-config:
     name: CMake config check
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,11 +53,17 @@ jobs:
       with:
         submodules: true
 
+
+    - name: Prepare commands
+      run: |
+        pipx install meson
+        pipx install ninja
+
     - name: Configure
-      run: pipx run meson setup build-meson . -Dtests=true
+      run: meson setup build-meson . -Dtests=true
 
     - name: Build
-      run: pipx run meson compile
+      run: meson compile
       working-directory: build-meson
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,14 +45,11 @@ jobs:
       run: ctest --output-on-failure
       working-directory: build
 
-  meson-tests:
-    name: Meson tests
+  meson-build:
+    name: Meson build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
-
 
     - name: Prepare commands
       run: |
@@ -63,8 +60,7 @@ jobs:
       run: meson setup build-meson . -Dtests=true
 
     - name: Build
-      run: meson compile
-      working-directory: build-meson
+      run: meson compile -C build-meson
 
 
   cmake-config:

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,9 @@
 project('CLI11', ['cpp'],
   version         : run_command(find_program('scripts/ExtractVersion.py')).stdout().strip(),
-  default_options : ['cpp_std=c++11']
+  default_options : ['cpp_std=c++11', 'warning_level=3']
 )
+
+cxx = meson.get_compiler('cpp')
 
 CLI11_inc = include_directories(['include'])
 
@@ -9,3 +11,13 @@ CLI11_dep = declare_dependency(
   include_directories : CLI11_inc,
   version             : meson.project_version(),
 )
+
+if get_option('tests')
+    warnings = ['-Wshadow', '-Wsign-conversion', '-Wswitch-enum']
+    if cxx.get_id() == 'gcc' and cxx.version().version_compare('>=4.9')
+        warnings += '-Weffc++'
+    endif
+    add_project_arguments(cxx.get_supported_arguments(warnings), language: 'cpp')
+
+    subdir('tests')
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('CLI11', ['cpp'],
-  version         : run_command(find_program('scripts/ExtractVersion.py')).stdout().strip(),
+  version         : run_command(find_program('scripts/ExtractVersion.py'), check: true).stdout().strip(),
   default_options : ['cpp_std=c++11', 'warning_level=3']
 )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('tests', type: 'boolean', value: false, description: 'Build CLI11 tests')

--- a/subprojects/catch2.wrap
+++ b/subprojects/catch2.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = Catch2-2.13.7
+source_url = https://github.com/catchorg/Catch2/archive/v2.13.7.zip
+source_filename = Catch2-2.13.7.zip
+source_hash = 3f3ccd90ad3a8fbb1beeb15e6db440ccdcbebe378dfd125d07a1f9a587a927e9
+patch_filename = catch2_2.13.7-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/catch2_2.13.7-1/get_patch
+patch_hash = 2f7369645d747e5bd866317ac1dd4c3d04dc97d3aad4fc6b864bdf75d3b57158
+
+[provide]
+catch2 = catch2_dep
+

--- a/subprojects/catch2.wrap
+++ b/subprojects/catch2.wrap
@@ -9,4 +9,3 @@ patch_hash = 2f7369645d747e5bd866317ac1dd4c3d04dc97d3aad4fc6b864bdf75d3b57158
 
 [provide]
 catch2 = catch2_dep
-

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,78 @@
+catch2 = dependency('catch2')
+
+testmain = static_library(
+    'catch_main',
+    'main.cpp', 'catch.hpp',
+    dependencies: catch2,
+)
+testdep = declare_dependency(
+    link_with: testmain,
+    dependencies: [catch2, CLI11_dep]
+)
+
+link_test_lib = library(
+    'link_test_1',
+    'link_test_1.cpp',
+    dependencies: CLI11_dep,
+)
+
+if cxx.get_id() == 'msvc'
+    nodeprecated = ['/wd4996']
+else
+    nodeprecated = ['-Wno-deprecated-declarations']
+endif
+
+boost = dependency('boost', required: false)
+if boost.found()
+    boost_dep = declare_dependency(
+        dependencies: boost,
+        compile_args: '-DCLI11_BOOST_OPTIONAL',
+    )
+else
+    boost_dep = declare_dependency()
+endif
+
+testnames = [
+    ['HelpersTest', {}],
+    ['ConfigFileTest', {}],
+    ['OptionTypeTest', {}],
+    ['SimpleTest', {}],
+    ['AppTest', {}],
+    ['SetTest', {}],
+    ['TransformTest', {}],
+    ['CreationTest', {}],
+    ['SubcommandTest', {}],
+    ['HelpTest', {}],
+    ['FormatterTest', {}],
+    ['NewParseTest', {}],
+    ['OptionalTest', {'dependencies': boost_dep}],
+    ['DeprecatedTest', {'cpp_args': nodeprecated}],
+    ['StringParseTest', {}],
+    ['ComplexTypeTest', {}],
+    ['TrueFalseTest', {}],
+    ['OptionGroupTest', {}],
+    # multi-only
+    ['TimerTest', {}],
+    # link_test
+    ['link_test_2', {'link_with': link_test_lib}],
+]
+
+if host_machine.system() == 'windows'
+    testnames += [['WindowsTest', {}]]
+endif
+
+if boost.found()
+    testnames += [['BoostOptionTypeTest', {'dependencies': boost_dep}]]
+endif
+
+foreach n: testnames
+    name = n[0]
+    kwargs = n[1]
+    t = executable(name, name + '.cpp',
+        cpp_args: kwargs.get('cpp_args', []),
+        build_by_default: false,
+        dependencies: [testdep] + kwargs.get('dependencies', []),
+        link_with: kwargs.get('link_with', [])
+    )
+    test(name, t)
+endforeach


### PR DESCRIPTION
As with CMakeLists.txt, this is disabled by default.

- I have not implemented the examples/ directory because it uses some output regex feature to run the tests, and meson doesn't have any similar feature, so that would probably require some kind of wrapper program that runs the test binary and compares output.
- I have not enabled doxygen documentation building, because it doesn't seem very useful in the same way that running tests under meson is; also, setting the output directory to be in the builddir requires either a python script to edit Doxyfile, or for Doxyfile to set `@VARNAME@` that can be replaced (breaking usage without first running cmake or meson) or for me to stop being lazy and finally implement doxygen in a meson module. :D
- I have not enabled CUDA tests, because I'm not sure if those are important?
- Testing `CLI11_SINGLE_FILE` doesn't seem very useful, because it should behave exactly the same anyway, modulo speed of e.g. deduplicated includes 
- There are some features which I didn't bother to implement, because meson supports it out of the box:
  - sanitizers can be configured with meson using `-Db_sanitize=`, possible values include `address`, `thread`, `undefined`, `memory`, `address,undefined`. AFAIK this functionality is not tested for cmake in CI anyway.
  - a clang-tidy command is automatically set up by meson if the `clang-tidy` program is installed.
  - code coverage can be configured with meson using `-Db_coverage=true`