### PR TITLE
trigger on parse positional

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2558,8 +2558,22 @@ class App {
                                     continue;
                                 }
                             }
-                            opt->add_result(positional);
+                            
                             parse_order_.push_back(opt.get());
+                            /// if we require a separator add it here
+                            if(opt->get_inject_separator()) {
+                                if(!opt->results().empty() && !opt->results().back().empty()) {
+                                    opt->add_result(std::string{});
+                                }
+                            }
+                            if(opt->get_trigger_on_parse() &&
+                               opt->current_option_state_ == Option::option_state::callback_run) {
+                               opt->clear();
+                            }
+                            opt->add_result(positional);
+                            if(opt->get_trigger_on_parse()) {
+                                opt->run_callback();
+                            }
                             args.pop_back();
                             return true;
                         }
@@ -2578,7 +2592,18 @@ class App {
                         continue;
                     }
                 }
+                if(opt->get_inject_separator()) {
+                    if(!opt->results().empty() && !opt->results().back().empty()) {
+                        opt->add_result(std::string{});
+                    }
+                }
+                if(opt->get_trigger_on_parse() && opt->current_option_state_ == Option::option_state::callback_run) {
+                    opt->clear();
+                }
                 opt->add_result(positional);
+                if(opt->get_trigger_on_parse()) {
+                    opt->run_callback();
+                }
                 parse_order_.push_back(opt.get());
                 args.pop_back();
                 return true;

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2558,7 +2558,7 @@ class App {
                                     continue;
                                 }
                             }
-                            
+
                             parse_order_.push_back(opt.get());
                             /// if we require a separator add it here
                             if(opt->get_inject_separator()) {
@@ -2568,7 +2568,7 @@ class App {
                             }
                             if(opt->get_trigger_on_parse() &&
                                opt->current_option_state_ == Option::option_state::callback_run) {
-                               opt->clear();
+                                opt->clear();
                             }
                             opt->add_result(positional);
                             if(opt->get_trigger_on_parse()) {

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -527,7 +527,7 @@ TEST_CASE_METHOD(TApp, "floatPair", "[optiontype]") {
     auto *opt = app.add_option("--fp", custom_opt)->delimiter(',');
     opt->default_str("3.4,2.7");
 
-    args = {"--fp","12", "1.5"};
+    args = {"--fp", "12", "1.5"};
 
     run();
     CHECK(12.0f == Approx(custom_opt.first));
@@ -996,7 +996,7 @@ TEST_CASE_METHOD(TApp, "OnParseCallPositional", "[optiontype]") {
                                })
                     ->trigger_on_parse()
                     ->allow_extra_args();
-    args = { "1", "2", "3"};
+    args = {"1", "2", "3"};
     CHECK(opt->get_trigger_on_parse());
     run();
     CHECK(3 == cnt);

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -519,6 +519,26 @@ TEST_CASE_METHOD(TApp, "CustomDoubleOptionAlt", "[optiontype]") {
     CHECK(1.5 == Approx(custom_opt.second));
 }
 
+// now with tuple support this is possible
+TEST_CASE_METHOD(TApp, "floatPair", "[optiontype]") {
+
+    std::pair<float, float> custom_opt;
+
+    auto *opt = app.add_option("--fp", custom_opt)->delimiter(',');
+    opt->default_str("3.4,2.7");
+
+    args = {"--fp","12", "1.5"};
+
+    run();
+    CHECK(12.0f == Approx(custom_opt.first));
+    CHECK(1.5f == Approx(custom_opt.second));
+    args = {};
+    opt->force_callback();
+    run();
+    CHECK(3.4f == Approx(custom_opt.first));
+    CHECK(2.7f == Approx(custom_opt.second));
+}
+
 // now with independent type sizes and expected this is possible
 TEST_CASE_METHOD(TApp, "vectorPair", "[optiontype]") {
 
@@ -960,6 +980,23 @@ TEST_CASE_METHOD(TApp, "OnParseCall", "[optiontype]") {
     std::vector<std::string> extras;
     app.add_option("args", extras);
     args = {"-c", "1", "-c", "2", "-c", "3"};
+    CHECK(opt->get_trigger_on_parse());
+    run();
+    CHECK(3 == cnt);
+}
+
+TEST_CASE_METHOD(TApp, "OnParseCallPositional", "[optiontype]") {
+
+    int cnt{0};
+
+    auto *opt = app.add_option("pos",
+                               [&cnt](const CLI::results_t &) {
+                                   ++cnt;
+                                   return true;
+                               })
+                    ->trigger_on_parse()
+                    ->allow_extra_args();
+    args = { "1", "2", "3"};
     CHECK(opt->get_trigger_on_parse());
     run();
     CHECK(3 == cnt);


### PR DESCRIPTION
allow the trigger on parse modifier to work with positional arguments as well.

Address #712.  which identified that trigger on parse did not work correctly on positional arguments.  

This PR fixes that issue. 