### PR TITLE
Include <functional> in FormatterFwd

### DIFF
--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 // [CLI11:public_includes:set]
+#include <functional>
 #include <map>
 #include <string>
 #include <utility>


### PR DESCRIPTION
Without this header, the project might not compile is some environments.

Signed-off-by: Shameek Ganguly <shameekarcanesphinx@gmail.com>