### PR TITLE
Incorrect subcommand callback trigger

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2413,7 +2413,7 @@ class App {
         }
         // check for section close
         if(item.name == "--") {
-            if(configurable_) {
+            if(configurable_ && parse_complete_callback_) {
                 _process_callbacks();
                 _process_requirements();
                 run_callback();

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1592,13 +1592,12 @@ TEST_CASE_METHOD(TApp, "SubcommandCallbackSingle", "[config]") {
         out << "[foo]" << std::endl;
     }
     int count{0};
-    auto* foo = app.add_subcommand("foo");
+    auto *foo = app.add_subcommand("foo");
     foo->configurable();
     foo->callback([&count]() { ++count; });
 
     run();
-    CHECK(1==count);
-    
+    CHECK(1 == count);
 }
 
 TEST_CASE_METHOD(TApp, "IniFailure", "[config]") {

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1581,6 +1581,26 @@ TEST_CASE_METHOD(TApp, "DuplicateSubcommandCallbacks", "[config]") {
     CHECK(3 == count);
 }
 
+TEST_CASE_METHOD(TApp, "SubcommandCallbackSingle", "[config]") {
+
+    TempFile tmptoml{"Testtomlcallback.toml"};
+
+    app.set_config("--config", tmptoml);
+
+    {
+        std::ofstream out{tmptoml};
+        out << "[foo]" << std::endl;
+    }
+    int count{0};
+    auto* foo = app.add_subcommand("foo");
+    foo->configurable();
+    foo->callback([&count]() { ++count; });
+
+    run();
+    CHECK(1==count);
+    
+}
+
 TEST_CASE_METHOD(TApp, "IniFailure", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};


### PR DESCRIPTION
fix the issue where subcommand callbacks would be triggered multiple times if specified as configurable.

This will fix #732.