### PR TITLE
fix: rename variable to avoid clash with optarg

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2844,9 +2844,9 @@ class App {
                     break;
                 }
                 if(validate_optional_arguments_) {
-                    std::string optarg = args.back();
-                    optarg = op->_validate(optarg, 0);
-                    if(!optarg.empty()) {
+                    std::string arg = args.back();
+                    arg = op->_validate(arg, 0);
+                    if(!arg.empty()) {
                         break;
                     }
                 }


### PR DESCRIPTION
https://linux.die.net/man/3/optarg

I realise it's unusual to include both CLI11 and getopt.h, but it can happen in large diverse codebases.