### PR TITLE
Fix Issue #739

### DIFF
--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -1163,7 +1163,7 @@ inline std::pair<std::string, std::string> split_program_name(std::string comman
     }
 
     // strip the program name
-    vals.second = (esp != std::string::npos) ? commandline.substr(esp + 1) : std::string{};
+    vals.second = (esp < commandline.length() - 1) ? commandline.substr(esp + 1) : std::string{};
     ltrim(vals.second);
     return vals;
 }

--- a/tests/StringParseTest.cpp
+++ b/tests/StringParseTest.cpp
@@ -89,6 +89,15 @@ TEST_CASE_METHOD(TApp, "ProgNameWithSpace", "[stringparse]") {
     CHECK(app.get_name() == "Foo Bar");
 }
 
+// From GitHub issue #739 https://github.com/CLIUtils/CLI11/issues/739
+TEST_CASE_METHOD(TApp, "ProgNameOnly", "[stringparse]") {
+
+    app.add_flag("--foo");
+    CHECK_NOTHROW(app.parse("\"C:\\example.exe\"", true));
+
+    CHECK(app.get_name() == "C:\\example.exe");
+}
+
 TEST_CASE_METHOD(TApp, "ProgNameWithSpaceEmbeddedQuote", "[stringparse]") {
 
     app.add_flag("--foo");


### PR DESCRIPTION
Fix an issue where an error was generated if just a file name was supplied to the `split_program_name` parsing.

Fixes Issue #739 