### PR TITLE
chore: clang tidy updates

### DIFF
--- a/.ci/azure-build.yml
+++ b/.ci/azure-build.yml
@@ -8,6 +8,12 @@ steps:
         -DCMAKE_BUILD_TYPE=$(cli11.build_type) $(cli11.options)
     displayName: "Configure"
 
-  - script: cmake --build .
-    displayName: "Build"
+  - script: cmake --build . -- -j2 --keep-going
+    displayName: "Build Unix"
     workingDirectory: build
+    condition: ne( variables['Agent.OS'], 'Windows_NT' )
+
+  - script: cmake --build .
+    displayName: "Build Windows"
+    workingDirectory: build
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )

--- a/.ci/make_and_test.sh
+++ b/.ci/make_and_test.sh
@@ -9,7 +9,7 @@ set -evx
 mkdir -p build
 cd build
 cmake .. -DCLI11_WARNINGS_AS_ERRORS=ON -DCLI11_SINGLE_FILE=ON -DCMAKE_CXX_STANDARD="$STD" -DCLI11_SINGLE_FILE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache $@
-cmake --build . -- -j2
+cmake --build . -- -j2 --keep-going
 
 set +evx
 echo -en "travis_fold:end:script.build\\r"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,17 +1,65 @@
 # Checks that will be implemented in future PRs:
 # performance-unnecessary-value-param, hints to ~110 issues. Be careful with implementing the suggested changes of this one, as auto-fixes may break the code
 
-FormatStyle: file
-
-Checks: >
-  -*, google-*, -google-runtime-references, llvm-include-order,
-  llvm-namespace-comment, misc-throw-by-value-catch-by-reference, modernize*,
-  -modernize-use-trailing-return-type, readability-container-size-empty,
-
-WarningsAsErrors: "*"
-
-HeaderFilterRegex: ".*hpp"
+Checks: |
+  *bugprone*,
+  clang-analyzer-optin.cplusplus.VirtualCall,
+  clang-analyzer-optin.performance.Padding,
+  cppcoreguidelines-init-variables,
+  cppcoreguidelines-prefer-member-initializer,
+  cppcoreguidelines-pro-type-static-cast-downcast,
+  cppcoreguidelines-slicing,
+  google-*,
+  -google-runtime-references,
+  llvm-include-order,
+  llvm-namespace-comment,
+  misc-definitions-in-headers,
+  misc-misplaced-const,
+  misc-non-copyable-objects,
+  misc-static-assert,
+  misc-throw-by-value-catch-by-reference,
+  misc-throw-by-value-catch-by-reference,
+  misc-uniqueptr-reset-release,
+  misc-unused-parameters,
+  modernize*,
+  -modernize-use-trailing-return-type,
+  *performance*,
+  -performance-unnecessary-value-param,
+  readability-avoid-const-params-in-decls,
+  readability-const-return-type,
+  readability-container-size-empty,
+  readability-delete-null-pointer,
+  readability-else-after-return,
+  readability-implicit-bool-conversion,
+  readability-inconsistent-declaration-parameter-name,
+  readability-make-member-function-const,
+  readability-misplaced-array-index,
+  readability-non-const-parameter,
+  readability-qualified-auto,
+  readability-redundant-function-ptr-dereference,
+  readability-redundant-smartptr-get,
+  readability-redundant-string-cstr,
+  readability-simplify-subscript-expr,
+  readability-static-accessed-through-instance,
+  readability-static-definition-in-anonymous-namespace,
+  readability-string-compare,
+  readability-suspicious-call-argument,
+  readability-uniqueptr-delete-release,
 
 CheckOptions:
   - key: google-readability-braces-around-statements.ShortStatementLines
     value: "3"
+  - key: performance-for-range-copy.WarnOnAllAutoCopies
+    value: true
+  - key: performance-inefficient-string-concatenation.StrictMode
+    value: true
+  - key: performance-unnecessary-value-param.AllowedTypes
+    value: "exception_ptr$;"
+  - key: readability-implicit-bool-conversion.AllowPointerConditions
+    value: true
+
+HeaderFilterRegex: "CLI.*hpp"
+
+FormatStyle: file
+
+WarningsAsErrors: "*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,10 +1,18 @@
 # Checks that will be implemented in future PRs:
 # performance-unnecessary-value-param, hints to ~110 issues. Be careful with implementing the suggested changes of this one, as auto-fixes may break the code
+# bugprone-forwarding-reference-overload probably should be enabled and fixed.
+# clang-diagnostic-float-equal can be fixed by using _a from Catch::literals
+# bugprone-exception-escape due to main being a bit simple in examples
+# modernize-avoid-c-arrays trips up in TEMPLATE_TEST_CASE catch macro
 
 Checks: |
   *bugprone*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-forwarding-reference-overload,
+  -bugprone-exception-escape,
   clang-analyzer-optin.cplusplus.VirtualCall,
   clang-analyzer-optin.performance.Padding,
+  -clang-diagnostic-float-equal,
   cppcoreguidelines-init-variables,
   cppcoreguidelines-prefer-member-initializer,
   cppcoreguidelines-pro-type-static-cast-downcast,
@@ -23,8 +31,10 @@ Checks: |
   misc-unused-parameters,
   modernize*,
   -modernize-use-trailing-return-type,
+  -modernize-concat-nested-namespaces,
   *performance*,
   -performance-unnecessary-value-param,
+  -performance-inefficient-string-concatenation,
   readability-avoid-const-params-in-decls,
   readability-const-return-type,
   readability-container-size-empty,
@@ -61,5 +71,4 @@ CheckOptions:
 HeaderFilterRegex: "CLI.*hpp"
 
 FormatStyle: file
-
-WarningsAsErrors: "*"
+# WarningsAsErrors: "*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,8 @@
 # clang-diagnostic-float-equal can be fixed by using _a from Catch::literals
 # bugprone-exception-escape due to main being a bit simple in examples
 # modernize-avoid-c-arrays trips up in TEMPLATE_TEST_CASE catch macro
+# modernize-return-braced-init-list triggers on lambdas ?
+# modernize-make-unique requires C++14
 
 Checks: |
   *bugprone*,
@@ -32,6 +34,8 @@ Checks: |
   modernize*,
   -modernize-use-trailing-return-type,
   -modernize-concat-nested-namespaces,
+  -modernize-return-braced-init-list,
+  -modernize-make-unique,
   *performance*,
   -performance-unnecessary-value-param,
   -performance-inefficient-string-concatenation,
@@ -67,6 +71,8 @@ CheckOptions:
     value: "exception_ptr$;"
   - key: readability-implicit-bool-conversion.AllowPointerConditions
     value: true
+  - key: modernize-use-nodiscard.ReplacementString
+    value: "CLI11_NODISCARD"
 
 HeaderFilterRegex: "CLI.*hpp"
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,9 +26,10 @@ complexity of CLI11 needlessly.
 - Formatting should be done with pre-commit, otherwise the format check will not
   pass. However, it is trivial to apply this to your PR, so don't worry about
   this check. If you do want to run it, see below.
-- Everything must pass clang-tidy as well, run with `-DCLI11_CLANG_TIDY=ON` (if
-  you set `-DCLI11_CLANG_TIDY_OPTIONS="-fix"`, make sure you use a single
-  threaded build process, or just build one example target).
+- Everything must pass clang-tidy as well, run with
+  `-DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy)"` (if you set
+  `"$(which clang-tidy) -fix"`, make sure you use a single threaded build
+  process, or just build one example target).
 - Your changes must also conform to most of the
   [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
   rules checked by [cpplint](https://github.com/cpplint/cpplint). For unused

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,22 @@ on:
   pull_request:
 
 jobs:
+  clang-tidy:
+    name: Clang-Tidy
+    runs-on: ubuntu-latest
+    container: silkeh/clang:14
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure
+        run: >
+          cmake -S . -B build -DCMAKE_CXX_STANDARD=17
+          -DCMAKE_CXX_CLANG_TIDY="$(which
+          clang-tidy);--use-color;--warnings-as-errors=*"
+
+      - name: Build
+        run: cmake --build build -j4 -- --keep-going
+
   cuda-build:
     name: CUDA build only
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,13 +105,6 @@ cmake_dependent_option(
   CLI11_CUDA_TESTS "Build the tests with NVCC to check for warnings there - requires CMake 3.9+"
   OFF "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME" OFF)
 
-cmake_dependent_option(
-  CLI11_CLANG_TIDY "Look for and use Clang-Tidy" OFF
-  "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME;NOT CMAKE_VERSION VERSION_LESS 3.6" OFF)
-set(CLI11_CLANG_TIDY_OPTIONS
-    ""
-    CACHE STRING "Clang tidy options, such as -fix, semicolon separated")
-
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()
@@ -133,6 +126,22 @@ endif()
 add_library(CLI11_warnings INTERFACE)
 
 set(unix-warnings -Wall -Wextra -pedantic -Wshadow -Wsign-conversion -Wswitch-enum)
+
+# Clang warnings
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  list(
+    APPEND
+    unix-warnings
+    -Wcast-align
+    -Wfloat-equal
+    -Wimplicit-atomic-properties
+    -Wmissing-declarations
+    -Woverlength-strings
+    -Wshadow
+    -Wstrict-selector-match
+    -Wundeclared-selector
+    -Wunreachable-code)
+endif()
 
 # Buggy in GCC 4.8
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
@@ -189,16 +198,6 @@ if(CLI11_CUDA_TESTS)
 
   # Print out warning and error numbers
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcudafe --display_error_number")
-endif()
-
-# Prepare Clang-Tidy
-if(CLI11_CLANG_TIDY)
-  find_program(
-    CLANG_TIDY_EXE
-    NAMES "clang-tidy"
-    DOC "Path to clang-tidy executable" REQUIRED)
-
-  set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" ${CLI11_CLANG_TIDY_OPTIONS})
 endif()
 
 # This folder should be installed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Woverlength-strings
     -Wshadow
     -Wstrict-selector-match
-    -Wundeclared-selector
-    -Wunreachable-code)
+    -Wundeclared-selector)
+  # -Wunreachable-code Doesn't work on Clang 3.4
 endif()
 
 # Buggy in GCC 4.8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,12 +128,12 @@ add_library(CLI11_warnings INTERFACE)
 set(unix-warnings -Wall -Wextra -pedantic -Wshadow -Wsign-conversion -Wswitch-enum)
 
 # Clang warnings
+# -Wfloat-equal could be added with Catch::literals and _a usage
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   list(
     APPEND
     unix-warnings
     -Wcast-align
-    -Wfloat-equal
     -Wimplicit-atomic-properties
     -Wmissing-declarations
     -Woverlength-strings

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,18 +21,13 @@ variables:
 jobs:
   - job: ClangTidy
     variables:
-      CXX_FLAGS: >
-        -Werror -Wcast-align -Wfloat-equal -Wimplicit-atomic-properties
-        -Wmissing-declarations -Woverlength-strings -Wshadow
-        -Wstrict-selector-match -Wundeclared-selector -Wunreachable-code
-        -std=c++11
-      cli11.options: -DCLI11_CLANG_TIDY=ON -DCLI11_CLANG_TIDY_OPTIONS="-fix"
-      cli11.std: 11
+      cli11.options: -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-fix"
+      cli11.std: 17
       cli11.single: OFF
       CMAKE_BUILD_PARALLEL_LEVEL: 1
     pool:
       vmImage: "ubuntu-latest"
-    container: silkeh/clang:8
+    container: silkeh/clang:14
     steps:
       - template: .ci/azure-cmake.yml
       - template: .ci/azure-build.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,21 +19,6 @@ variables:
   CMAKE_BUILD_PARALLEL_LEVEL: 4
 
 jobs:
-  - job: ClangTidy
-    variables:
-      cli11.options: -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-fix"
-      cli11.std: 17
-      cli11.single: OFF
-      CMAKE_BUILD_PARALLEL_LEVEL: 1
-    pool:
-      vmImage: "ubuntu-latest"
-    container: silkeh/clang:14
-    steps:
-      - template: .ci/azure-cmake.yml
-      - template: .ci/azure-build.yml
-      - script: git diff --exit-code --color
-        displayName: Check tidy
-
   - job: CppLint
     pool:
       vmImage: "ubuntu-latest"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,9 +8,6 @@ function(add_cli_exe T)
       APPEND_STRING
       PROPERTY LINK_FLAGS -stdlib=libc++)
   endif()
-  if(CLI11_CLANG_TIDY)
-    set_property(TARGET ${T} PROPERTY CXX_CLANG_TIDY "${DO_CLANG_TIDY}")
-  endif()
 endfunction()
 
 if(CLI11_BUILD_EXAMPLES_JSON)

--- a/examples/custom_parse.cpp
+++ b/examples/custom_parse.cpp
@@ -22,7 +22,7 @@ template <class T = int> struct Values {
 using DoubleValues = Values<double>;
 
 // the lexical cast operator should be in the same namespace as the type for ADL to work properly
-bool lexical_cast(const std::string &input, Values<double> &v) {
+bool lexical_cast(const std::string &input, Values<double> & /*v*/) {
     std::cout << "called correct lexical_cast function ! val: " << input << std::endl;
     return true;
 }

--- a/examples/formatter.cpp
+++ b/examples/formatter.cpp
@@ -24,9 +24,9 @@ int main(int argc, char **argv) {
 
     app.add_flag("--flag", "This is a flag");
 
-    auto sub1 = app.add_subcommand("one", "Description One");
+    auto *sub1 = app.add_subcommand("one", "Description One");
     sub1->add_flag("--oneflag", "Some flag");
-    auto sub2 = app.add_subcommand("two", "Description Two");
+    auto *sub2 = app.add_subcommand("two", "Description Two");
     sub2->add_flag("--twoflag", "Some other flag");
 
     CLI11_PARSE(app, argc, argv);

--- a/examples/groups.cpp
+++ b/examples/groups.cpp
@@ -10,7 +10,7 @@
 #include <string>
 
 int main(int argc, char **argv) {
-    CLI::AutoTimer("This is a timer");
+    CLI::AutoTimer give_me_a_name("This is a timer");
 
     CLI::App app("K3Pi goofit fitter");
 

--- a/examples/inter_argument_order.cpp
+++ b/examples/inter_argument_order.cpp
@@ -14,10 +14,10 @@ int main(int argc, char **argv) {
     CLI::App app{"An app to practice mixing unlimited arguments, but still recover the original order."};
 
     std::vector<int> foos;
-    auto foo = app.add_option("--foo,-f", foos, "Some unlimited argument");
+    auto *foo = app.add_option("--foo,-f", foos, "Some unlimited argument");
 
     std::vector<int> bars;
-    auto bar = app.add_option("--bar", bars, "Some unlimited argument");
+    auto *bar = app.add_option("--bar", bars, "Some unlimited argument");
 
     app.add_flag("--z,--x", "Random other flags");
 
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
     std::reverse(std::begin(bars), std::end(bars));
 
     std::vector<std::pair<std::string, int>> keyval;
-    for(auto option : app.parse_order()) {
+    for(auto *option : app.parse_order()) {
         if(option == foo) {
             keyval.emplace_back("foo", foos.back());
             foos.pop_back();

--- a/examples/modhelp.cpp
+++ b/examples/modhelp.cpp
@@ -16,7 +16,7 @@ Note that this will not shortcut `->required` and other similar options.)raw"};
     test.set_help_flag();
 
     // Add custom flag that activates help
-    auto help = test.add_flag("-h,--help", "Request help");
+    auto *help = test.add_flag("-h,--help", "Request help");
 
     std::string some_option;
     test.add_option("-a", some_option, "Some description");

--- a/examples/option_groups.cpp
+++ b/examples/option_groups.cpp
@@ -13,8 +13,8 @@ int main(int argc, char **argv) {
     CLI::App app("data output specification");
     app.set_help_all_flag("--help-all", "Expand all help");
 
-    auto format = app.add_option_group("output_format", "formatting type for output");
-    auto target = app.add_option_group("output target", "target location for the output");
+    auto *format = app.add_option_group("output_format", "formatting type for output");
+    auto *target = app.add_option_group("output target", "target location for the output");
     bool csv{false};
     bool human{false};
     bool binary{false};

--- a/examples/positional_arity.cpp
+++ b/examples/positional_arity.cpp
@@ -12,8 +12,8 @@ int main(int argc, char **argv) {
 
     CLI::App app("test for positional arity");
 
-    auto numbers = app.add_option_group("numbers", "specify key numbers");
-    auto files = app.add_option_group("files", "specify files");
+    auto *numbers = app.add_option_group("numbers", "specify key numbers");
+    auto *files = app.add_option_group("files", "specify files");
     int num1{-1}, num2{-1};
     numbers->add_option("num1", num1, "first number");
     numbers->add_option("num2", num2, "second number");

--- a/examples/prefix_command.cpp
+++ b/examples/prefix_command.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
 
     std::cout << std::endl << "Remaining commands: ";
 
-    for(auto com : more_comms)
+    for(const auto &com : more_comms)
         std::cout << com << " ";
     std::cout << std::endl;
 

--- a/examples/ranges.cpp
+++ b/examples/ranges.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     std::vector<int> range;
     app.add_option("--range,-R", range, "A range")->expected(-2);
 
-    auto ogroup = app.add_option_group("min_max_step", "set the min max and step");
+    auto *ogroup = app.add_option_group("min_max_step", "set the min max and step");
     int min{0}, max{0}, step{1};
     ogroup->add_option("--min,-m", min, "The minimum")->required();
     ogroup->add_option("--max,-M", max, "The maximum")->required();

--- a/examples/retired.cpp
+++ b/examples/retired.cpp
@@ -14,10 +14,10 @@ int main(int argc, char **argv) {
 
     CLI::App app("example for retired/deprecated options");
     std::vector<int> x;
-    auto opt1 = app.add_option("--retired_option2", x);
+    auto *opt1 = app.add_option("--retired_option2", x);
 
     std::pair<int, int> y;
-    auto opt2 = app.add_option("--deprecate", y);
+    auto *opt2 = app.add_option("--deprecate", y);
 
     app.add_option("--not_deprecated", x);
 

--- a/examples/shapes.cpp
+++ b/examples/shapes.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
     CLI::App app("load shapes");
 
     app.set_help_all_flag("--help-all");
-    auto circle = app.add_subcommand("circle", "draw a circle")->immediate_callback();
+    auto *circle = app.add_subcommand("circle", "draw a circle")->immediate_callback();
     double radius{0.0};
     int circle_counter{0};
     circle->callback([&radius, &circle_counter] {
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
 
     circle->add_option("radius", radius, "the radius of the circle")->required();
 
-    auto rect = app.add_subcommand("rectangle", "draw a rectangle")->immediate_callback();
+    auto *rect = app.add_subcommand("rectangle", "draw a rectangle")->immediate_callback();
     double edge1{0.0};
     double edge2{0.0};
     int rect_counter{0};
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
     rect->add_option("edge1", edge1, "the first edge length of the rectangle")->required();
     rect->add_option("edge2", edge2, "the second edge length of the rectangle");
 
-    auto tri = app.add_subcommand("triangle", "draw a rectangle")->immediate_callback();
+    auto *tri = app.add_subcommand("triangle", "draw a rectangle")->immediate_callback();
     std::vector<double> sides;
     int tri_counter = 0;
     tri->callback([&sides, &tri_counter] {

--- a/examples/subcom_in_files/subcommand_a.cpp
+++ b/examples/subcom_in_files/subcommand_a.cpp
@@ -15,7 +15,7 @@
 void setup_subcommand_a(CLI::App &app) {
     // Create the option and subcommand objects.
     auto opt = std::make_shared<SubcommandAOptions>();
-    auto sub = app.add_subcommand("subcommand_a", "performs subcommand a");
+    auto *sub = app.add_subcommand("subcommand_a", "performs subcommand a");
 
     // Add options to sub, binding them to opt.
     sub->add_option("-f,--file", opt->file, "File name")->required();

--- a/examples/subcom_partitioned.cpp
+++ b/examples/subcom_partitioned.cpp
@@ -11,7 +11,7 @@
 #include <string>
 
 int main(int argc, char **argv) {
-    CLI::AutoTimer("This is a timer");
+    CLI::AutoTimer give_me_a_name("This is a timer");
 
     CLI::App app("K3Pi goofit fitter");
 

--- a/examples/subcommands.cpp
+++ b/examples/subcommands.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     std::cout << "Working on --count from stop: " << s->count() << ", direct count: " << stop->count("--count")
               << std::endl;
     std::cout << "Count of --random flag: " << app.count("--random") << std::endl;
-    for(auto subcom : app.get_subcommands())
+    for(auto *subcom : app.get_subcommands())
         std::cout << "Subcommand: " << subcom->get_name() << std::endl;
 
     return 0;

--- a/examples/testEXE.cpp
+++ b/examples/testEXE.cpp
@@ -17,7 +17,7 @@ int main(int argc, const char *argv[]) {
 
     app.add_option("-v", logLevel, "level");
 
-    auto subcom = app.add_subcommand("sub", "")->fallthrough();
+    auto *subcom = app.add_subcommand("sub", "")->fallthrough();
     subcom->preparse_callback([&app](size_t) { app.get_subcommand("sub")->add_option_group("group"); });
 
     CLI11_PARSE(app, argc, argv);

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -2561,7 +2561,7 @@ class App {
 
                             parse_order_.push_back(opt.get());
                             /// if we require a separator add it here
-                            if(opt->get_inject_separator() != 0) {
+                            if(opt->get_inject_separator()) {
                                 if(!opt->results().empty() && !opt->results().back().empty()) {
                                     opt->add_result(std::string{});
                                 }
@@ -2592,7 +2592,7 @@ class App {
                         continue;
                     }
                 }
-                if(opt->get_inject_separator() != 0) {
+                if(opt->get_inject_separator()) {
                     if(!opt->results().empty() && !opt->results().back().empty()) {
                         opt->add_result(std::string{});
                     }
@@ -2790,7 +2790,7 @@ class App {
         // Get a reference to the pointer to make syntax bearable
         Option_p &op = *op_ptr;
         /// if we require a separator add it here
-        if(op->get_inject_separator() != 0) {
+        if(op->get_inject_separator()) {
             if(!op->results().empty() && !op->results().back().empty()) {
                 op->add_result(std::string{});
             }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -567,7 +567,7 @@ class App {
     }
 
     /// Check to see if this subcommand was parsed, true only if received on command line.
-    [[nodiscard]] bool parsed() const { return parsed_ > 0; }
+    CLI11_NODISCARD bool parsed() const { return parsed_ > 0; }
 
     /// Get the OptionDefault object, to set option defaults
     OptionDefaults *option_defaults() { return &option_defaults_; }
@@ -1028,14 +1028,14 @@ class App {
     }
 
     /// Check to see if a subcommand is part of this command (text version)
-    [[nodiscard]] App *get_subcommand(std::string subcom) const {
+    CLI11_NODISCARD App *get_subcommand(std::string subcom) const {
         auto *subc = _find_subcommand(subcom, false, false);
         if(subc == nullptr)
             throw OptionNotFound(subcom);
         return subc;
     }
     /// Get a pointer to subcommand by index
-    [[nodiscard]] App *get_subcommand(int index = 0) const {
+    CLI11_NODISCARD App *get_subcommand(int index = 0) const {
         if(index >= 0) {
             auto uindex = static_cast<unsigned>(index);
             if(uindex < subcommands_.size())
@@ -1055,7 +1055,7 @@ class App {
     }
 
     /// Check to see if a subcommand is part of this command (text version)
-    [[nodiscard]] CLI::App_p get_subcommand_ptr(std::string subcom) const {
+    CLI11_NODISCARD CLI::App_p get_subcommand_ptr(std::string subcom) const {
         for(const App_p &subcomptr : subcommands_)
             if(subcomptr->check_name(subcom))
                 return subcomptr;
@@ -1063,7 +1063,7 @@ class App {
     }
 
     /// Get an owning pointer to subcommand by index
-    [[nodiscard]] CLI::App_p get_subcommand_ptr(int index = 0) const {
+    CLI11_NODISCARD CLI::App_p get_subcommand_ptr(int index = 0) const {
         if(index >= 0) {
             auto uindex = static_cast<unsigned>(index);
             if(uindex < subcommands_.size())
@@ -1073,7 +1073,7 @@ class App {
     }
 
     /// Check to see if an option group is part of this App
-    [[nodiscard]] App *get_option_group(std::string group_name) const {
+    CLI11_NODISCARD App *get_option_group(std::string group_name) const {
         for(const App_p &app : subcommands_) {
             if(app->name_.empty() && app->group_ == group_name) {
                 return app.get();
@@ -1085,11 +1085,11 @@ class App {
     /// No argument version of count counts the number of times this subcommand was
     /// passed in. The main app will return 1. Unnamed subcommands will also return 1 unless
     /// otherwise modified in a callback
-    [[nodiscard]] std::size_t count() const { return parsed_; }
+    CLI11_NODISCARD std::size_t count() const { return parsed_; }
 
     /// Get a count of all the arguments processed in options and subcommands, this excludes arguments which were
     /// treated as extras.
-    [[nodiscard]] std::size_t count_all() const {
+    CLI11_NODISCARD std::size_t count_all() const {
         std::size_t cnt{0};
         for(const auto &opt : options_) {
             cnt += opt->count();
@@ -1345,11 +1345,11 @@ class App {
     ///@{
 
     /// Counts the number of times the given option was passed.
-    [[nodiscard]] std::size_t count(std::string option_name) const { return get_option(option_name)->count(); }
+    CLI11_NODISCARD std::size_t count(std::string option_name) const { return get_option(option_name)->count(); }
 
     /// Get a subcommand pointer list to the currently selected subcommands (after parsing by default, in command
     /// line order; use parsed = false to get the original definition list.)
-    [[nodiscard]] std::vector<App *> get_subcommands() const { return parsed_subcommands_; }
+    CLI11_NODISCARD std::vector<App *> get_subcommands() const { return parsed_subcommands_; }
 
     /// Get a filtered subcommand pointer list from the original definition list. An empty function will provide all
     /// subcommands (const)
@@ -1393,7 +1393,7 @@ class App {
     }
 
     /// Check with name instead of pointer to see if subcommand was selected
-    [[nodiscard]] bool got_subcommand(std::string subcommand_name) const {
+    CLI11_NODISCARD bool got_subcommand(std::string subcommand_name) const {
         return get_subcommand(subcommand_name)->parsed_ > 0;
     }
 
@@ -1499,13 +1499,13 @@ class App {
     }
     /// Produce a string that could be read in as a config of the current values of the App. Set default_also to
     /// include default arguments. write_descriptions will print a description for the App and for each option.
-    [[nodiscard]] std::string config_to_str(bool default_also = false, bool write_description = false) const {
+    CLI11_NODISCARD std::string config_to_str(bool default_also = false, bool write_description = false) const {
         return config_formatter_->to_config(this, default_also, write_description, "");
     }
 
     /// Makes a help message, using the currently configured formatter
     /// Will only do one subcommand at a time
-    [[nodiscard]] std::string help(std::string prev = "", AppFormatMode mode = AppFormatMode::Normal) const {
+    CLI11_NODISCARD std::string help(std::string prev = "", AppFormatMode mode = AppFormatMode::Normal) const {
         if(prev.empty())
             prev = get_name();
         else
@@ -1520,7 +1520,7 @@ class App {
     }
 
     /// Displays a version string
-    [[nodiscard]] std::string version() const {
+    CLI11_NODISCARD std::string version() const {
         std::string val;
         if(version_ptr_ != nullptr) {
             auto rv = version_ptr_->results();
@@ -1541,13 +1541,13 @@ class App {
     ///@{
 
     /// Access the formatter
-    [[nodiscard]] std::shared_ptr<FormatterBase> get_formatter() const { return formatter_; }
+    CLI11_NODISCARD std::shared_ptr<FormatterBase> get_formatter() const { return formatter_; }
 
     /// Access the config formatter
-    [[nodiscard]] std::shared_ptr<Config> get_config_formatter() const { return config_formatter_; }
+    CLI11_NODISCARD std::shared_ptr<Config> get_config_formatter() const { return config_formatter_; }
 
     /// Access the config formatter as a configBase pointer
-    [[nodiscard]] std::shared_ptr<ConfigBase> get_config_formatter_base() const {
+    CLI11_NODISCARD std::shared_ptr<ConfigBase> get_config_formatter_base() const {
         // This is safer as a dynamic_cast if we have RTTI, as Config -> ConfigBase
 #if CLI11_USE_STATIC_RTTI == 0
         return std::dynamic_pointer_cast<ConfigBase>(config_formatter_);
@@ -1557,7 +1557,7 @@ class App {
     }
 
     /// Get the app or subcommand description
-    [[nodiscard]] std::string get_description() const { return description_; }
+    CLI11_NODISCARD std::string get_description() const { return description_; }
 
     /// Set the description of the app
     App *description(std::string app_description) {
@@ -1618,7 +1618,7 @@ class App {
     }
 
     /// Get an option by name (noexcept const version)
-    [[nodiscard]] const Option *get_option_no_throw(std::string option_name) const noexcept {
+    CLI11_NODISCARD const Option *get_option_no_throw(std::string option_name) const noexcept {
         for(const Option_p &opt : options_) {
             if(opt->check_name(option_name)) {
                 return opt.get();
@@ -1637,7 +1637,7 @@ class App {
     }
 
     /// Get an option by name
-    [[nodiscard]] const Option *get_option(std::string option_name) const {
+    CLI11_NODISCARD const Option *get_option(std::string option_name) const {
         const auto *opt = get_option_no_throw(option_name);
         if(opt == nullptr) {
             throw OptionNotFound(option_name);
@@ -1661,106 +1661,106 @@ class App {
     const Option *operator[](const char *option_name) const { return get_option(option_name); }
 
     /// Check the status of ignore_case
-    [[nodiscard]] bool get_ignore_case() const { return ignore_case_; }
+    CLI11_NODISCARD bool get_ignore_case() const { return ignore_case_; }
 
     /// Check the status of ignore_underscore
-    [[nodiscard]] bool get_ignore_underscore() const { return ignore_underscore_; }
+    CLI11_NODISCARD bool get_ignore_underscore() const { return ignore_underscore_; }
 
     /// Check the status of fallthrough
-    [[nodiscard]] bool get_fallthrough() const { return fallthrough_; }
+    CLI11_NODISCARD bool get_fallthrough() const { return fallthrough_; }
 
     /// Check the status of the allow windows style options
-    [[nodiscard]] bool get_allow_windows_style_options() const { return allow_windows_style_options_; }
+    CLI11_NODISCARD bool get_allow_windows_style_options() const { return allow_windows_style_options_; }
 
     /// Check the status of the allow windows style options
-    [[nodiscard]] bool get_positionals_at_end() const { return positionals_at_end_; }
+    CLI11_NODISCARD bool get_positionals_at_end() const { return positionals_at_end_; }
 
     /// Check the status of the allow windows style options
-    [[nodiscard]] bool get_configurable() const { return configurable_; }
+    CLI11_NODISCARD bool get_configurable() const { return configurable_; }
 
     /// Get the group of this subcommand
-    [[nodiscard]] const std::string &get_group() const { return group_; }
+    CLI11_NODISCARD const std::string &get_group() const { return group_; }
 
     /// Generate and return the footer.
-    [[nodiscard]] std::string get_footer() const {
+    CLI11_NODISCARD std::string get_footer() const {
         return (footer_callback_) ? footer_callback_() + '\n' + footer_ : footer_;
     }
 
     /// Get the required min subcommand value
-    [[nodiscard]] std::size_t get_require_subcommand_min() const { return require_subcommand_min_; }
+    CLI11_NODISCARD std::size_t get_require_subcommand_min() const { return require_subcommand_min_; }
 
     /// Get the required max subcommand value
-    [[nodiscard]] std::size_t get_require_subcommand_max() const { return require_subcommand_max_; }
+    CLI11_NODISCARD std::size_t get_require_subcommand_max() const { return require_subcommand_max_; }
 
     /// Get the required min option value
-    [[nodiscard]] std::size_t get_require_option_min() const { return require_option_min_; }
+    CLI11_NODISCARD std::size_t get_require_option_min() const { return require_option_min_; }
 
     /// Get the required max option value
-    [[nodiscard]] std::size_t get_require_option_max() const { return require_option_max_; }
+    CLI11_NODISCARD std::size_t get_require_option_max() const { return require_option_max_; }
 
     /// Get the prefix command status
-    [[nodiscard]] bool get_prefix_command() const { return prefix_command_; }
+    CLI11_NODISCARD bool get_prefix_command() const { return prefix_command_; }
 
     /// Get the status of allow extras
-    [[nodiscard]] bool get_allow_extras() const { return allow_extras_; }
+    CLI11_NODISCARD bool get_allow_extras() const { return allow_extras_; }
 
     /// Get the status of required
-    [[nodiscard]] bool get_required() const { return required_; }
+    CLI11_NODISCARD bool get_required() const { return required_; }
 
     /// Get the status of disabled
-    [[nodiscard]] bool get_disabled() const { return disabled_; }
+    CLI11_NODISCARD bool get_disabled() const { return disabled_; }
 
     /// Get the status of silence
-    [[nodiscard]] bool get_silent() const { return silent_; }
+    CLI11_NODISCARD bool get_silent() const { return silent_; }
 
     /// Get the status of disabled
-    [[nodiscard]] bool get_immediate_callback() const { return immediate_callback_; }
+    CLI11_NODISCARD bool get_immediate_callback() const { return immediate_callback_; }
 
     /// Get the status of disabled by default
-    [[nodiscard]] bool get_disabled_by_default() const { return (default_startup == startup_mode::disabled); }
+    CLI11_NODISCARD bool get_disabled_by_default() const { return (default_startup == startup_mode::disabled); }
 
     /// Get the status of disabled by default
-    [[nodiscard]] bool get_enabled_by_default() const { return (default_startup == startup_mode::enabled); }
+    CLI11_NODISCARD bool get_enabled_by_default() const { return (default_startup == startup_mode::enabled); }
     /// Get the status of validating positionals
-    [[nodiscard]] bool get_validate_positionals() const { return validate_positionals_; }
+    CLI11_NODISCARD bool get_validate_positionals() const { return validate_positionals_; }
     /// Get the status of validating optional vector arguments
-    [[nodiscard]] bool get_validate_optional_arguments() const { return validate_optional_arguments_; }
+    CLI11_NODISCARD bool get_validate_optional_arguments() const { return validate_optional_arguments_; }
 
     /// Get the status of allow extras
-    [[nodiscard]] config_extras_mode get_allow_config_extras() const { return allow_config_extras_; }
+    CLI11_NODISCARD config_extras_mode get_allow_config_extras() const { return allow_config_extras_; }
 
     /// Get a pointer to the help flag.
     Option *get_help_ptr() { return help_ptr_; }
 
     /// Get a pointer to the help flag. (const)
-    [[nodiscard]] const Option *get_help_ptr() const { return help_ptr_; }
+    CLI11_NODISCARD const Option *get_help_ptr() const { return help_ptr_; }
 
     /// Get a pointer to the help all flag. (const)
-    [[nodiscard]] const Option *get_help_all_ptr() const { return help_all_ptr_; }
+    CLI11_NODISCARD const Option *get_help_all_ptr() const { return help_all_ptr_; }
 
     /// Get a pointer to the config option.
     Option *get_config_ptr() { return config_ptr_; }
 
     /// Get a pointer to the config option. (const)
-    [[nodiscard]] const Option *get_config_ptr() const { return config_ptr_; }
+    CLI11_NODISCARD const Option *get_config_ptr() const { return config_ptr_; }
 
     /// Get a pointer to the version option.
     Option *get_version_ptr() { return version_ptr_; }
 
     /// Get a pointer to the version option. (const)
-    [[nodiscard]] const Option *get_version_ptr() const { return version_ptr_; }
+    CLI11_NODISCARD const Option *get_version_ptr() const { return version_ptr_; }
 
     /// Get the parent of this subcommand (or nullptr if main app)
     App *get_parent() { return parent_; }
 
     /// Get the parent of this subcommand (or nullptr if main app) (const version)
-    [[nodiscard]] const App *get_parent() const { return parent_; }
+    CLI11_NODISCARD const App *get_parent() const { return parent_; }
 
     /// Get the name of the current app
-    [[nodiscard]] const std::string &get_name() const { return name_; }
+    CLI11_NODISCARD const std::string &get_name() const { return name_; }
 
     /// Get the aliases of the current app
-    [[nodiscard]] const std::vector<std::string> &get_aliases() const { return aliases_; }
+    CLI11_NODISCARD const std::vector<std::string> &get_aliases() const { return aliases_; }
 
     /// clear all the aliases of the current App
     App *clear_aliases() {
@@ -1769,7 +1769,7 @@ class App {
     }
 
     /// Get a display name for an app
-    [[nodiscard]] std::string get_display_name(bool with_aliases = false) const {
+    CLI11_NODISCARD std::string get_display_name(bool with_aliases = false) const {
         if(name_.empty()) {
             return std::string("[Option Group: ") + get_group() + "]";
         }
@@ -1786,7 +1786,7 @@ class App {
     }
 
     /// Check the name, case insensitive and underscore insensitive if set
-    [[nodiscard]] bool check_name(std::string name_to_check) const {
+    CLI11_NODISCARD bool check_name(std::string name_to_check) const {
         std::string local_name = name_;
         if(ignore_underscore_) {
             local_name = detail::remove_underscore(name_);
@@ -1815,7 +1815,7 @@ class App {
     }
 
     /// Get the groups available directly from this option (in order)
-    [[nodiscard]] std::vector<std::string> get_groups() const {
+    CLI11_NODISCARD std::vector<std::string> get_groups() const {
         std::vector<std::string> groups;
 
         for(const Option_p &opt : options_) {
@@ -1829,10 +1829,10 @@ class App {
     }
 
     /// This gets a vector of pointers with the original parse order
-    [[nodiscard]] const std::vector<Option *> &parse_order() const { return parse_order_; }
+    CLI11_NODISCARD const std::vector<Option *> &parse_order() const { return parse_order_; }
 
     /// This returns the missing options from the current subcommand
-    [[nodiscard]] std::vector<std::string> remaining(bool recurse = false) const {
+    CLI11_NODISCARD std::vector<std::string> remaining(bool recurse = false) const {
         std::vector<std::string> miss_list;
         for(const std::pair<detail::Classifier, std::string> &miss : missing_) {
             miss_list.push_back(std::get<1>(miss));
@@ -1859,14 +1859,14 @@ class App {
     }
 
     /// This returns the missing options in a form ready for processing by another command line program
-    [[nodiscard]] std::vector<std::string> remaining_for_passthrough(bool recurse = false) const {
+    CLI11_NODISCARD std::vector<std::string> remaining_for_passthrough(bool recurse = false) const {
         std::vector<std::string> miss_list = remaining(recurse);
         std::reverse(std::begin(miss_list), std::end(miss_list));
         return miss_list;
     }
 
     /// This returns the number of remaining options, minus the -- separator
-    [[nodiscard]] std::size_t remaining_size(bool recurse = false) const {
+    CLI11_NODISCARD std::size_t remaining_size(bool recurse = false) const {
         auto remaining_options = static_cast<std::size_t>(std::count_if(
             std::begin(missing_), std::end(missing_), [](const std::pair<detail::Classifier, std::string> &val) {
                 return val.first != detail::Classifier::POSITIONAL_MARK;
@@ -1975,7 +1975,7 @@ class App {
     }
 
     /// Check to see if a subcommand is valid. Give up immediately if subcommand max has been reached.
-    [[nodiscard]] bool _valid_subcommand(const std::string &current, bool ignore_used = true) const {
+    CLI11_NODISCARD bool _valid_subcommand(const std::string &current, bool ignore_used = true) const {
         // Don't match if max has been reached - but still check parents
         if(require_subcommand_max_ != 0 && parsed_subcommands_.size() >= require_subcommand_max_) {
             return parent_ != nullptr && parent_->_valid_subcommand(current, ignore_used);
@@ -1989,7 +1989,8 @@ class App {
     }
 
     /// Selects a Classifier enum based on the type of the current argument
-    [[nodiscard]] detail::Classifier _recognize(const std::string &current, bool ignore_used_subcommands = true) const {
+    CLI11_NODISCARD detail::Classifier _recognize(const std::string &current,
+                                                  bool ignore_used_subcommands = true) const {
         std::string dummy1, dummy2;
 
         if(current == "--")
@@ -2511,7 +2512,7 @@ class App {
     }
 
     /// Count the required remaining positional arguments
-    [[nodiscard]] std::size_t _count_remaining_positionals(bool required_only = false) const {
+    CLI11_NODISCARD std::size_t _count_remaining_positionals(bool required_only = false) const {
         std::size_t retval = 0;
         for(const Option_p &opt : options_) {
             if(opt->get_positional() && (!required_only || opt->get_required())) {
@@ -2525,7 +2526,7 @@ class App {
     }
 
     /// Count the required remaining positional arguments
-    [[nodiscard]] bool _has_remaining_positionals() const {
+    CLI11_NODISCARD bool _has_remaining_positionals() const {
         for(const Option_p &opt : options_) {
             if(opt->get_positional() && ((static_cast<int>(opt->count()) < opt->get_items_expected_min()))) {
                 return true;
@@ -2664,7 +2665,7 @@ class App {
 
     /// Locate a subcommand by name with two conditions, should disabled subcommands be ignored, and should used
     /// subcommands be ignored
-    [[nodiscard]] App *
+    CLI11_NODISCARD App *
     _find_subcommand(const std::string &subc_name, bool ignore_disabled, bool ignore_used) const noexcept {
         for(const App_p &com : subcommands_) {
             if(com->disabled_ && ignore_disabled)
@@ -2921,7 +2922,7 @@ class App {
     }
 
     /// Helper function to run through all possible comparisons of subcommand names to check there is no overlap
-    [[nodiscard]] const std::string &_compare_subcommand_names(const App &subcom, const App &base) const {
+    CLI11_NODISCARD const std::string &_compare_subcommand_names(const App &subcom, const App &base) const {
         static const std::string estring;
         if(subcom.disabled_) {
             return estring;

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -374,7 +374,7 @@ class App {
         if(parent_ != nullptr) {
             auto oname = name_;
             name_ = app_name;
-            auto &res = _compare_subcommand_names(*this, *_get_fallthrough_parent());
+            const auto &res = _compare_subcommand_names(*this, *_get_fallthrough_parent());
             if(!res.empty()) {
                 name_ = oname;
                 throw(OptionAlreadyAdded(app_name + " conflicts with existing subcommand names"));
@@ -393,7 +393,7 @@ class App {
         }
         if(parent_ != nullptr) {
             aliases_.push_back(app_name);
-            auto &res = _compare_subcommand_names(*this, *_get_fallthrough_parent());
+            const auto &res = _compare_subcommand_names(*this, *_get_fallthrough_parent());
             if(!res.empty()) {
                 aliases_.pop_back();
                 throw(OptionAlreadyAdded("alias already matches an existing subcommand: " + app_name));
@@ -504,7 +504,7 @@ class App {
         if(value && !ignore_case_) {
             ignore_case_ = true;
             auto *p = (parent_ != nullptr) ? _get_fallthrough_parent() : this;
-            auto &match = _compare_subcommand_names(*this, *p);
+            const auto &match = _compare_subcommand_names(*this, *p);
             if(!match.empty()) {
                 ignore_case_ = false;  // we are throwing so need to be exception invariant
                 throw OptionAlreadyAdded("ignore case would cause subcommand name conflicts: " + match);
@@ -538,7 +538,7 @@ class App {
         if(value && !ignore_underscore_) {
             ignore_underscore_ = true;
             auto *p = (parent_ != nullptr) ? _get_fallthrough_parent() : this;
-            auto &match = _compare_subcommand_names(*this, *p);
+            const auto &match = _compare_subcommand_names(*this, *p);
             if(!match.empty()) {
                 ignore_underscore_ = false;
                 throw OptionAlreadyAdded("ignore underscore would cause subcommand name conflicts: " + match);
@@ -567,7 +567,7 @@ class App {
     }
 
     /// Check to see if this subcommand was parsed, true only if received on command line.
-    bool parsed() const { return parsed_ > 0; }
+    [[nodiscard]] bool parsed() const { return parsed_ > 0; }
 
     /// Get the OptionDefault object, to set option defaults
     OptionDefaults *option_defaults() { return &option_defaults_; }
@@ -622,7 +622,7 @@ class App {
         }
         // we know something matches now find what it is so we can produce more error information
         for(auto &opt : options_) {
-            auto &matchname = opt->matching_name(myopt);
+            const auto &matchname = opt->matching_name(myopt);
             if(!matchname.empty()) {
                 throw(OptionAlreadyAdded("added option matched existing option name: " + matchname));
             }
@@ -785,7 +785,7 @@ class App {
   private:
     /// Internal function for adding a flag
     Option *_add_flag_internal(std::string flag_name, CLI::callback_t fun, std::string flag_description) {
-        Option *opt;
+        Option *opt = nullptr;
         if(detail::has_default_flag_values(flag_name)) {
             // check for default values and if it has them
             auto flag_defaults = detail::get_default_flag_values(flag_name);
@@ -956,7 +956,7 @@ class App {
             throw IncorrectConstruction("option group names may not contain newlines or null characters");
         }
         auto option_group = std::make_shared<T>(std::move(group_description), group_name, this);
-        auto ptr = option_group.get();
+        auto *ptr = option_group.get();
         // move to App_p for overload resolution on older gcc versions
         App_p app_ptr = std::dynamic_pointer_cast<App>(option_group);
         add_subcommand(std::move(app_ptr));
@@ -990,8 +990,8 @@ class App {
     App *add_subcommand(CLI::App_p subcom) {
         if(!subcom)
             throw IncorrectConstruction("passed App is not valid");
-        auto ckapp = (name_.empty() && parent_ != nullptr) ? _get_fallthrough_parent() : this;
-        auto &mstrg = _compare_subcommand_names(*subcom, *ckapp);
+        auto *ckapp = (name_.empty() && parent_ != nullptr) ? _get_fallthrough_parent() : this;
+        const auto &mstrg = _compare_subcommand_names(*subcom, *ckapp);
         if(!mstrg.empty()) {
             throw(OptionAlreadyAdded("subcommand name or alias matches existing subcommand: " + mstrg));
         }
@@ -1028,14 +1028,14 @@ class App {
     }
 
     /// Check to see if a subcommand is part of this command (text version)
-    App *get_subcommand(std::string subcom) const {
-        auto subc = _find_subcommand(subcom, false, false);
+    [[nodiscard]] App *get_subcommand(std::string subcom) const {
+        auto *subc = _find_subcommand(subcom, false, false);
         if(subc == nullptr)
             throw OptionNotFound(subcom);
         return subc;
     }
     /// Get a pointer to subcommand by index
-    App *get_subcommand(int index = 0) const {
+    [[nodiscard]] App *get_subcommand(int index = 0) const {
         if(index >= 0) {
             auto uindex = static_cast<unsigned>(index);
             if(uindex < subcommands_.size())
@@ -1055,7 +1055,7 @@ class App {
     }
 
     /// Check to see if a subcommand is part of this command (text version)
-    CLI::App_p get_subcommand_ptr(std::string subcom) const {
+    [[nodiscard]] CLI::App_p get_subcommand_ptr(std::string subcom) const {
         for(const App_p &subcomptr : subcommands_)
             if(subcomptr->check_name(subcom))
                 return subcomptr;
@@ -1063,7 +1063,7 @@ class App {
     }
 
     /// Get an owning pointer to subcommand by index
-    CLI::App_p get_subcommand_ptr(int index = 0) const {
+    [[nodiscard]] CLI::App_p get_subcommand_ptr(int index = 0) const {
         if(index >= 0) {
             auto uindex = static_cast<unsigned>(index);
             if(uindex < subcommands_.size())
@@ -1073,7 +1073,7 @@ class App {
     }
 
     /// Check to see if an option group is part of this App
-    App *get_option_group(std::string group_name) const {
+    [[nodiscard]] App *get_option_group(std::string group_name) const {
         for(const App_p &app : subcommands_) {
             if(app->name_.empty() && app->group_ == group_name) {
                 return app.get();
@@ -1085,16 +1085,16 @@ class App {
     /// No argument version of count counts the number of times this subcommand was
     /// passed in. The main app will return 1. Unnamed subcommands will also return 1 unless
     /// otherwise modified in a callback
-    std::size_t count() const { return parsed_; }
+    [[nodiscard]] std::size_t count() const { return parsed_; }
 
     /// Get a count of all the arguments processed in options and subcommands, this excludes arguments which were
     /// treated as extras.
-    std::size_t count_all() const {
+    [[nodiscard]] std::size_t count_all() const {
         std::size_t cnt{0};
-        for(auto &opt : options_) {
+        for(const auto &opt : options_) {
             cnt += opt->count();
         }
-        for(auto &sub : subcommands_) {
+        for(const auto &sub : subcommands_) {
             cnt += sub->count_all();
         }
         if(!get_name().empty()) {  // for named subcommands add the number of times the subcommand was called
@@ -1345,11 +1345,11 @@ class App {
     ///@{
 
     /// Counts the number of times the given option was passed.
-    std::size_t count(std::string option_name) const { return get_option(option_name)->count(); }
+    [[nodiscard]] std::size_t count(std::string option_name) const { return get_option(option_name)->count(); }
 
     /// Get a subcommand pointer list to the currently selected subcommands (after parsing by default, in command
     /// line order; use parsed = false to get the original definition list.)
-    std::vector<App *> get_subcommands() const { return parsed_subcommands_; }
+    [[nodiscard]] std::vector<App *> get_subcommands() const { return parsed_subcommands_; }
 
     /// Get a filtered subcommand pointer list from the original definition list. An empty function will provide all
     /// subcommands (const)
@@ -1393,7 +1393,9 @@ class App {
     }
 
     /// Check with name instead of pointer to see if subcommand was selected
-    bool got_subcommand(std::string subcommand_name) const { return get_subcommand(subcommand_name)->parsed_ > 0; }
+    [[nodiscard]] bool got_subcommand(std::string subcommand_name) const {
+        return get_subcommand(subcommand_name)->parsed_ > 0;
+    }
 
     /// Sets excluded options for the subcommand
     App *excludes(Option *opt) {
@@ -1455,7 +1457,7 @@ class App {
         if(iterator == std::end(exclude_subcommands_)) {
             return false;
         }
-        auto other_app = *iterator;
+        auto *other_app = *iterator;
         exclude_subcommands_.erase(iterator);
         other_app->remove_excludes(this);
         return true;
@@ -1497,13 +1499,13 @@ class App {
     }
     /// Produce a string that could be read in as a config of the current values of the App. Set default_also to
     /// include default arguments. write_descriptions will print a description for the App and for each option.
-    std::string config_to_str(bool default_also = false, bool write_description = false) const {
+    [[nodiscard]] std::string config_to_str(bool default_also = false, bool write_description = false) const {
         return config_formatter_->to_config(this, default_also, write_description, "");
     }
 
     /// Makes a help message, using the currently configured formatter
     /// Will only do one subcommand at a time
-    std::string help(std::string prev = "", AppFormatMode mode = AppFormatMode::Normal) const {
+    [[nodiscard]] std::string help(std::string prev = "", AppFormatMode mode = AppFormatMode::Normal) const {
         if(prev.empty())
             prev = get_name();
         else
@@ -1518,7 +1520,7 @@ class App {
     }
 
     /// Displays a version string
-    std::string version() const {
+    [[nodiscard]] std::string version() const {
         std::string val;
         if(version_ptr_ != nullptr) {
             auto rv = version_ptr_->results();
@@ -1539,13 +1541,13 @@ class App {
     ///@{
 
     /// Access the formatter
-    std::shared_ptr<FormatterBase> get_formatter() const { return formatter_; }
+    [[nodiscard]] std::shared_ptr<FormatterBase> get_formatter() const { return formatter_; }
 
     /// Access the config formatter
-    std::shared_ptr<Config> get_config_formatter() const { return config_formatter_; }
+    [[nodiscard]] std::shared_ptr<Config> get_config_formatter() const { return config_formatter_; }
 
     /// Access the config formatter as a configBase pointer
-    std::shared_ptr<ConfigBase> get_config_formatter_base() const {
+    [[nodiscard]] std::shared_ptr<ConfigBase> get_config_formatter_base() const {
         // This is safer as a dynamic_cast if we have RTTI, as Config -> ConfigBase
 #if CLI11_USE_STATIC_RTTI == 0
         return std::dynamic_pointer_cast<ConfigBase>(config_formatter_);
@@ -1555,7 +1557,7 @@ class App {
     }
 
     /// Get the app or subcommand description
-    std::string get_description() const { return description_; }
+    [[nodiscard]] std::string get_description() const { return description_; }
 
     /// Set the description of the app
     App *description(std::string app_description) {
@@ -1606,7 +1608,7 @@ class App {
         for(auto &subc : subcommands_) {
             // also check down into nameless subcommands
             if(subc->get_name().empty()) {
-                auto opt = subc->get_option_no_throw(option_name);
+                auto *opt = subc->get_option_no_throw(option_name);
                 if(opt != nullptr) {
                     return opt;
                 }
@@ -1616,7 +1618,7 @@ class App {
     }
 
     /// Get an option by name (noexcept const version)
-    const Option *get_option_no_throw(std::string option_name) const noexcept {
+    [[nodiscard]] const Option *get_option_no_throw(std::string option_name) const noexcept {
         for(const Option_p &opt : options_) {
             if(opt->check_name(option_name)) {
                 return opt.get();
@@ -1625,7 +1627,7 @@ class App {
         for(const auto &subc : subcommands_) {
             // also check down into nameless subcommands
             if(subc->get_name().empty()) {
-                auto opt = subc->get_option_no_throw(option_name);
+                auto *opt = subc->get_option_no_throw(option_name);
                 if(opt != nullptr) {
                     return opt;
                 }
@@ -1635,8 +1637,8 @@ class App {
     }
 
     /// Get an option by name
-    const Option *get_option(std::string option_name) const {
-        auto opt = get_option_no_throw(option_name);
+    [[nodiscard]] const Option *get_option(std::string option_name) const {
+        const auto *opt = get_option_no_throw(option_name);
         if(opt == nullptr) {
             throw OptionNotFound(option_name);
         }
@@ -1645,7 +1647,7 @@ class App {
 
     /// Get an option by name (non-const version)
     Option *get_option(std::string option_name) {
-        auto opt = get_option_no_throw(option_name);
+        auto *opt = get_option_no_throw(option_name);
         if(opt == nullptr) {
             throw OptionNotFound(option_name);
         }
@@ -1659,104 +1661,106 @@ class App {
     const Option *operator[](const char *option_name) const { return get_option(option_name); }
 
     /// Check the status of ignore_case
-    bool get_ignore_case() const { return ignore_case_; }
+    [[nodiscard]] bool get_ignore_case() const { return ignore_case_; }
 
     /// Check the status of ignore_underscore
-    bool get_ignore_underscore() const { return ignore_underscore_; }
+    [[nodiscard]] bool get_ignore_underscore() const { return ignore_underscore_; }
 
     /// Check the status of fallthrough
-    bool get_fallthrough() const { return fallthrough_; }
+    [[nodiscard]] bool get_fallthrough() const { return fallthrough_; }
 
     /// Check the status of the allow windows style options
-    bool get_allow_windows_style_options() const { return allow_windows_style_options_; }
+    [[nodiscard]] bool get_allow_windows_style_options() const { return allow_windows_style_options_; }
 
     /// Check the status of the allow windows style options
-    bool get_positionals_at_end() const { return positionals_at_end_; }
+    [[nodiscard]] bool get_positionals_at_end() const { return positionals_at_end_; }
 
     /// Check the status of the allow windows style options
-    bool get_configurable() const { return configurable_; }
+    [[nodiscard]] bool get_configurable() const { return configurable_; }
 
     /// Get the group of this subcommand
-    const std::string &get_group() const { return group_; }
+    [[nodiscard]] const std::string &get_group() const { return group_; }
 
     /// Generate and return the footer.
-    std::string get_footer() const { return (footer_callback_) ? footer_callback_() + '\n' + footer_ : footer_; }
+    [[nodiscard]] std::string get_footer() const {
+        return (footer_callback_) ? footer_callback_() + '\n' + footer_ : footer_;
+    }
 
     /// Get the required min subcommand value
-    std::size_t get_require_subcommand_min() const { return require_subcommand_min_; }
+    [[nodiscard]] std::size_t get_require_subcommand_min() const { return require_subcommand_min_; }
 
     /// Get the required max subcommand value
-    std::size_t get_require_subcommand_max() const { return require_subcommand_max_; }
+    [[nodiscard]] std::size_t get_require_subcommand_max() const { return require_subcommand_max_; }
 
     /// Get the required min option value
-    std::size_t get_require_option_min() const { return require_option_min_; }
+    [[nodiscard]] std::size_t get_require_option_min() const { return require_option_min_; }
 
     /// Get the required max option value
-    std::size_t get_require_option_max() const { return require_option_max_; }
+    [[nodiscard]] std::size_t get_require_option_max() const { return require_option_max_; }
 
     /// Get the prefix command status
-    bool get_prefix_command() const { return prefix_command_; }
+    [[nodiscard]] bool get_prefix_command() const { return prefix_command_; }
 
     /// Get the status of allow extras
-    bool get_allow_extras() const { return allow_extras_; }
+    [[nodiscard]] bool get_allow_extras() const { return allow_extras_; }
 
     /// Get the status of required
-    bool get_required() const { return required_; }
+    [[nodiscard]] bool get_required() const { return required_; }
 
     /// Get the status of disabled
-    bool get_disabled() const { return disabled_; }
+    [[nodiscard]] bool get_disabled() const { return disabled_; }
 
     /// Get the status of silence
-    bool get_silent() const { return silent_; }
+    [[nodiscard]] bool get_silent() const { return silent_; }
 
     /// Get the status of disabled
-    bool get_immediate_callback() const { return immediate_callback_; }
+    [[nodiscard]] bool get_immediate_callback() const { return immediate_callback_; }
 
     /// Get the status of disabled by default
-    bool get_disabled_by_default() const { return (default_startup == startup_mode::disabled); }
+    [[nodiscard]] bool get_disabled_by_default() const { return (default_startup == startup_mode::disabled); }
 
     /// Get the status of disabled by default
-    bool get_enabled_by_default() const { return (default_startup == startup_mode::enabled); }
+    [[nodiscard]] bool get_enabled_by_default() const { return (default_startup == startup_mode::enabled); }
     /// Get the status of validating positionals
-    bool get_validate_positionals() const { return validate_positionals_; }
+    [[nodiscard]] bool get_validate_positionals() const { return validate_positionals_; }
     /// Get the status of validating optional vector arguments
-    bool get_validate_optional_arguments() const { return validate_optional_arguments_; }
+    [[nodiscard]] bool get_validate_optional_arguments() const { return validate_optional_arguments_; }
 
     /// Get the status of allow extras
-    config_extras_mode get_allow_config_extras() const { return allow_config_extras_; }
+    [[nodiscard]] config_extras_mode get_allow_config_extras() const { return allow_config_extras_; }
 
     /// Get a pointer to the help flag.
     Option *get_help_ptr() { return help_ptr_; }
 
     /// Get a pointer to the help flag. (const)
-    const Option *get_help_ptr() const { return help_ptr_; }
+    [[nodiscard]] const Option *get_help_ptr() const { return help_ptr_; }
 
     /// Get a pointer to the help all flag. (const)
-    const Option *get_help_all_ptr() const { return help_all_ptr_; }
+    [[nodiscard]] const Option *get_help_all_ptr() const { return help_all_ptr_; }
 
     /// Get a pointer to the config option.
     Option *get_config_ptr() { return config_ptr_; }
 
     /// Get a pointer to the config option. (const)
-    const Option *get_config_ptr() const { return config_ptr_; }
+    [[nodiscard]] const Option *get_config_ptr() const { return config_ptr_; }
 
     /// Get a pointer to the version option.
     Option *get_version_ptr() { return version_ptr_; }
 
     /// Get a pointer to the version option. (const)
-    const Option *get_version_ptr() const { return version_ptr_; }
+    [[nodiscard]] const Option *get_version_ptr() const { return version_ptr_; }
 
     /// Get the parent of this subcommand (or nullptr if main app)
     App *get_parent() { return parent_; }
 
     /// Get the parent of this subcommand (or nullptr if main app) (const version)
-    const App *get_parent() const { return parent_; }
+    [[nodiscard]] const App *get_parent() const { return parent_; }
 
     /// Get the name of the current app
-    const std::string &get_name() const { return name_; }
+    [[nodiscard]] const std::string &get_name() const { return name_; }
 
     /// Get the aliases of the current app
-    const std::vector<std::string> &get_aliases() const { return aliases_; }
+    [[nodiscard]] const std::vector<std::string> &get_aliases() const { return aliases_; }
 
     /// clear all the aliases of the current App
     App *clear_aliases() {
@@ -1765,7 +1769,7 @@ class App {
     }
 
     /// Get a display name for an app
-    std::string get_display_name(bool with_aliases = false) const {
+    [[nodiscard]] std::string get_display_name(bool with_aliases = false) const {
         if(name_.empty()) {
             return std::string("[Option Group: ") + get_group() + "]";
         }
@@ -1782,7 +1786,7 @@ class App {
     }
 
     /// Check the name, case insensitive and underscore insensitive if set
-    bool check_name(std::string name_to_check) const {
+    [[nodiscard]] bool check_name(std::string name_to_check) const {
         std::string local_name = name_;
         if(ignore_underscore_) {
             local_name = detail::remove_underscore(name_);
@@ -1796,7 +1800,7 @@ class App {
         if(local_name == name_to_check) {
             return true;
         }
-        for(auto les : aliases_) {
+        for(auto les : aliases_) {  // NOLINT(performance-for-range-copy)
             if(ignore_underscore_) {
                 les = detail::remove_underscore(les);
             }
@@ -1811,7 +1815,7 @@ class App {
     }
 
     /// Get the groups available directly from this option (in order)
-    std::vector<std::string> get_groups() const {
+    [[nodiscard]] std::vector<std::string> get_groups() const {
         std::vector<std::string> groups;
 
         for(const Option_p &opt : options_) {
@@ -1825,10 +1829,10 @@ class App {
     }
 
     /// This gets a vector of pointers with the original parse order
-    const std::vector<Option *> &parse_order() const { return parse_order_; }
+    [[nodiscard]] const std::vector<Option *> &parse_order() const { return parse_order_; }
 
     /// This returns the missing options from the current subcommand
-    std::vector<std::string> remaining(bool recurse = false) const {
+    [[nodiscard]] std::vector<std::string> remaining(bool recurse = false) const {
         std::vector<std::string> miss_list;
         for(const std::pair<detail::Classifier, std::string> &miss : missing_) {
             miss_list.push_back(std::get<1>(miss));
@@ -1855,14 +1859,14 @@ class App {
     }
 
     /// This returns the missing options in a form ready for processing by another command line program
-    std::vector<std::string> remaining_for_passthrough(bool recurse = false) const {
+    [[nodiscard]] std::vector<std::string> remaining_for_passthrough(bool recurse = false) const {
         std::vector<std::string> miss_list = remaining(recurse);
         std::reverse(std::begin(miss_list), std::end(miss_list));
         return miss_list;
     }
 
     /// This returns the number of remaining options, minus the -- separator
-    std::size_t remaining_size(bool recurse = false) const {
+    [[nodiscard]] std::size_t remaining_size(bool recurse = false) const {
         auto remaining_options = static_cast<std::size_t>(std::count_if(
             std::begin(missing_), std::end(missing_), [](const std::pair<detail::Classifier, std::string> &val) {
                 return val.first != detail::Classifier::POSITIONAL_MARK;
@@ -1971,12 +1975,12 @@ class App {
     }
 
     /// Check to see if a subcommand is valid. Give up immediately if subcommand max has been reached.
-    bool _valid_subcommand(const std::string &current, bool ignore_used = true) const {
+    [[nodiscard]] bool _valid_subcommand(const std::string &current, bool ignore_used = true) const {
         // Don't match if max has been reached - but still check parents
         if(require_subcommand_max_ != 0 && parsed_subcommands_.size() >= require_subcommand_max_) {
             return parent_ != nullptr && parent_->_valid_subcommand(current, ignore_used);
         }
-        auto com = _find_subcommand(current, true, ignore_used);
+        auto *com = _find_subcommand(current, true, ignore_used);
         if(com != nullptr) {
             return true;
         }
@@ -1985,7 +1989,7 @@ class App {
     }
 
     /// Selects a Classifier enum based on the type of the current argument
-    detail::Classifier _recognize(const std::string &current, bool ignore_used_subcommands = true) const {
+    [[nodiscard]] detail::Classifier _recognize(const std::string &current, bool ignore_used_subcommands = true) const {
         std::string dummy1, dummy2;
 
         if(current == "--")
@@ -2132,13 +2136,13 @@ class App {
         // check excludes
         bool excluded{false};
         std::string excluder;
-        for(auto &opt : exclude_options_) {
+        for(const auto &opt : exclude_options_) {
             if(opt->count() > 0) {
                 excluded = true;
                 excluder = opt->get_name();
             }
         }
-        for(auto &subc : exclude_subcommands_) {
+        for(const auto &subc : exclude_subcommands_) {
             if(subc->count_all() > 0) {
                 excluded = true;
                 excluder = subc->get_display_name();
@@ -2155,13 +2159,13 @@ class App {
         // check excludes
         bool missing_needed{false};
         std::string missing_need;
-        for(auto &opt : need_options_) {
+        for(const auto &opt : need_options_) {
             if(opt->count() == 0) {
                 missing_needed = true;
                 missing_need = opt->get_name();
             }
         }
-        for(auto &subc : need_subcommands_) {
+        for(const auto &subc : need_subcommands_) {
             if(subc->count_all() == 0) {
                 missing_needed = true;
                 missing_need = subc->get_display_name();
@@ -2392,7 +2396,7 @@ class App {
     bool _parse_single_config(const ConfigItem &item, std::size_t level = 0) {
         if(level < item.parents.size()) {
             try {
-                auto subcom = get_subcommand(item.parents.at(level));
+                auto *subcom = get_subcommand(item.parents.at(level));
                 auto result = subcom->_parse_single_config(item, level + 1);
 
                 return result;
@@ -2507,7 +2511,7 @@ class App {
     }
 
     /// Count the required remaining positional arguments
-    std::size_t _count_remaining_positionals(bool required_only = false) const {
+    [[nodiscard]] std::size_t _count_remaining_positionals(bool required_only = false) const {
         std::size_t retval = 0;
         for(const Option_p &opt : options_) {
             if(opt->get_positional() && (!required_only || opt->get_required())) {
@@ -2521,7 +2525,7 @@ class App {
     }
 
     /// Count the required remaining positional arguments
-    bool _has_remaining_positionals() const {
+    [[nodiscard]] bool _has_remaining_positionals() const {
         for(const Option_p &opt : options_) {
             if(opt->get_positional() && ((static_cast<int>(opt->count()) < opt->get_items_expected_min()))) {
                 return true;
@@ -2556,7 +2560,7 @@ class App {
 
                             parse_order_.push_back(opt.get());
                             /// if we require a separator add it here
-                            if(opt->get_inject_separator()) {
+                            if(opt->get_inject_separator() != 0) {
                                 if(!opt->results().empty() && !opt->results().back().empty()) {
                                     opt->add_result(std::string{});
                                 }
@@ -2587,7 +2591,7 @@ class App {
                         continue;
                     }
                 }
-                if(opt->get_inject_separator()) {
+                if(opt->get_inject_separator() != 0) {
                     if(!opt->results().empty() && !opt->results().back().empty()) {
                         opt->add_result(std::string{});
                     }
@@ -2620,7 +2624,7 @@ class App {
             return _get_fallthrough_parent()->_parse_positional(args, static_cast<bool>(parse_complete_callback_));
 
         /// Try to find a local subcommand that is repeated
-        auto com = _find_subcommand(args.back(), true, false);
+        auto *com = _find_subcommand(args.back(), true, false);
         if(com != nullptr && (require_subcommand_max_ == 0 || require_subcommand_max_ > parsed_subcommands_.size())) {
             if(haltOnSubcommand) {
                 return false;
@@ -2631,7 +2635,7 @@ class App {
         }
         /// now try one last gasp at subcommands that have been executed before, go to root app and try to find a
         /// subcommand in a broader way, if one exists let the parent deal with it
-        auto parent_app = (parent_ != nullptr) ? _get_fallthrough_parent() : this;
+        auto *parent_app = (parent_ != nullptr) ? _get_fallthrough_parent() : this;
         com = parent_app->_find_subcommand(args.back(), true, false);
         if(com != nullptr && (com->parent_->require_subcommand_max_ == 0 ||
                               com->parent_->require_subcommand_max_ > com->parent_->parsed_subcommands_.size())) {
@@ -2660,12 +2664,13 @@ class App {
 
     /// Locate a subcommand by name with two conditions, should disabled subcommands be ignored, and should used
     /// subcommands be ignored
-    App *_find_subcommand(const std::string &subc_name, bool ignore_disabled, bool ignore_used) const noexcept {
+    [[nodiscard]] App *
+    _find_subcommand(const std::string &subc_name, bool ignore_disabled, bool ignore_used) const noexcept {
         for(const App_p &com : subcommands_) {
             if(com->disabled_ && ignore_disabled)
                 continue;
             if(com->get_name().empty()) {
-                auto subc = com->_find_subcommand(subc_name, ignore_disabled, ignore_used);
+                auto *subc = com->_find_subcommand(subc_name, ignore_disabled, ignore_used);
                 if(subc != nullptr) {
                     return subc;
                 }
@@ -2687,14 +2692,14 @@ class App {
             _parse_positional(args, false);
             return true;
         }
-        auto com = _find_subcommand(args.back(), true, true);
+        auto *com = _find_subcommand(args.back(), true, true);
         if(com != nullptr) {
             args.pop_back();
             if(!com->silent_) {
                 parsed_subcommands_.push_back(com);
             }
             com->_parse(args);
-            auto parent_app = com->parent_;
+            auto *parent_app = com->parent_;
             while(parent_app != this) {
                 parent_app->_trigger_pre_parse(args.size());
                 if(!com->silent_) {
@@ -2784,7 +2789,7 @@ class App {
         // Get a reference to the pointer to make syntax bearable
         Option_p &op = *op_ptr;
         /// if we require a separator add it here
-        if(op->get_inject_separator()) {
+        if(op->get_inject_separator() != 0) {
             if(!op->results().empty() && !op->results().back().empty()) {
                 op->add_result(std::string{});
             }
@@ -2908,7 +2913,7 @@ class App {
         if(parent_ == nullptr) {
             throw(HorribleError("No Valid parent"));
         }
-        auto fallthrough_parent = parent_;
+        auto *fallthrough_parent = parent_;
         while((fallthrough_parent->parent_ != nullptr) && (fallthrough_parent->get_name().empty())) {
             fallthrough_parent = fallthrough_parent->parent_;
         }
@@ -2916,12 +2921,12 @@ class App {
     }
 
     /// Helper function to run through all possible comparisons of subcommand names to check there is no overlap
-    const std::string &_compare_subcommand_names(const App &subcom, const App &base) const {
+    [[nodiscard]] const std::string &_compare_subcommand_names(const App &subcom, const App &base) const {
         static const std::string estring;
         if(subcom.disabled_) {
             return estring;
         }
-        for(auto &subc : base.subcommands_) {
+        for(const auto &subc : base.subcommands_) {
             if(subc.get() != &subcom) {
                 if(subc->disabled_) {
                     continue;
@@ -2949,14 +2954,14 @@ class App {
                 }
                 // if the subcommand is an option group we need to check deeper
                 if(subc->get_name().empty()) {
-                    auto &cmpres = _compare_subcommand_names(subcom, *subc);
+                    const auto &cmpres = _compare_subcommand_names(subcom, *subc);
                     if(!cmpres.empty()) {
                         return cmpres;
                     }
                 }
                 // if the test subcommand is an option group we need to check deeper
                 if(subcom.get_name().empty()) {
-                    auto &cmpres = _compare_subcommand_names(*subc, subcom);
+                    const auto &cmpres = _compare_subcommand_names(*subc, subcom);
                     if(!cmpres.empty()) {
                         return cmpres;
                     }
@@ -3072,7 +3077,7 @@ inline void TriggerOn(App *trigger_app, std::vector<App *> apps_to_enable) {
     }
 
     trigger_app->preparse_callback([apps_to_enable](std::size_t) {
-        for(auto &app : apps_to_enable) {
+        for(const auto &app : apps_to_enable) {
             app->disabled(false);
         }
     });
@@ -3093,7 +3098,7 @@ inline void TriggerOff(App *trigger_app, std::vector<App *> apps_to_enable) {
     }
 
     trigger_app->preparse_callback([apps_to_enable](std::size_t) {
-        for(auto &app : apps_to_enable) {
+        for(const auto &app : apps_to_enable) {
             app->disabled();
         }
     });
@@ -3116,31 +3121,31 @@ inline void deprecate_option(Option *opt, const std::string &replacement = "") {
 
 /// Helper function to mark an option as deprecated
 inline void deprecate_option(App *app, const std::string &option_name, const std::string &replacement = "") {
-    auto opt = app->get_option(option_name);
+    auto *opt = app->get_option(option_name);
     deprecate_option(opt, replacement);
 }
 
 /// Helper function to mark an option as deprecated
 inline void deprecate_option(App &app, const std::string &option_name, const std::string &replacement = "") {
-    auto opt = app.get_option(option_name);
+    auto *opt = app.get_option(option_name);
     deprecate_option(opt, replacement);
 }
 
 /// Helper function to mark an option as retired
 inline void retire_option(App *app, Option *opt) {
     App temp;
-    auto option_copy = temp.add_option(opt->get_name(false, true))
-                           ->type_size(opt->get_type_size_min(), opt->get_type_size_max())
-                           ->expected(opt->get_expected_min(), opt->get_expected_max())
-                           ->allow_extra_args(opt->get_allow_extra_args());
+    auto *option_copy = temp.add_option(opt->get_name(false, true))
+                            ->type_size(opt->get_type_size_min(), opt->get_type_size_max())
+                            ->expected(opt->get_expected_min(), opt->get_expected_max())
+                            ->allow_extra_args(opt->get_allow_extra_args());
 
     app->remove_option(opt);
-    auto opt2 = app->add_option(option_copy->get_name(false, true), "option has been retired and has no effect")
-                    ->type_name("RETIRED")
-                    ->default_str("RETIRED")
-                    ->type_size(option_copy->get_type_size_min(), option_copy->get_type_size_max())
-                    ->expected(option_copy->get_expected_min(), option_copy->get_expected_max())
-                    ->allow_extra_args(option_copy->get_allow_extra_args());
+    auto *opt2 = app->add_option(option_copy->get_name(false, true), "option has been retired and has no effect")
+                     ->type_name("RETIRED")
+                     ->default_str("RETIRED")
+                     ->type_size(option_copy->get_type_size_min(), option_copy->get_type_size_max())
+                     ->expected(option_copy->get_expected_min(), option_copy->get_expected_max())
+                     ->allow_extra_args(option_copy->get_allow_extra_args());
 
     Validator retired_warning{[opt2](std::string &) {
                                   std::cout << "WARNING " << opt2->get_name() << " is retired and has no effect\n";
@@ -3157,15 +3162,15 @@ inline void retire_option(App &app, Option *opt) { retire_option(&app, opt); }
 /// Helper function to mark an option as retired
 inline void retire_option(App *app, const std::string &option_name) {
 
-    auto opt = app->get_option_no_throw(option_name);
+    auto *opt = app->get_option_no_throw(option_name);
     if(opt != nullptr) {
         retire_option(app, opt);
         return;
     }
-    auto opt2 = app->add_option(option_name, "option has been retired and has no effect")
-                    ->type_name("RETIRED")
-                    ->expected(0, 1)
-                    ->default_str("RETIRED");
+    auto *opt2 = app->add_option(option_name, "option has been retired and has no effect")
+                     ->type_name("RETIRED")
+                     ->expected(0, 1)
+                     ->default_str("RETIRED");
     Validator retired_warning{[opt2](std::string &) {
                                   std::cout << "WARNING " << opt2->get_name() << " is retired and has no effect\n";
                                   return std::string();

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -82,7 +82,7 @@ inline std::string ini_join(const std::vector<std::string> &args,
     for(const auto &arg : args) {
         if(start++ > 0) {
             joined.push_back(sepChar);
-            if(std::isspace(sepChar) == 0) {
+            if(std::isspace<char>(sepChar, std::local()) == 0) {
                 joined.push_back(' ');
             }
         }

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -8,6 +8,7 @@
 
 // [CLI11:public_includes:set]
 #include <algorithm>
+#include <cctype>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -81,7 +82,7 @@ inline std::string ini_join(const std::vector<std::string> &args,
     for(const auto &arg : args) {
         if(start++ > 0) {
             joined.push_back(sepChar);
-            if(isspace(sepChar) == 0) {
+            if(std::isspace(sepChar) == 0) {
                 joined.push_back(' ');
             }
         }

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -25,7 +25,7 @@ namespace detail {
 
 inline std::string convert_arg_for_ini(const std::string &arg, char stringQuote = '"', char characterQuote = '\'') {
     if(arg.empty()) {
-        return {2, stringQuote};
+        return std::string(2, stringQuote);
     }
     // some specifically supported strings
     if(arg == "true" || arg == "false" || arg == "nan" || arg == "inf") {

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -25,7 +25,7 @@ namespace detail {
 
 inline std::string convert_arg_for_ini(const std::string &arg, char stringQuote = '"', char characterQuote = '\'') {
     if(arg.empty()) {
-        return std::string(2, stringQuote);
+        return {2, stringQuote};
     }
     // some specifically supported strings
     if(arg == "true" || arg == "false" || arg == "nan" || arg == "inf") {
@@ -33,7 +33,7 @@ inline std::string convert_arg_for_ini(const std::string &arg, char stringQuote 
     }
     // floating point conversion can convert some hex codes, but don't try that here
     if(arg.compare(0, 2, "0x") != 0 && arg.compare(0, 2, "0X") != 0) {
-        double val;
+        double val = 0.0;
         if(detail::lexical_cast(arg, val)) {
             return arg;
         }
@@ -62,9 +62,8 @@ inline std::string convert_arg_for_ini(const std::string &arg, char stringQuote 
     }
     if(arg.find_first_of(stringQuote) == std::string::npos) {
         return std::string(1, stringQuote) + arg + stringQuote;
-    } else {
-        return characterQuote + arg + characterQuote;
     }
+    return characterQuote + arg + characterQuote;
 }
 
 /// Comma separated join, adds quotes if needed
@@ -230,7 +229,7 @@ inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) cons
             std::string item = detail::trim_copy(line.substr(pos + 1));
             auto cloc = item.find(commentChar);
             if(cloc != std::string::npos) {
-                item.erase(cloc, std::string::npos);
+                item.erase(cloc, std::string::npos);  // NOLINT(readability-suspicious-call-argument)
                 detail::trim(item);
             }
             if(item.size() > 1 && item.front() == aStart) {
@@ -250,7 +249,7 @@ inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) cons
             name = detail::trim_copy(line);
             auto cloc = name.find(commentChar);
             if(cloc != std::string::npos) {
-                name.erase(cloc, std::string::npos);
+                name.erase(cloc, std::string::npos);  // NOLINT(readability-suspicious-call-argument)
                 detail::trim(name);
             }
 
@@ -374,7 +373,7 @@ ConfigBase::to_config(const App *app, bool default_also, bool write_description,
                     out << '[' << prefix << subcom->get_name() << "]\n";
                 } else {
                     std::string subname = app->get_name() + parentSeparatorChar + subcom->get_name();
-                    auto p = app->get_parent();
+                    const auto *p = app->get_parent();
                     while(p->get_parent() != nullptr) {
                         subname = p->get_name() + parentSeparatorChar + subname;
                         p = p->get_parent();

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -82,7 +82,7 @@ inline std::string ini_join(const std::vector<std::string> &args,
     for(const auto &arg : args) {
         if(start++ > 0) {
             joined.push_back(sepChar);
-            if(std::isspace<char>(sepChar, std::locale()) {
+            if(std::isspace<char>(sepChar, std::locale())) {
                 joined.push_back(' ');
             }
         }

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -82,7 +82,7 @@ inline std::string ini_join(const std::vector<std::string> &args,
     for(const auto &arg : args) {
         if(start++ > 0) {
             joined.push_back(sepChar);
-            if(std::isspace<char>(sepChar, std::locale()) == 0) {
+            if(std::isspace<char>(sepChar, std::locale()) {
                 joined.push_back(' ');
             }
         }

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -82,7 +82,7 @@ inline std::string ini_join(const std::vector<std::string> &args,
     for(const auto &arg : args) {
         if(start++ > 0) {
             joined.push_back(sepChar);
-            if(std::isspace<char>(sepChar, std::local()) == 0) {
+            if(std::isspace<char>(sepChar, std::locale()) == 0) {
                 joined.push_back(' ');
             }
         }

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -82,7 +82,7 @@ inline std::string ini_join(const std::vector<std::string> &args,
     for(const auto &arg : args) {
         if(start++ > 0) {
             joined.push_back(sepChar);
-            if(std::isspace<char>(sepChar, std::locale())) {
+            if(!std::isspace<char>(sepChar, std::locale())) {
                 joined.push_back(' ');
             }
         }

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -34,7 +34,7 @@ struct ConfigItem {
     std::vector<std::string> inputs{};
 
     /// The list of parents and name joined by "."
-    [[nodiscard]] std::string fullname() const {
+    CLI11_NODISCARD std::string fullname() const {
         std::vector<std::string> tmp = parents;
         tmp.emplace_back(name);
         return detail::join(tmp, ".");
@@ -54,7 +54,7 @@ class Config {
     virtual std::vector<ConfigItem> from_config(std::istream &) const = 0;
 
     /// Get a flag value
-    [[nodiscard]] virtual std::string to_flag(const ConfigItem &item) const {
+    CLI11_NODISCARD virtual std::string to_flag(const ConfigItem &item) const {
         if(item.inputs.size() == 1) {
             return item.inputs.at(0);
         }
@@ -65,7 +65,7 @@ class Config {
     }
 
     /// Parse a config file, throw an error (ParseError:ConfigParseError or FileError) on failure
-    [[nodiscard]] std::vector<ConfigItem> from_file(const std::string &name) const {
+    CLI11_NODISCARD std::vector<ConfigItem> from_file(const std::string &name) const {
         std::ifstream input{name};
         if(!input.good())
             throw FileError::Missing(name);
@@ -148,7 +148,7 @@ class ConfigBase : public Config {
     /// get a reference to the configuration section
     std::string &sectionRef() { return configSection; }
     /// get the section
-    [[nodiscard]] const std::string &section() const { return configSection; }
+    CLI11_NODISCARD const std::string &section() const { return configSection; }
     /// specify a particular section of the configuration file to use
     ConfigBase *section(const std::string &sectionName) {
         configSection = sectionName;
@@ -158,7 +158,7 @@ class ConfigBase : public Config {
     /// get a reference to the configuration index
     int16_t &indexRef() { return configIndex; }
     /// get the section index
-    [[nodiscard]] int16_t index() const { return configIndex; }
+    CLI11_NODISCARD int16_t index() const { return configIndex; }
     /// specify a particular index in the section to use (-1) for all sections to use
     ConfigBase *index(int16_t sectionIndex) {
         configIndex = sectionIndex;

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -34,7 +34,7 @@ struct ConfigItem {
     std::vector<std::string> inputs{};
 
     /// The list of parents and name joined by "."
-    std::string fullname() const {
+    [[nodiscard]] std::string fullname() const {
         std::vector<std::string> tmp = parents;
         tmp.emplace_back(name);
         return detail::join(tmp, ".");
@@ -54,7 +54,7 @@ class Config {
     virtual std::vector<ConfigItem> from_config(std::istream &) const = 0;
 
     /// Get a flag value
-    virtual std::string to_flag(const ConfigItem &item) const {
+    [[nodiscard]] virtual std::string to_flag(const ConfigItem &item) const {
         if(item.inputs.size() == 1) {
             return item.inputs.at(0);
         }
@@ -65,7 +65,7 @@ class Config {
     }
 
     /// Parse a config file, throw an error (ParseError:ConfigParseError or FileError) on failure
-    std::vector<ConfigItem> from_file(const std::string &name) {
+    [[nodiscard]] std::vector<ConfigItem> from_file(const std::string &name) const {
         std::ifstream input{name};
         if(!input.good())
             throw FileError::Missing(name);
@@ -148,7 +148,7 @@ class ConfigBase : public Config {
     /// get a reference to the configuration section
     std::string &sectionRef() { return configSection; }
     /// get the section
-    const std::string &section() const { return configSection; }
+    [[nodiscard]] const std::string &section() const { return configSection; }
     /// specify a particular section of the configuration file to use
     ConfigBase *section(const std::string &sectionName) {
         configSection = sectionName;
@@ -158,7 +158,7 @@ class ConfigBase : public Config {
     /// get a reference to the configuration index
     int16_t &indexRef() { return configIndex; }
     /// get the section index
-    int16_t index() const { return configIndex; }
+    [[nodiscard]] int16_t index() const { return configIndex; }
     /// specify a particular index in the section to use (-1) for all sections to use
     ConfigBase *index(int16_t sectionIndex) {
         configIndex = sectionIndex;

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -72,9 +72,9 @@ class Error : public std::runtime_error {
     std::string error_name{"Error"};
 
   public:
-    int get_exit_code() const { return actual_exit_code; }
+    [[nodiscard]] int get_exit_code() const { return actual_exit_code; }
 
-    std::string get_name() const { return error_name; }
+    [[nodiscard]] std::string get_name() const { return error_name; }
 
     Error(std::string name, std::string msg, int exit_code = static_cast<int>(ExitCodes::BaseClass))
         : runtime_error(msg), actual_exit_code(exit_code), error_name(std::move(name)) {}
@@ -137,10 +137,10 @@ class OptionAlreadyAdded : public ConstructionError {
     explicit OptionAlreadyAdded(std::string name)
         : OptionAlreadyAdded(name + " is already added", ExitCodes::OptionAlreadyAdded) {}
     static OptionAlreadyAdded Requires(std::string name, std::string other) {
-        return OptionAlreadyAdded(name + " requires " + other, ExitCodes::OptionAlreadyAdded);
+        return {name + " requires " + other, ExitCodes::OptionAlreadyAdded};
     }
     static OptionAlreadyAdded Excludes(std::string name, std::string other) {
-        return OptionAlreadyAdded(name + " excludes " + other, ExitCodes::OptionAlreadyAdded);
+        return {name + " excludes " + other, ExitCodes::OptionAlreadyAdded};
     }
 };
 
@@ -223,32 +223,30 @@ class RequiredError : public ParseError {
         if(min_subcom == 1) {
             return RequiredError("A subcommand");
         }
-        return RequiredError("Requires at least " + std::to_string(min_subcom) + " subcommands",
-                             ExitCodes::RequiredError);
+        return {"Requires at least " + std::to_string(min_subcom) + " subcommands", ExitCodes::RequiredError};
     }
     static RequiredError
     Option(std::size_t min_option, std::size_t max_option, std::size_t used, const std::string &option_list) {
         if((min_option == 1) && (max_option == 1) && (used == 0))
             return RequiredError("Exactly 1 option from [" + option_list + "]");
         if((min_option == 1) && (max_option == 1) && (used > 1)) {
-            return RequiredError("Exactly 1 option from [" + option_list + "] is required and " + std::to_string(used) +
-                                     " were given",
-                                 ExitCodes::RequiredError);
+            return {"Exactly 1 option from [" + option_list + "] is required and " + std::to_string(used) +
+                        " were given",
+                    ExitCodes::RequiredError};
         }
         if((min_option == 1) && (used == 0))
             return RequiredError("At least 1 option from [" + option_list + "]");
         if(used < min_option) {
-            return RequiredError("Requires at least " + std::to_string(min_option) + " options used and only " +
-                                     std::to_string(used) + "were given from [" + option_list + "]",
-                                 ExitCodes::RequiredError);
+            return {"Requires at least " + std::to_string(min_option) + " options used and only " +
+                        std::to_string(used) + "were given from [" + option_list + "]",
+                    ExitCodes::RequiredError};
         }
         if(max_option == 1)
-            return RequiredError("Requires at most 1 options be given from [" + option_list + "]",
-                                 ExitCodes::RequiredError);
+            return {"Requires at most 1 options be given from [" + option_list + "]", ExitCodes::RequiredError};
 
-        return RequiredError("Requires at most " + std::to_string(max_option) + " options be used and " +
-                                 std::to_string(used) + "were given from [" + option_list + "]",
-                             ExitCodes::RequiredError);
+        return {"Requires at most " + std::to_string(max_option) + " options be used and " + std::to_string(used) +
+                    "were given from [" + option_list + "]",
+                ExitCodes::RequiredError};
     }
 };
 

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -72,9 +72,9 @@ class Error : public std::runtime_error {
     std::string error_name{"Error"};
 
   public:
-    [[nodiscard]] int get_exit_code() const { return actual_exit_code; }
+    CLI11_NODISCARD int get_exit_code() const { return actual_exit_code; }
 
-    [[nodiscard]] std::string get_name() const { return error_name; }
+    CLI11_NODISCARD std::string get_name() const { return error_name; }
 
     Error(std::string name, std::string msg, int exit_code = static_cast<int>(ExitCodes::BaseClass))
         : runtime_error(msg), actual_exit_code(exit_code), error_name(std::move(name)) {}

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -35,7 +35,7 @@ inline std::string Formatter::make_positionals(const App *app) const {
         app->get_options([](const Option *opt) { return !opt->get_group().empty() && opt->get_positional(); });
 
     if(opts.empty())
-        return std::string();
+        return {};
 
     return make_group(get_label("Positionals"), true, opts);
 }

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -79,14 +79,14 @@ class FormatterBase {
     ///@{
 
     /// Get the current value of a name (REQUIRED, etc.)
-    [[nodiscard]] std::string get_label(std::string key) const {
+    CLI11_NODISCARD std::string get_label(std::string key) const {
         if(labels_.find(key) == labels_.end())
             return key;
         return labels_.at(key);
     }
 
     /// Get the current column width
-    [[nodiscard]] std::size_t get_column_width() const { return column_width_; }
+    CLI11_NODISCARD std::size_t get_column_width() const { return column_width_; }
 
     ///@}
 };
@@ -124,7 +124,7 @@ class Formatter : public FormatterBase {
 
     /// This prints out a group of options with title
     ///
-    [[nodiscard]] virtual std::string
+    CLI11_NODISCARD virtual std::string
     make_group(std::string group, bool is_positional, std::vector<const Option *> opts) const;
 
     /// This prints out just the positionals "group"

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -79,15 +79,14 @@ class FormatterBase {
     ///@{
 
     /// Get the current value of a name (REQUIRED, etc.)
-    std::string get_label(std::string key) const {
+    [[nodiscard]] std::string get_label(std::string key) const {
         if(labels_.find(key) == labels_.end())
             return key;
-        else
-            return labels_.at(key);
+        return labels_.at(key);
     }
 
     /// Get the current column width
-    std::size_t get_column_width() const { return column_width_; }
+    [[nodiscard]] std::size_t get_column_width() const { return column_width_; }
 
     ///@}
 };
@@ -125,7 +124,8 @@ class Formatter : public FormatterBase {
 
     /// This prints out a group of options with title
     ///
-    virtual std::string make_group(std::string group, bool is_positional, std::vector<const Option *> opts) const;
+    [[nodiscard]] virtual std::string
+    make_group(std::string group, bool is_positional, std::vector<const Option *> opts) const;
 
     /// This prints out just the positionals "group"
     virtual std::string make_positionals(const App *app) const;

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -41,6 +41,14 @@
 #define CLI11_DEPRECATED(reason) __attribute__((deprecated(reason)))
 #endif
 
+// GCC < 10 doesn't ignore this in unevaluated contexts
+#if !defined(CLI11_CPP17) ||                                                                                           \
+    (defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER) && __GNUC__ < 10 && __GNUC__ > 4)
+#define CLI11_NODISCARD
+#else
+#define CLI11_NODISCARD [[nodiscard]]
+#endif
+
 /** detection of rtti */
 #ifndef CLI11_USE_STATIC_RTTI
 #if(defined(_HAS_STATIC_RTTI) && _HAS_STATIC_RTTI)

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -690,7 +690,7 @@ class Option : public OptionBase<Option> {
     CLI11_NODISCARD int get_type_size_max() const { return type_size_max_; }
 
     /// Return the inject_separator flag
-    CLI11_NODISCARD int get_inject_separator() const { return static_cast<int>(inject_separator_); }
+    CLI11_NODISCARD bool get_inject_separator() const { return inject_separator_; }
 
     /// The environment variable associated to this value
     CLI11_NODISCARD std::string get_envname() const { return envname_; }

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -119,44 +119,44 @@ template <typename CRTP> class OptionBase {
     // Getters
 
     /// Get the group of this option
-    const std::string &get_group() const { return group_; }
+    [[nodiscard]] const std::string &get_group() const { return group_; }
 
     /// True if this is a required option
-    bool get_required() const { return required_; }
+    [[nodiscard]] bool get_required() const { return required_; }
 
     /// The status of ignore case
-    bool get_ignore_case() const { return ignore_case_; }
+    [[nodiscard]] bool get_ignore_case() const { return ignore_case_; }
 
     /// The status of ignore_underscore
-    bool get_ignore_underscore() const { return ignore_underscore_; }
+    [[nodiscard]] bool get_ignore_underscore() const { return ignore_underscore_; }
 
     /// The status of configurable
-    bool get_configurable() const { return configurable_; }
+    [[nodiscard]] bool get_configurable() const { return configurable_; }
 
     /// The status of configurable
-    bool get_disable_flag_override() const { return disable_flag_override_; }
+    [[nodiscard]] bool get_disable_flag_override() const { return disable_flag_override_; }
 
     /// Get the current delimiter char
-    char get_delimiter() const { return delimiter_; }
+    [[nodiscard]] char get_delimiter() const { return delimiter_; }
 
     /// Return true if this will automatically capture the default value for help printing
-    bool get_always_capture_default() const { return always_capture_default_; }
+    [[nodiscard]] bool get_always_capture_default() const { return always_capture_default_; }
 
     /// The status of the multi option policy
-    MultiOptionPolicy get_multi_option_policy() const { return multi_option_policy_; }
+    [[nodiscard]] MultiOptionPolicy get_multi_option_policy() const { return multi_option_policy_; }
 
     // Shortcuts for multi option policy
 
     /// Set the multi option policy to take last
     CRTP *take_last() {
-        auto self = static_cast<CRTP *>(this);
+        auto *self = static_cast<CRTP *>(this);
         self->multi_option_policy(MultiOptionPolicy::TakeLast);
         return self;
     }
 
     /// Set the multi option policy to take last
     CRTP *take_first() {
-        auto self = static_cast<CRTP *>(this);
+        auto *self = static_cast<CRTP *>(this);
         self->multi_option_policy(MultiOptionPolicy::TakeFirst);
         return self;
     }
@@ -170,7 +170,7 @@ template <typename CRTP> class OptionBase {
 
     /// Set the multi option policy to join
     CRTP *join() {
-        auto self = static_cast<CRTP *>(this);
+        auto *self = static_cast<CRTP *>(this);
         self->multi_option_policy(MultiOptionPolicy::Join);
         return self;
     }
@@ -361,10 +361,10 @@ class Option : public OptionBase<Option> {
     Option &operator=(const Option &) = delete;
 
     /// Count the total number of times an option was passed
-    std::size_t count() const { return results_.size(); }
+    [[nodiscard]] std::size_t count() const { return results_.size(); }
 
     /// True if the option was not passed
-    bool empty() const { return results_.empty(); }
+    [[nodiscard]] bool empty() const { return results_.empty(); }
 
     /// This bool operator returns true if any arguments were passed or the option callback is forced
     explicit operator bool() const { return !empty() || force_callback_; }
@@ -427,14 +427,14 @@ class Option : public OptionBase<Option> {
         return this;
     }
     /// Get the current value of allow extra args
-    bool get_allow_extra_args() const { return allow_extra_args_; }
+    [[nodiscard]] bool get_allow_extra_args() const { return allow_extra_args_; }
     /// Set the value of trigger_on_parse which specifies that the option callback should be triggered on every parse
     Option *trigger_on_parse(bool value = true) {
         trigger_on_result_ = value;
         return this;
     }
     /// The status of trigger on parse
-    bool get_trigger_on_parse() const { return trigger_on_result_; }
+    [[nodiscard]] bool get_trigger_on_parse() const { return trigger_on_result_; }
 
     /// Set the value of force_callback
     Option *force_callback(bool value = true) {
@@ -442,7 +442,7 @@ class Option : public OptionBase<Option> {
         return this;
     }
     /// The status of force_callback
-    bool get_force_callback() const { return force_callback_; }
+    [[nodiscard]] bool get_force_callback() const { return force_callback_; }
 
     /// Set the value of run_callback_for_default which controls whether the callback function should be called to set
     /// the default This is controlled automatically but could be manipulated by the user.
@@ -451,7 +451,7 @@ class Option : public OptionBase<Option> {
         return this;
     }
     /// Get the current value of run_callback_for_default
-    bool get_run_callback_for_default() const { return run_callback_for_default_; }
+    [[nodiscard]] bool get_run_callback_for_default() const { return run_callback_for_default_; }
 
     /// Adds a Validator with a built in type name
     Option *check(Validator validator, const std::string &validator_name = "") {
@@ -547,7 +547,7 @@ class Option : public OptionBase<Option> {
     /// Any number supported, any mix of string and Opt
     template <typename A, typename B, typename... ARG> Option *needs(A opt, B opt1, ARG... args) {
         needs(opt);
-        return needs(opt1, args...);
+        return needs(opt1, args...);  // NOLINT(readability-suspicious-call-argument)
     }
 
     /// Remove needs link from an option. Returns true if the option really was in the needs list.
@@ -621,7 +621,7 @@ class Option : public OptionBase<Option> {
                 if(opt.get() == this) {
                     continue;
                 }
-                auto &omatch = opt->matching_name(*this);
+                const auto &omatch = opt->matching_name(*this);
                 if(!omatch.empty()) {
                     ignore_case_ = false;
                     throw OptionAlreadyAdded("adding ignore case caused a name conflict with " + omatch);
@@ -646,7 +646,7 @@ class Option : public OptionBase<Option> {
                 if(opt.get() == this) {
                     continue;
                 }
-                auto &omatch = opt->matching_name(*this);
+                const auto &omatch = opt->matching_name(*this);
                 if(!omatch.empty()) {
                     ignore_underscore_ = false;
                     throw OptionAlreadyAdded("adding ignore underscore caused a name conflict with " + omatch);
@@ -682,41 +682,41 @@ class Option : public OptionBase<Option> {
     ///@{
 
     /// The number of arguments the option expects
-    int get_type_size() const { return type_size_min_; }
+    [[nodiscard]] int get_type_size() const { return type_size_min_; }
 
     /// The minimum number of arguments the option expects
-    int get_type_size_min() const { return type_size_min_; }
+    [[nodiscard]] int get_type_size_min() const { return type_size_min_; }
     /// The maximum number of arguments the option expects
-    int get_type_size_max() const { return type_size_max_; }
+    [[nodiscard]] int get_type_size_max() const { return type_size_max_; }
 
     /// Return the inject_separator flag
-    int get_inject_separator() const { return inject_separator_; }
+    [[nodiscard]] int get_inject_separator() const { return static_cast<int>(inject_separator_); }
 
     /// The environment variable associated to this value
-    std::string get_envname() const { return envname_; }
+    [[nodiscard]] std::string get_envname() const { return envname_; }
 
     /// The set of options needed
-    std::set<Option *> get_needs() const { return needs_; }
+    [[nodiscard]] std::set<Option *> get_needs() const { return needs_; }
 
     /// The set of options excluded
-    std::set<Option *> get_excludes() const { return excludes_; }
+    [[nodiscard]] std::set<Option *> get_excludes() const { return excludes_; }
 
     /// The default value (for help printing)
-    std::string get_default_str() const { return default_str_; }
+    [[nodiscard]] std::string get_default_str() const { return default_str_; }
 
     /// Get the callback function
-    callback_t get_callback() const { return callback_; }
+    [[nodiscard]] callback_t get_callback() const { return callback_; }
 
     /// Get the long names
-    const std::vector<std::string> &get_lnames() const { return lnames_; }
+    [[nodiscard]] const std::vector<std::string> &get_lnames() const { return lnames_; }
 
     /// Get the short names
-    const std::vector<std::string> &get_snames() const { return snames_; }
+    [[nodiscard]] const std::vector<std::string> &get_snames() const { return snames_; }
 
     /// Get the flag names with specified default values
-    const std::vector<std::string> &get_fnames() const { return fnames_; }
+    [[nodiscard]] const std::vector<std::string> &get_fnames() const { return fnames_; }
     /// Get a single name for the option, first of lname, pname, sname, envname
-    const std::string &get_single_name() const {
+    [[nodiscard]] const std::string &get_single_name() const {
         if(!lnames_.empty()) {
             return lnames_[0];
         }
@@ -729,35 +729,35 @@ class Option : public OptionBase<Option> {
         return envname_;
     }
     /// The number of times the option expects to be included
-    int get_expected() const { return expected_min_; }
+    [[nodiscard]] int get_expected() const { return expected_min_; }
 
     /// The number of times the option expects to be included
-    int get_expected_min() const { return expected_min_; }
+    [[nodiscard]] int get_expected_min() const { return expected_min_; }
     /// The max number of times the option expects to be included
-    int get_expected_max() const { return expected_max_; }
+    [[nodiscard]] int get_expected_max() const { return expected_max_; }
 
     /// The total min number of expected  string values to be used
-    int get_items_expected_min() const { return type_size_min_ * expected_min_; }
+    [[nodiscard]] int get_items_expected_min() const { return type_size_min_ * expected_min_; }
 
     /// Get the maximum number of items expected to be returned and used for the callback
-    int get_items_expected_max() const {
+    [[nodiscard]] int get_items_expected_max() const {
         int t = type_size_max_;
         return detail::checked_multiply(t, expected_max_) ? t : detail::expected_max_vector_size;
     }
     /// The total min number of expected  string values to be used
-    int get_items_expected() const { return get_items_expected_min(); }
+    [[nodiscard]] int get_items_expected() const { return get_items_expected_min(); }
 
     /// True if the argument can be given directly
-    bool get_positional() const { return pname_.length() > 0; }
+    [[nodiscard]] bool get_positional() const { return pname_.length() > 0; }
 
     /// True if option has at least one non-positional name
-    bool nonpositional() const { return (snames_.size() + lnames_.size()) > 0; }
+    [[nodiscard]] bool nonpositional() const { return (snames_.size() + lnames_.size()) > 0; }
 
     /// True if option has description
-    bool has_description() const { return description_.length() > 0; }
+    [[nodiscard]] bool has_description() const { return description_.length() > 0; }
 
     /// Get the description
-    const std::string &get_description() const { return description_; }
+    [[nodiscard]] const std::string &get_description() const { return description_; }
 
     /// Set the description
     Option *description(std::string option_description) {
@@ -770,7 +770,7 @@ class Option : public OptionBase<Option> {
         return this;
     }
 
-    const std::string &get_option_text() const { return option_text_; }
+    [[nodiscard]] const std::string &get_option_text() const { return option_text_; }
 
     ///@}
     /// @name Help tools
@@ -780,8 +780,8 @@ class Option : public OptionBase<Option> {
     /// Will include / prefer the positional name if positional is true.
     /// If all_options is false, pick just the most descriptive name to show.
     /// Use `get_name(true)` to get the positional name (replaces `get_pname`)
-    std::string get_name(bool positional = false,  ///< Show the positional name
-                         bool all_options = false  ///< Show every option
+    [[nodiscard]] std::string get_name(bool positional = false,  ///< Show the positional name
+                                       bool all_options = false  ///< Show every option
     ) const {
         if(get_group().empty())
             return {};  // Hidden
@@ -867,7 +867,7 @@ class Option : public OptionBase<Option> {
     }
 
     /// If options share any of the same names, find it
-    const std::string &matching_name(const Option &other) const {
+    [[nodiscard]] const std::string &matching_name(const Option &other) const {
         static const std::string estring;
         for(const std::string &sname : snames_)
             if(other.check_sname(sname))
@@ -891,7 +891,7 @@ class Option : public OptionBase<Option> {
     bool operator==(const Option &other) const { return !matching_name(other).empty(); }
 
     /// Check a name. Requires "-" or "--" for short / long, supports positional name
-    bool check_name(const std::string &name) const {
+    [[nodiscard]] bool check_name(const std::string &name) const {
 
         if(name.length() > 2 && name[0] == '-' && name[1] == '-')
             return check_lname(name.substr(2));
@@ -921,17 +921,17 @@ class Option : public OptionBase<Option> {
     }
 
     /// Requires "-" to be removed from string
-    bool check_sname(std::string name) const {
+    [[nodiscard]] bool check_sname(std::string name) const {
         return (detail::find_member(std::move(name), snames_, ignore_case_) >= 0);
     }
 
     /// Requires "--" to be removed from string
-    bool check_lname(std::string name) const {
+    [[nodiscard]] bool check_lname(std::string name) const {
         return (detail::find_member(std::move(name), lnames_, ignore_case_, ignore_underscore_) >= 0);
     }
 
     /// Requires "--" to be removed from string
-    bool check_fname(std::string name) const {
+    [[nodiscard]] bool check_fname(std::string name) const {
         if(fnames_.empty()) {
             return false;
         }
@@ -940,7 +940,7 @@ class Option : public OptionBase<Option> {
 
     /// Get the value that goes for a flag, nominally gets the default value but allows for overrides if not
     /// disabled
-    std::string get_flag_value(const std::string &name, std::string input_value) const {
+    [[nodiscard]] std::string get_flag_value(const std::string &name, std::string input_value) const {
         static const std::string trueString{"true"};
         static const std::string falseString{"false"};
         static const std::string emptyString{"{}"};
@@ -964,9 +964,8 @@ class Option : public OptionBase<Option> {
         if((input_value.empty()) || (input_value == emptyString)) {
             if(flag_like_) {
                 return (ind < 0) ? trueString : default_flag_values_[static_cast<std::size_t>(ind)].second;
-            } else {
-                return (ind < 0) ? default_str_ : default_flag_values_[static_cast<std::size_t>(ind)].second;
             }
+            return (ind < 0) ? default_str_ : default_flag_values_[static_cast<std::size_t>(ind)].second;
         }
         if(ind < 0) {
             return input_value;
@@ -1007,10 +1006,10 @@ class Option : public OptionBase<Option> {
     }
 
     /// Get the current complete results set
-    const results_t &results() const { return results_; }
+    [[nodiscard]] const results_t &results() const { return results_; }
 
     /// Get a copy of the results
-    results_t reduced_results() const {
+    [[nodiscard]] results_t reduced_results() const {
         results_t res = proc_results_.empty() ? results_ : proc_results_;
         if(current_option_state_ < option_state::reduced) {
             if(current_option_state_ == option_state::parsing) {
@@ -1030,7 +1029,7 @@ class Option : public OptionBase<Option> {
 
     /// Get the results as a specified type
     template <typename T> void results(T &output) const {
-        bool retval;
+        bool retval = false;
         if(current_option_state_ >= option_state::reduced || (results_.size() == 1 && validators_.empty())) {
             const results_t &res = (proc_results_.empty()) ? results_ : proc_results_;
             retval = detail::lexical_conversion<T, T>(res, output);
@@ -1060,14 +1059,14 @@ class Option : public OptionBase<Option> {
     }
 
     /// Return the results as the specified type
-    template <typename T> T as() const {
+    template <typename T> [[nodiscard]] T as() const {
         T output;
         results(output);
         return output;
     }
 
     /// See if the callback has been run already
-    bool get_callback_run() const { return (current_option_state_ == option_state::callback_run); }
+    [[nodiscard]] bool get_callback_run() const { return (current_option_state_ == option_state::callback_run); }
 
     ///@}
     /// @name Custom options
@@ -1181,10 +1180,10 @@ class Option : public OptionBase<Option> {
     }
 
     /// Get the full typename for this option
-    std::string get_type_name() const {
+    [[nodiscard]] std::string get_type_name() const {
         std::string full_type_name = type_name_();
         if(!validators_.empty()) {
-            for(auto &Validator : validators_) {
+            for(const auto &Validator : validators_) {
                 std::string vtype = Validator.get_description();
                 if(!vtype.empty()) {
                     full_type_name += ":" + vtype;
@@ -1235,14 +1234,14 @@ class Option : public OptionBase<Option> {
     }
 
     /** reduce the results in accordance with the MultiOptionPolicy
-    @param[out] res results are assigned to res if there if they are different
+    @param[out] out results are assigned to res if there if they are different
     */
-    void _reduce_results(results_t &res, const results_t &original) const {
+    void _reduce_results(results_t &out, const results_t &original) const {
 
         // max num items expected or length of vector, always at least 1
         // Only valid for a trimming policy
 
-        res.clear();
+        out.clear();
         // Operation depends on the policy setting
         switch(multi_option_policy_) {
         case MultiOptionPolicy::TakeAll:
@@ -1252,23 +1251,23 @@ class Option : public OptionBase<Option> {
             std::size_t trim_size = std::min<std::size_t>(
                 static_cast<std::size_t>(std::max<int>(get_items_expected_max(), 1)), original.size());
             if(original.size() != trim_size) {
-                res.assign(original.end() - static_cast<results_t::difference_type>(trim_size), original.end());
+                out.assign(original.end() - static_cast<results_t::difference_type>(trim_size), original.end());
             }
         } break;
         case MultiOptionPolicy::TakeFirst: {
             std::size_t trim_size = std::min<std::size_t>(
                 static_cast<std::size_t>(std::max<int>(get_items_expected_max(), 1)), original.size());
             if(original.size() != trim_size) {
-                res.assign(original.begin(), original.begin() + static_cast<results_t::difference_type>(trim_size));
+                out.assign(original.begin(), original.begin() + static_cast<results_t::difference_type>(trim_size));
             }
         } break;
         case MultiOptionPolicy::Join:
             if(results_.size() > 1) {
-                res.push_back(detail::join(original, std::string(1, (delimiter_ == '\0') ? '\n' : delimiter_)));
+                out.push_back(detail::join(original, std::string(1, (delimiter_ == '\0') ? '\n' : delimiter_)));
             }
             break;
         case MultiOptionPolicy::Sum:
-            res.push_back(detail::sum_string_vector(original));
+            out.push_back(detail::sum_string_vector(original));
             break;
         case MultiOptionPolicy::Throw:
         default: {
@@ -1290,14 +1289,14 @@ class Option : public OptionBase<Option> {
         }
         }
         // this check is to allow an empty vector in certain circumstances but not if expected is not zero.
-        // {} is the indicator for a an empty container
-        if(res.empty()) {
+        // {} is the indicator for an empty container
+        if(out.empty()) {
             if(original.size() == 1 && original[0] == "{}" && get_items_expected_min() > 0) {
-                res.push_back("{}");
-                res.push_back("%%");
+                out.push_back("{}");
+                out.push_back("%%");
             }
-        } else if(res.size() == 1 && res[0] == "{}" && get_items_expected_min() > 0) {
-            res.push_back("%%");
+        } else if(out.size() == 1 && out[0] == "{}" && get_items_expected_min() > 0) {
+            out.push_back("%%");
         }
     }
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -119,31 +119,31 @@ template <typename CRTP> class OptionBase {
     // Getters
 
     /// Get the group of this option
-    [[nodiscard]] const std::string &get_group() const { return group_; }
+    CLI11_NODISCARD const std::string &get_group() const { return group_; }
 
     /// True if this is a required option
-    [[nodiscard]] bool get_required() const { return required_; }
+    CLI11_NODISCARD bool get_required() const { return required_; }
 
     /// The status of ignore case
-    [[nodiscard]] bool get_ignore_case() const { return ignore_case_; }
+    CLI11_NODISCARD bool get_ignore_case() const { return ignore_case_; }
 
     /// The status of ignore_underscore
-    [[nodiscard]] bool get_ignore_underscore() const { return ignore_underscore_; }
+    CLI11_NODISCARD bool get_ignore_underscore() const { return ignore_underscore_; }
 
     /// The status of configurable
-    [[nodiscard]] bool get_configurable() const { return configurable_; }
+    CLI11_NODISCARD bool get_configurable() const { return configurable_; }
 
     /// The status of configurable
-    [[nodiscard]] bool get_disable_flag_override() const { return disable_flag_override_; }
+    CLI11_NODISCARD bool get_disable_flag_override() const { return disable_flag_override_; }
 
     /// Get the current delimiter char
-    [[nodiscard]] char get_delimiter() const { return delimiter_; }
+    CLI11_NODISCARD char get_delimiter() const { return delimiter_; }
 
     /// Return true if this will automatically capture the default value for help printing
-    [[nodiscard]] bool get_always_capture_default() const { return always_capture_default_; }
+    CLI11_NODISCARD bool get_always_capture_default() const { return always_capture_default_; }
 
     /// The status of the multi option policy
-    [[nodiscard]] MultiOptionPolicy get_multi_option_policy() const { return multi_option_policy_; }
+    CLI11_NODISCARD MultiOptionPolicy get_multi_option_policy() const { return multi_option_policy_; }
 
     // Shortcuts for multi option policy
 
@@ -361,10 +361,10 @@ class Option : public OptionBase<Option> {
     Option &operator=(const Option &) = delete;
 
     /// Count the total number of times an option was passed
-    [[nodiscard]] std::size_t count() const { return results_.size(); }
+    CLI11_NODISCARD std::size_t count() const { return results_.size(); }
 
     /// True if the option was not passed
-    [[nodiscard]] bool empty() const { return results_.empty(); }
+    CLI11_NODISCARD bool empty() const { return results_.empty(); }
 
     /// This bool operator returns true if any arguments were passed or the option callback is forced
     explicit operator bool() const { return !empty() || force_callback_; }
@@ -427,14 +427,14 @@ class Option : public OptionBase<Option> {
         return this;
     }
     /// Get the current value of allow extra args
-    [[nodiscard]] bool get_allow_extra_args() const { return allow_extra_args_; }
+    CLI11_NODISCARD bool get_allow_extra_args() const { return allow_extra_args_; }
     /// Set the value of trigger_on_parse which specifies that the option callback should be triggered on every parse
     Option *trigger_on_parse(bool value = true) {
         trigger_on_result_ = value;
         return this;
     }
     /// The status of trigger on parse
-    [[nodiscard]] bool get_trigger_on_parse() const { return trigger_on_result_; }
+    CLI11_NODISCARD bool get_trigger_on_parse() const { return trigger_on_result_; }
 
     /// Set the value of force_callback
     Option *force_callback(bool value = true) {
@@ -442,7 +442,7 @@ class Option : public OptionBase<Option> {
         return this;
     }
     /// The status of force_callback
-    [[nodiscard]] bool get_force_callback() const { return force_callback_; }
+    CLI11_NODISCARD bool get_force_callback() const { return force_callback_; }
 
     /// Set the value of run_callback_for_default which controls whether the callback function should be called to set
     /// the default This is controlled automatically but could be manipulated by the user.
@@ -451,7 +451,7 @@ class Option : public OptionBase<Option> {
         return this;
     }
     /// Get the current value of run_callback_for_default
-    [[nodiscard]] bool get_run_callback_for_default() const { return run_callback_for_default_; }
+    CLI11_NODISCARD bool get_run_callback_for_default() const { return run_callback_for_default_; }
 
     /// Adds a Validator with a built in type name
     Option *check(Validator validator, const std::string &validator_name = "") {
@@ -682,41 +682,41 @@ class Option : public OptionBase<Option> {
     ///@{
 
     /// The number of arguments the option expects
-    [[nodiscard]] int get_type_size() const { return type_size_min_; }
+    CLI11_NODISCARD int get_type_size() const { return type_size_min_; }
 
     /// The minimum number of arguments the option expects
-    [[nodiscard]] int get_type_size_min() const { return type_size_min_; }
+    CLI11_NODISCARD int get_type_size_min() const { return type_size_min_; }
     /// The maximum number of arguments the option expects
-    [[nodiscard]] int get_type_size_max() const { return type_size_max_; }
+    CLI11_NODISCARD int get_type_size_max() const { return type_size_max_; }
 
     /// Return the inject_separator flag
-    [[nodiscard]] int get_inject_separator() const { return static_cast<int>(inject_separator_); }
+    CLI11_NODISCARD int get_inject_separator() const { return static_cast<int>(inject_separator_); }
 
     /// The environment variable associated to this value
-    [[nodiscard]] std::string get_envname() const { return envname_; }
+    CLI11_NODISCARD std::string get_envname() const { return envname_; }
 
     /// The set of options needed
-    [[nodiscard]] std::set<Option *> get_needs() const { return needs_; }
+    CLI11_NODISCARD std::set<Option *> get_needs() const { return needs_; }
 
     /// The set of options excluded
-    [[nodiscard]] std::set<Option *> get_excludes() const { return excludes_; }
+    CLI11_NODISCARD std::set<Option *> get_excludes() const { return excludes_; }
 
     /// The default value (for help printing)
-    [[nodiscard]] std::string get_default_str() const { return default_str_; }
+    CLI11_NODISCARD std::string get_default_str() const { return default_str_; }
 
     /// Get the callback function
-    [[nodiscard]] callback_t get_callback() const { return callback_; }
+    CLI11_NODISCARD callback_t get_callback() const { return callback_; }
 
     /// Get the long names
-    [[nodiscard]] const std::vector<std::string> &get_lnames() const { return lnames_; }
+    CLI11_NODISCARD const std::vector<std::string> &get_lnames() const { return lnames_; }
 
     /// Get the short names
-    [[nodiscard]] const std::vector<std::string> &get_snames() const { return snames_; }
+    CLI11_NODISCARD const std::vector<std::string> &get_snames() const { return snames_; }
 
     /// Get the flag names with specified default values
-    [[nodiscard]] const std::vector<std::string> &get_fnames() const { return fnames_; }
+    CLI11_NODISCARD const std::vector<std::string> &get_fnames() const { return fnames_; }
     /// Get a single name for the option, first of lname, pname, sname, envname
-    [[nodiscard]] const std::string &get_single_name() const {
+    CLI11_NODISCARD const std::string &get_single_name() const {
         if(!lnames_.empty()) {
             return lnames_[0];
         }
@@ -729,35 +729,35 @@ class Option : public OptionBase<Option> {
         return envname_;
     }
     /// The number of times the option expects to be included
-    [[nodiscard]] int get_expected() const { return expected_min_; }
+    CLI11_NODISCARD int get_expected() const { return expected_min_; }
 
     /// The number of times the option expects to be included
-    [[nodiscard]] int get_expected_min() const { return expected_min_; }
+    CLI11_NODISCARD int get_expected_min() const { return expected_min_; }
     /// The max number of times the option expects to be included
-    [[nodiscard]] int get_expected_max() const { return expected_max_; }
+    CLI11_NODISCARD int get_expected_max() const { return expected_max_; }
 
     /// The total min number of expected  string values to be used
-    [[nodiscard]] int get_items_expected_min() const { return type_size_min_ * expected_min_; }
+    CLI11_NODISCARD int get_items_expected_min() const { return type_size_min_ * expected_min_; }
 
     /// Get the maximum number of items expected to be returned and used for the callback
-    [[nodiscard]] int get_items_expected_max() const {
+    CLI11_NODISCARD int get_items_expected_max() const {
         int t = type_size_max_;
         return detail::checked_multiply(t, expected_max_) ? t : detail::expected_max_vector_size;
     }
     /// The total min number of expected  string values to be used
-    [[nodiscard]] int get_items_expected() const { return get_items_expected_min(); }
+    CLI11_NODISCARD int get_items_expected() const { return get_items_expected_min(); }
 
     /// True if the argument can be given directly
-    [[nodiscard]] bool get_positional() const { return pname_.length() > 0; }
+    CLI11_NODISCARD bool get_positional() const { return pname_.length() > 0; }
 
     /// True if option has at least one non-positional name
-    [[nodiscard]] bool nonpositional() const { return (snames_.size() + lnames_.size()) > 0; }
+    CLI11_NODISCARD bool nonpositional() const { return (snames_.size() + lnames_.size()) > 0; }
 
     /// True if option has description
-    [[nodiscard]] bool has_description() const { return description_.length() > 0; }
+    CLI11_NODISCARD bool has_description() const { return description_.length() > 0; }
 
     /// Get the description
-    [[nodiscard]] const std::string &get_description() const { return description_; }
+    CLI11_NODISCARD const std::string &get_description() const { return description_; }
 
     /// Set the description
     Option *description(std::string option_description) {
@@ -770,7 +770,7 @@ class Option : public OptionBase<Option> {
         return this;
     }
 
-    [[nodiscard]] const std::string &get_option_text() const { return option_text_; }
+    CLI11_NODISCARD const std::string &get_option_text() const { return option_text_; }
 
     ///@}
     /// @name Help tools
@@ -780,8 +780,8 @@ class Option : public OptionBase<Option> {
     /// Will include / prefer the positional name if positional is true.
     /// If all_options is false, pick just the most descriptive name to show.
     /// Use `get_name(true)` to get the positional name (replaces `get_pname`)
-    [[nodiscard]] std::string get_name(bool positional = false,  ///< Show the positional name
-                                       bool all_options = false  ///< Show every option
+    CLI11_NODISCARD std::string get_name(bool positional = false,  ///< Show the positional name
+                                         bool all_options = false  ///< Show every option
     ) const {
         if(get_group().empty())
             return {};  // Hidden
@@ -867,7 +867,7 @@ class Option : public OptionBase<Option> {
     }
 
     /// If options share any of the same names, find it
-    [[nodiscard]] const std::string &matching_name(const Option &other) const {
+    CLI11_NODISCARD const std::string &matching_name(const Option &other) const {
         static const std::string estring;
         for(const std::string &sname : snames_)
             if(other.check_sname(sname))
@@ -891,7 +891,7 @@ class Option : public OptionBase<Option> {
     bool operator==(const Option &other) const { return !matching_name(other).empty(); }
 
     /// Check a name. Requires "-" or "--" for short / long, supports positional name
-    [[nodiscard]] bool check_name(const std::string &name) const {
+    CLI11_NODISCARD bool check_name(const std::string &name) const {
 
         if(name.length() > 2 && name[0] == '-' && name[1] == '-')
             return check_lname(name.substr(2));
@@ -921,17 +921,17 @@ class Option : public OptionBase<Option> {
     }
 
     /// Requires "-" to be removed from string
-    [[nodiscard]] bool check_sname(std::string name) const {
+    CLI11_NODISCARD bool check_sname(std::string name) const {
         return (detail::find_member(std::move(name), snames_, ignore_case_) >= 0);
     }
 
     /// Requires "--" to be removed from string
-    [[nodiscard]] bool check_lname(std::string name) const {
+    CLI11_NODISCARD bool check_lname(std::string name) const {
         return (detail::find_member(std::move(name), lnames_, ignore_case_, ignore_underscore_) >= 0);
     }
 
     /// Requires "--" to be removed from string
-    [[nodiscard]] bool check_fname(std::string name) const {
+    CLI11_NODISCARD bool check_fname(std::string name) const {
         if(fnames_.empty()) {
             return false;
         }
@@ -940,7 +940,7 @@ class Option : public OptionBase<Option> {
 
     /// Get the value that goes for a flag, nominally gets the default value but allows for overrides if not
     /// disabled
-    [[nodiscard]] std::string get_flag_value(const std::string &name, std::string input_value) const {
+    CLI11_NODISCARD std::string get_flag_value(const std::string &name, std::string input_value) const {
         static const std::string trueString{"true"};
         static const std::string falseString{"false"};
         static const std::string emptyString{"{}"};
@@ -1006,10 +1006,10 @@ class Option : public OptionBase<Option> {
     }
 
     /// Get the current complete results set
-    [[nodiscard]] const results_t &results() const { return results_; }
+    CLI11_NODISCARD const results_t &results() const { return results_; }
 
     /// Get a copy of the results
-    [[nodiscard]] results_t reduced_results() const {
+    CLI11_NODISCARD results_t reduced_results() const {
         results_t res = proc_results_.empty() ? results_ : proc_results_;
         if(current_option_state_ < option_state::reduced) {
             if(current_option_state_ == option_state::parsing) {
@@ -1059,14 +1059,14 @@ class Option : public OptionBase<Option> {
     }
 
     /// Return the results as the specified type
-    template <typename T> [[nodiscard]] T as() const {
+    template <typename T> CLI11_NODISCARD T as() const {
         T output;
         results(output);
         return output;
     }
 
     /// See if the callback has been run already
-    [[nodiscard]] bool get_callback_run() const { return (current_option_state_ == option_state::callback_run); }
+    CLI11_NODISCARD bool get_callback_run() const { return (current_option_state_ == option_state::callback_run); }
 
     ///@}
     /// @name Custom options
@@ -1180,7 +1180,7 @@ class Option : public OptionBase<Option> {
     }
 
     /// Get the full typename for this option
-    [[nodiscard]] std::string get_type_name() const {
+    CLI11_NODISCARD std::string get_type_name() const {
         std::string full_type_name = type_name_();
         if(!validators_.empty()) {
             for(const auto &Validator : validators_) {

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -134,7 +134,7 @@ get_names(const std::vector<std::string> &input) {
         }
     }
 
-    return {short_names, long_names, pos_name};
+    return std::make_tuple(short_names, long_names, pos_name);
 }
 
 }  // namespace detail

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -66,8 +66,8 @@ inline bool split_windows_style(const std::string &current, std::string &name, s
 // Splits a string into multiple long and short names
 inline std::vector<std::string> split_names(std::string current) {
     std::vector<std::string> output;
-    std::size_t val;
-    while((val = current.find(",")) != std::string::npos) {
+    std::size_t val = 0;
+    while((val = current.find(',')) != std::string::npos) {
         output.push_back(trim_copy(current.substr(0, val)));
         current = current.substr(val + 1);
     }
@@ -94,7 +94,7 @@ inline std::vector<std::pair<std::string, std::string>> get_default_flag_values(
         if((def_start != std::string::npos) && (flag.back() == '}')) {
             defval = flag.substr(def_start + 1);
             defval.pop_back();
-            flag.erase(def_start, std::string::npos);
+            flag.erase(def_start, std::string::npos);  // NOLINT(readability-suspicious-call-argument)
         }
         flag.erase(0, flag.find_first_not_of("-!"));
         output.emplace_back(flag, defval);
@@ -134,8 +134,7 @@ get_names(const std::vector<std::string> &input) {
         }
     }
 
-    return std::tuple<std::vector<std::string>, std::vector<std::string>, std::string>(
-        short_names, long_names, pos_name);
+    return {short_names, long_names, pos_name};
 }
 
 }  // namespace detail

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -347,7 +347,7 @@ inline std::vector<std::string> split_up(std::string str, char delimiter = '\0')
 
     const std::string delims("\'\"`");
     auto find_ws = [delimiter](char ch) {
-        return (delimiter == '\0') ? (static_cast<int>(std::isspace<char>(ch, std::locale())) != 0) : (ch == delimiter);
+        return (delimiter == '\0') ? std::isspace<char>(ch, std::locale()) : (ch == delimiter);
     };
     trim(str);
 

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -347,7 +347,7 @@ inline std::vector<std::string> split_up(std::string str, char delimiter = '\0')
 
     const std::string delims("\'\"`");
     auto find_ws = [delimiter](char ch) {
-        return (delimiter == '\0') ? (std::isspace<char>(ch, std::locale()) != 0) : (ch == delimiter);
+        return (delimiter == '\0') ? (static_cast<int>(std::isspace<char>(ch, std::locale())) != 0) : (ch == delimiter);
     };
     trim(str);
 

--- a/include/CLI/Timer.hpp
+++ b/include/CLI/Timer.hpp
@@ -81,7 +81,7 @@ class Timer {
     }
 
     /// This formats the numerical value for the time string
-    [[nodiscard]] std::string make_time_str() const {
+    std::string make_time_str() const {  // NOLINT(modernize-use-nodiscard)
         time_point stop = clock::now();
         std::chrono::duration<double> elapsed = stop - start_;
         double time = elapsed.count() / static_cast<double>(cycles);
@@ -90,7 +90,7 @@ class Timer {
 
     // LCOV_EXCL_START
     /// This prints out a time string from a time
-    [[nodiscard]] std::string make_time_str(double time) const {
+    std::string make_time_str(double time) const {  // NOLINT(modernize-use-nodiscard)
         auto print_it = [](double x, std::string unit) {
             const unsigned int buffer_length = 50;
             std::array<char, buffer_length> buffer;
@@ -109,7 +109,7 @@ class Timer {
     // LCOV_EXCL_STOP
 
     /// This is the main function, it creates a string
-    [[nodiscard]] std::string to_string() const { return time_print_(title_, make_time_str()); }
+    std::string to_string() const { return time_print_(title_, make_time_str()); }  // NOLINT(modernize-use-nodiscard)
 
     /// Division sets the number of cycles to divide by (no graphical change)
     Timer &operator/(std::size_t val) {

--- a/include/CLI/Timer.hpp
+++ b/include/CLI/Timer.hpp
@@ -12,6 +12,8 @@
 #define _GLIBCXX_USE_NANOSLEEP
 #endif
 
+#include <cmath>
+
 #include <array>
 #include <chrono>
 #include <functional>
@@ -63,7 +65,7 @@ class Timer {
     /// Time a function by running it multiple times. Target time is the len to target.
     std::string time_it(std::function<void()> f, double target_time = 1) {
         time_point start = start_;
-        double total_time;
+        double total_time = NAN;
 
         start_ = clock::now();
         std::size_t n = 0;
@@ -79,7 +81,7 @@ class Timer {
     }
 
     /// This formats the numerical value for the time string
-    std::string make_time_str() const {
+    [[nodiscard]] std::string make_time_str() const {
         time_point stop = clock::now();
         std::chrono::duration<double> elapsed = stop - start_;
         double time = elapsed.count() / static_cast<double>(cycles);
@@ -88,7 +90,7 @@ class Timer {
 
     // LCOV_EXCL_START
     /// This prints out a time string from a time
-    std::string make_time_str(double time) const {
+    [[nodiscard]] std::string make_time_str(double time) const {
         auto print_it = [](double x, std::string unit) {
             const unsigned int buffer_length = 50;
             std::array<char, buffer_length> buffer;
@@ -98,17 +100,16 @@ class Timer {
 
         if(time < .000001)
             return print_it(time * 1000000000, "ns");
-        else if(time < .001)
+        if(time < .001)
             return print_it(time * 1000000, "us");
-        else if(time < 1)
+        if(time < 1)
             return print_it(time * 1000, "ms");
-        else
-            return print_it(time, "s");
+        return print_it(time, "s");
     }
     // LCOV_EXCL_STOP
 
     /// This is the main function, it creates a string
-    std::string to_string() const { return time_print_(title_, make_time_str()); }
+    [[nodiscard]] std::string to_string() const { return time_print_(title_, make_time_str()); }
 
     /// Division sets the number of cycles to divide by (no graphical change)
     Timer &operator/(std::size_t val) {

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -276,7 +276,7 @@ template <typename T,
           enable_if_t<std::is_constructible<std::string, T>::value && !std::is_convertible<T, std::string>::value,
                       detail::enabler> = detail::dummy>
 std::string to_string(const T &value) {
-    return std::string{value};
+    return std::string(value);  // NOLINT(google-readability-casting)
 }
 
 /// Convert an object to a string (streaming must be supported for that type)

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -276,7 +276,7 @@ template <typename T,
           enable_if_t<std::is_constructible<std::string, T>::value && !std::is_convertible<T, std::string>::value,
                       detail::enabler> = detail::dummy>
 std::string to_string(const T &value) {
-    return std::string(value);
+    return std::string{value};
 }
 
 /// Convert an object to a string (streaming must be supported for that type)
@@ -296,7 +296,7 @@ template <typename T,
                           !is_readable_container<typename std::remove_const<T>::type>::value,
                       detail::enabler> = detail::dummy>
 std::string to_string(T &&) {
-    return std::string{};
+    return {};
 }
 
 /// convert a readable container to a string
@@ -308,14 +308,14 @@ std::string to_string(T &&variable) {
     auto cval = variable.begin();
     auto end = variable.end();
     if(cval == end) {
-        return std::string("{}");
+        return {"{}"};
     }
     std::vector<std::string> defaults;
     while(cval != end) {
         defaults.emplace_back(CLI::detail::to_string(*cval));
         ++cval;
     }
-    return std::string("[" + detail::join(defaults) + "]");
+    return {"[" + detail::join(defaults) + "]"};
 }
 
 /// special template overload
@@ -763,8 +763,8 @@ inline typename std::enable_if<I == type_count_base<T>::value, std::string>::typ
 /// Recursively generate the tuple type name
 template <typename T, std::size_t I>
 inline typename std::enable_if<(I < type_count_base<T>::value), std::string>::type tuple_name() {
-    std::string str = std::string(type_name<typename std::decay<typename std::tuple_element<I, T>::type>::type>()) +
-                      ',' + tuple_name<T, I + 1>();
+    auto str = std::string{type_name<typename std::decay<typename std::tuple_element<I, T>::type>::type>()} + ',' +
+               tuple_name<T, I + 1>();
     if(str.back() == ',')
         str.pop_back();
     return str;
@@ -843,7 +843,7 @@ inline std::int64_t to_flag_value(std::string val) {
         return -1;
     }
     val = detail::to_lower(val);
-    std::int64_t ret;
+    std::int64_t ret = 0;
     if(val.size() == 1) {
         if(val[0] >= '1' && val[0] <= '9') {
             return (static_cast<std::int64_t>(val[0]) - '0');
@@ -1019,17 +1019,18 @@ template <
     typename T,
     enable_if_t<classify_object<T>::value == object_category::number_constructible, detail::enabler> = detail::dummy>
 bool lexical_cast(const std::string &input, T &output) {
-    int val;
+    int val = 0;
     if(integral_conversion(input, val)) {
         output = T(val);
         return true;
-    } else {
-        double dval;
-        if(lexical_cast(input, dval)) {
-            output = T{dval};
-            return true;
-        }
     }
+
+    double dval = 0.0;
+    if(lexical_cast(input, dval)) {
+        output = T{dval};
+        return true;
+    }
+
     return from_stream(input, output);
 }
 
@@ -1038,7 +1039,7 @@ template <
     typename T,
     enable_if_t<classify_object<T>::value == object_category::integer_constructible, detail::enabler> = detail::dummy>
 bool lexical_cast(const std::string &input, T &output) {
-    int val;
+    int val = 0;
     if(integral_conversion(input, val)) {
         output = T(val);
         return true;
@@ -1051,7 +1052,7 @@ template <
     typename T,
     enable_if_t<classify_object<T>::value == object_category::double_constructible, detail::enabler> = detail::dummy>
 bool lexical_cast(const std::string &input, T &output) {
-    double val;
+    double val = 0.0;
     if(lexical_cast(input, val)) {
         output = T{val};
         return true;
@@ -1064,7 +1065,7 @@ template <typename T,
           enable_if_t<classify_object<T>::value == object_category::other && std::is_assignable<T &, int>::value,
                       detail::enabler> = detail::dummy>
 bool lexical_cast(const std::string &input, T &output) {
-    int val;
+    int val = 0;
     if(integral_conversion(input, val)) {
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -1152,7 +1153,7 @@ bool lexical_assign(const std::string &input, AssignTo &output) {
         output = 0;
         return true;
     }
-    int val;
+    int val = 0;
     if(lexical_cast(input, val)) {
         output = val;
         return true;
@@ -1266,9 +1267,8 @@ bool lexical_conversion(const std::vector<std::string> &strings, AssignTo &outpu
             output = ConvertTo{x, y};
         }
         return worked;
-    } else {
-        return lexical_assign<AssignTo, ConvertTo>(strings[0], output);
     }
+    return lexical_assign<AssignTo, ConvertTo>(strings[0], output);
 }
 
 /// Conversion to a vector type using a particular single type as the conversion type
@@ -1544,6 +1544,7 @@ inline std::string sum_string_vector(const std::vector<std::string> &values) {
     } else {
         if(val <= static_cast<double>((std::numeric_limits<std::int64_t>::min)()) ||
            val >= static_cast<double>((std::numeric_limits<std::int64_t>::max)()) ||
+           // NOLINTNEXTLINE(clang-diagnostic-float-equal,bugprone-narrowing-conversions)
            val == static_cast<std::int64_t>(val)) {
             output = detail::value_string(static_cast<int64_t>(val));
         } else {

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -138,13 +138,13 @@ class Validator {
         return *this;
     }
     /// Specify the type string
-    [[nodiscard]] Validator description(std::string validator_desc) const {
+    CLI11_NODISCARD Validator description(std::string validator_desc) const {
         Validator newval(*this);
         newval.desc_function_ = [validator_desc]() { return validator_desc; };
         return newval;
     }
     /// Generate type description information for the Validator
-    [[nodiscard]] std::string get_description() const {
+    CLI11_NODISCARD std::string get_description() const {
         if(active_) {
             return desc_function_();
         }
@@ -156,20 +156,20 @@ class Validator {
         return *this;
     }
     /// Specify the type string
-    [[nodiscard]] Validator name(std::string validator_name) const {
+    CLI11_NODISCARD Validator name(std::string validator_name) const {
         Validator newval(*this);
         newval.name_ = std::move(validator_name);
         return newval;
     }
     /// Get the name of the Validator
-    [[nodiscard]] const std::string &get_name() const { return name_; }
+    CLI11_NODISCARD const std::string &get_name() const { return name_; }
     /// Specify whether the Validator is active or not
     Validator &active(bool active_val = true) {
         active_ = active_val;
         return *this;
     }
     /// Specify whether the Validator is active or not
-    [[nodiscard]] Validator active(bool active_val = true) const {
+    CLI11_NODISCARD Validator active(bool active_val = true) const {
         Validator newval(*this);
         newval.active_ = active_val;
         return newval;
@@ -186,18 +186,18 @@ class Validator {
         return *this;
     }
     /// Specify the application index of a validator
-    [[nodiscard]] Validator application_index(int app_index) const {
+    CLI11_NODISCARD Validator application_index(int app_index) const {
         Validator newval(*this);
         newval.application_index_ = app_index;
         return newval;
     }
     /// Get the current value of the application index
-    [[nodiscard]] int get_application_index() const { return application_index_; }
+    CLI11_NODISCARD int get_application_index() const { return application_index_; }
     /// Get a boolean if the validator is active
-    [[nodiscard]] bool get_active() const { return active_; }
+    CLI11_NODISCARD bool get_active() const { return active_; }
 
     /// Get a boolean if the validator is allowed to modify the input returns true if it can modify the input
-    [[nodiscard]] bool get_modifying() const { return !non_modifying_; }
+    CLI11_NODISCARD bool get_modifying() const { return !non_modifying_; }
 
     /// Combining validators is a new validator. Type comes from left validator if function, otherwise only set if the
     /// same.

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -218,7 +218,7 @@ class Validator {
             return s1 + s2;
         };
 
-        newval.active_ = ((static_cast<int>(active_) & static_cast<int>(other.active_)) != 0);
+        newval.active_ = active_ && other.active_;
         newval.application_index_ = application_index_;
         return newval;
     }
@@ -242,7 +242,7 @@ class Validator {
 
             return std::string("(") + s1 + ") OR (" + s2 + ")";
         };
-        newval.active_ = ((static_cast<int>(active_) & static_cast<int>(other.active_)) != 0);
+        newval.active_ = active_ && other.active_;
         newval.application_index_ = application_index_;
         return newval;
     }

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -94,6 +94,9 @@ class Validator {
     /// specify that a validator should not modify the input
     bool non_modifying_{false};
 
+    Validator(std::string validator_desc, std::function<std::string(std::string &)> func)
+        : desc_function_([validator_desc]() { return validator_desc; }), func_(std::move(func)) {}
+
   public:
     Validator() = default;
     /// Construct a Validator with just the description string
@@ -135,13 +138,13 @@ class Validator {
         return *this;
     }
     /// Specify the type string
-    Validator description(std::string validator_desc) const {
+    [[nodiscard]] Validator description(std::string validator_desc) const {
         Validator newval(*this);
         newval.desc_function_ = [validator_desc]() { return validator_desc; };
         return newval;
     }
     /// Generate type description information for the Validator
-    std::string get_description() const {
+    [[nodiscard]] std::string get_description() const {
         if(active_) {
             return desc_function_();
         }
@@ -153,20 +156,20 @@ class Validator {
         return *this;
     }
     /// Specify the type string
-    Validator name(std::string validator_name) const {
+    [[nodiscard]] Validator name(std::string validator_name) const {
         Validator newval(*this);
         newval.name_ = std::move(validator_name);
         return newval;
     }
     /// Get the name of the Validator
-    const std::string &get_name() const { return name_; }
+    [[nodiscard]] const std::string &get_name() const { return name_; }
     /// Specify whether the Validator is active or not
     Validator &active(bool active_val = true) {
         active_ = active_val;
         return *this;
     }
     /// Specify whether the Validator is active or not
-    Validator active(bool active_val = true) const {
+    [[nodiscard]] Validator active(bool active_val = true) const {
         Validator newval(*this);
         newval.active_ = active_val;
         return newval;
@@ -183,18 +186,18 @@ class Validator {
         return *this;
     }
     /// Specify the application index of a validator
-    Validator application_index(int app_index) const {
+    [[nodiscard]] Validator application_index(int app_index) const {
         Validator newval(*this);
         newval.application_index_ = app_index;
         return newval;
     }
     /// Get the current value of the application index
-    int get_application_index() const { return application_index_; }
+    [[nodiscard]] int get_application_index() const { return application_index_; }
     /// Get a boolean if the validator is active
-    bool get_active() const { return active_; }
+    [[nodiscard]] bool get_active() const { return active_; }
 
     /// Get a boolean if the validator is allowed to modify the input returns true if it can modify the input
-    bool get_modifying() const { return !non_modifying_; }
+    [[nodiscard]] bool get_modifying() const { return !non_modifying_; }
 
     /// Combining validators is a new validator. Type comes from left validator if function, otherwise only set if the
     /// same.
@@ -212,11 +215,10 @@ class Validator {
             std::string s2 = f2(input);
             if(!s1.empty() && !s2.empty())
                 return std::string("(") + s1 + ") AND (" + s2 + ")";
-            else
-                return s1 + s2;
+            return s1 + s2;
         };
 
-        newval.active_ = (active_ & other.active_);
+        newval.active_ = ((static_cast<int>(active_) & static_cast<int>(other.active_)) != 0);
         newval.application_index_ = application_index_;
         return newval;
     }
@@ -240,7 +242,7 @@ class Validator {
 
             return std::string("(") + s1 + ") OR (" + s2 + ")";
         };
-        newval.active_ = (active_ & other.active_);
+        newval.active_ = ((static_cast<int>(active_) & static_cast<int>(other.active_)) != 0);
         newval.application_index_ = application_index_;
         return newval;
     }
@@ -410,7 +412,7 @@ class IPV4Validator : public Validator {
             if(result.size() != 4) {
                 return std::string("Invalid IPV4 address must have four parts (") + ip_addr + ')';
             }
-            int num;
+            int num = 0;
             for(const auto &var : result) {
                 bool retval = detail::lexical_cast(var, num);
                 if(!retval) {
@@ -447,15 +449,14 @@ const detail::IPV4Validator ValidIPV4;
 /// Validate the input as a particular type
 template <typename DesiredType> class TypeValidator : public Validator {
   public:
-    explicit TypeValidator(const std::string &validator_name) : Validator(validator_name) {
-        func_ = [](std::string &input_string) {
-            auto val = DesiredType();
-            if(!detail::lexical_cast(input_string, val)) {
-                return std::string("Failed parsing ") + input_string + " as a " + detail::type_name<DesiredType>();
-            }
-            return std::string();
-        };
-    }
+    explicit TypeValidator(const std::string &validator_name)
+        : Validator(validator_name, [](std::string &input_string) {
+              auto val = DesiredType();
+              if(!detail::lexical_cast(input_string, val)) {
+                  return std::string("Failed parsing ") + input_string + " as a " + detail::type_name<DesiredType>();
+              }
+              return std::string();
+          }) {}
     TypeValidator() : TypeValidator(detail::type_name<DesiredType>()) {}
 };
 
@@ -664,9 +665,8 @@ template <typename T>
 inline typename std::enable_if<std::is_signed<T>::value, T>::type overflowCheck(const T &a, const T &b) {
     if((a > 0) == (b > 0)) {
         return ((std::numeric_limits<T>::max)() / (std::abs)(a) < (std::abs)(b));
-    } else {
-        return ((std::numeric_limits<T>::min)() / (std::abs)(a) > -(std::abs)(b));
     }
+    return ((std::numeric_limits<T>::min)() / (std::abs)(a) > -(std::abs)(b));
 }
 /// Do a check for overflow on unsigned numbers
 template <typename T>
@@ -1056,6 +1056,10 @@ class AsNumberWithUnit : public Validator {
     }
 };
 
+inline AsNumberWithUnit::Options operator|(const AsNumberWithUnit::Options &a, const AsNumberWithUnit::Options &b) {
+    return static_cast<AsNumberWithUnit::Options>(static_cast<int>(a) | static_cast<int>(b));
+}
+
 /// Converts a human-readable size string (with unit literal) to uin64_t size.
 /// Example:
 ///   "100" => 100
@@ -1111,10 +1115,9 @@ class AsSizeValue : public AsNumberWithUnit {
         if(kb_is_1000) {
             static auto m = init_mapping(true);
             return m;
-        } else {
-            static auto m = init_mapping(false);
-            return m;
         }
+        static auto m = init_mapping(false);
+        return m;
     }
 };
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "app_helper.hpp"
+#include <cmath>
+
 #include <complex>
 #include <cstdint>
 #include <cstdlib>
@@ -30,10 +32,10 @@ TEST_CASE_METHOD(TApp, "OneFlagShortValues", "[app]") {
 }
 
 TEST_CASE_METHOD(TApp, "OneFlagShortValuesAs", "[app]") {
-    auto flg = app.add_flag("-c{1},--count{2}");
+    auto *flg = app.add_flag("-c{1},--count{2}");
     args = {"-c"};
     run();
-    auto opt = app["-c"];
+    const auto *opt = app["-c"];
     CHECK(1 == opt->as<int>());
     args = {"--count"};
     run();
@@ -68,8 +70,8 @@ TEST_CASE_METHOD(TApp, "OneFlagShortWindows", "[app]") {
 TEST_CASE_METHOD(TApp, "WindowsLongShortMix1", "[app]") {
     app.allow_windows_style_options();
 
-    auto a = app.add_flag("-c");
-    auto b = app.add_flag("--c");
+    auto *a = app.add_flag("-c");
+    auto *b = app.add_flag("--c");
     args = {"/c"};
     run();
     CHECK(a->count() == 1u);
@@ -79,8 +81,8 @@ TEST_CASE_METHOD(TApp, "WindowsLongShortMix1", "[app]") {
 TEST_CASE_METHOD(TApp, "WindowsLongShortMix2", "[app]") {
     app.allow_windows_style_options();
 
-    auto a = app.add_flag("--c");
-    auto b = app.add_flag("-c");
+    auto *a = app.add_flag("--c");
+    auto *b = app.add_flag("-c");
     args = {"/c"};
     run();
     CHECK(a->count() == 1u);
@@ -160,7 +162,7 @@ TEST_CASE_METHOD(TApp, "RequireOptionsError", "[app]") {
 
 TEST_CASE_METHOD(TApp, "BoolFlagOverride", "[app]") {
     bool val{false};
-    auto flg = app.add_flag("--this,--that", val);
+    auto *flg = app.add_flag("--this,--that", val);
 
     app.parse("--this");
     CHECK(val);
@@ -200,7 +202,7 @@ TEST_CASE_METHOD(TApp, "OneFlagRefValue", "[app]") {
 
 TEST_CASE_METHOD(TApp, "OneFlagRefValueFalse", "[app]") {
     int ref{0};
-    auto flg = app.add_flag("-c,--count", ref);
+    auto *flg = app.add_flag("-c,--count", ref);
     args = {"--count=false"};
     run();
     CHECK(app.count("-c") == 1u);
@@ -220,7 +222,7 @@ TEST_CASE_METHOD(TApp, "OneFlagRefValueFalse", "[app]") {
 
 TEST_CASE_METHOD(TApp, "FlagNegation", "[app]") {
     int ref{0};
-    auto flg = app.add_flag("-c,--count,--ncount{false}", ref);
+    auto *flg = app.add_flag("-c,--count,--ncount{false}", ref);
     args = {"--count", "-c", "--ncount"};
     CHECK(!flg->check_fname("count"));
     CHECK(flg->check_fname("ncount"));
@@ -437,7 +439,7 @@ TEST_CASE_METHOD(TApp, "OneStringFlagLike", "[app]") {
 
 TEST_CASE_METHOD(TApp, "OneIntFlagLike", "[app]") {
     int val{0};
-    auto opt = app.add_option("-i", val)->expected(0, 1);
+    auto *opt = app.add_option("-i", val)->expected(0, 1);
     args = {"-i"};
     run();
     CHECK(app.count("-i") == 1u);
@@ -534,7 +536,7 @@ TEST_CASE_METHOD(TApp, "NumberFlags", "[app]") {
 TEST_CASE_METHOD(TApp, "DisableFlagOverrideTest", "[app]") {
 
     int val{0};
-    auto opt = app.add_flag("--1{1},--2{2},--3{3},--4{4},--5{5},--6{6}, --7{7}, --8{8}, --9{9}", val);
+    auto *opt = app.add_flag("--1{1},--2{2},--3{3},--4{4},--5{5},--6{6}, --7{7}, --8{8}, --9{9}", val);
     CHECK(!opt->get_disable_flag_override());
     opt->disable_flag_override();
     args = {"--7=5"};
@@ -609,7 +611,7 @@ TEST_CASE_METHOD(TApp, "StrangeOptionNames", "[app]") {
 
 TEST_CASE_METHOD(TApp, "FlagLikeOption", "[app]") {
     bool val{false};
-    auto opt = app.add_option("--flag", val)->type_size(0)->default_str("true");
+    auto *opt = app.add_option("--flag", val)->type_size(0)->default_str("true");
     args = {"--flag"};
     run();
     CHECK(app.count("--flag") == 1u);
@@ -625,7 +627,7 @@ TEST_CASE_METHOD(TApp, "FlagLikeOption", "[app]") {
 
 TEST_CASE_METHOD(TApp, "FlagLikeIntOption", "[app]") {
     int val{-47};
-    auto opt = app.add_option("--flag", val)->expected(0, 1);
+    auto *opt = app.add_option("--flag", val)->expected(0, 1);
     // normally some default value should be set, but this test is for some paths in the validators checks to skip
     // validation on empty string if nothing is expected
     opt->check(CLI::PositiveNumber);
@@ -678,7 +680,7 @@ TEST_CASE_METHOD(TApp, "ShortOpts", "[app]") {
 TEST_CASE_METHOD(TApp, "TwoParamTemplateOpts", "[app]") {
 
     double funnyint{0.0};
-    auto opt = app.add_option<double, unsigned int>("-y", funnyint);
+    auto *opt = app.add_option<double, unsigned int>("-y", funnyint);
 
     args = {"-y", "32"};
 
@@ -776,7 +778,7 @@ TEST_CASE_METHOD(TApp, "JoinOpt", "[app]") {
 
 TEST_CASE_METHOD(TApp, "SumOpt", "[app]") {
 
-    int val;
+    int val = 0;
     app.add_option("--val", val)->multi_option_policy(CLI::MultiOptionPolicy::Sum);
 
     args = {"--val=1", "--val=4"};
@@ -788,7 +790,7 @@ TEST_CASE_METHOD(TApp, "SumOpt", "[app]") {
 
 TEST_CASE_METHOD(TApp, "SumOptFloat", "[app]") {
 
-    double val;
+    double val = NAN;
     app.add_option("--val", val)->multi_option_policy(CLI::MultiOptionPolicy::Sum);
 
     args = {"--val=1.3", "--val=-0.7"};
@@ -846,7 +848,7 @@ TEST_CASE_METHOD(TApp, "TakeLastOptMulti_alternative_path", "[app]") {
 
 TEST_CASE_METHOD(TApp, "TakeLastOptMultiCheck", "[app]") {
     std::vector<int> vals;
-    auto opt = app.add_option("--long", vals)->expected(-2)->take_last();
+    auto *opt = app.add_option("--long", vals)->expected(-2)->take_last();
 
     opt->check(CLI::Validator(CLI::PositiveNumber).application_index(0));
     opt->check((!CLI::PositiveNumber).application_index(1));
@@ -979,7 +981,7 @@ TEST_CASE_METHOD(TApp, "emptyVectorReturn", "[app]") {
 
     std::vector<std::string> strs;
     std::vector<std::string> strs2;
-    auto opt1 = app.add_option("--str", strs)->required()->expected(0, 2);
+    auto *opt1 = app.add_option("--str", strs)->required()->expected(0, 2);
     app.add_option("--str2", strs2);
     args = {"--str"};
 
@@ -995,13 +997,13 @@ TEST_CASE_METHOD(TApp, "emptyVectorReturn", "[app]") {
 
     run();
 
-    CHECK(std::vector<std::string>{} == strs);
+    CHECK(strs.empty());
     CHECK(std::vector<std::string>{"{}"} == strs2);
     opt1->default_str("{}");
     args = {"--str"};
 
     CHECK_NOTHROW(run());
-    CHECK(std::vector<std::string>{} == strs);
+    CHECK(strs.empty());
 }
 
 TEST_CASE_METHOD(TApp, "RequiredOptsDoubleShort", "[app]") {
@@ -1096,7 +1098,7 @@ TEST_CASE_METHOD(TApp, "RequiredPositionals", "[app]") {
     sources.clear();
     run();
 
-    CHECK(0u == sources.size());
+    CHECK(sources.empty());
     CHECK("a" == dest);
 }
 
@@ -1130,7 +1132,7 @@ TEST_CASE_METHOD(TApp, "RequiredPositionalVector", "[app]") {
 // Tests positionals at end
 TEST_CASE_METHOD(TApp, "RequiredPositionalValidation", "[app]") {
     std::vector<std::string> sources;
-    int dest;  // required
+    int dest = 0;  // required
     std::string d2;
     app.add_option("src", sources);
     app.add_option("dest", dest)->required()->check(CLI::PositiveNumber);
@@ -1214,10 +1216,10 @@ TEST_CASE_METHOD(TApp, "RequiredOptsUnlimited", "[app]") {
 
     app.allow_extras(false);
     std::vector<std::string> remain;
-    auto popt = app.add_option("positional", remain);
+    auto *popt = app.add_option("positional", remain);
     run();
     CHECK(std::vector<std::string>({"one", "two"}) == strs);
-    CHECK(std::vector<std::string>() == remain);
+    CHECK(remain.empty());
 
     args = {"--str", "one", "--", "two"};
 
@@ -1265,7 +1267,7 @@ TEST_CASE_METHOD(TApp, "RequiredOptsUnlimitedShort", "[app]") {
     app.add_option("positional", remain);
     run();
     CHECK(std::vector<std::string>({"one", "two"}) == strs);
-    CHECK(std::vector<std::string>() == remain);
+    CHECK(remain.empty());
 
     args = {"-s", "one", "--", "two"};
 
@@ -1492,7 +1494,7 @@ TEST_CASE_METHOD(TApp, "Positionals", "[app]") {
 
 TEST_CASE_METHOD(TApp, "ForcedPositional", "[app]") {
     std::vector<std::string> posit;
-    auto one = app.add_flag("--one");
+    auto *one = app.add_flag("--one");
     app.add_option("posit", posit);
 
     args = {"--one", "two", "three"};
@@ -1597,7 +1599,7 @@ TEST_CASE_METHOD(TApp, "Reset", "[app]") {
 
 TEST_CASE_METHOD(TApp, "RemoveOption", "[app]") {
     app.add_flag("--one");
-    auto opt = app.add_flag("--two");
+    auto *opt = app.add_flag("--two");
 
     CHECK(app.remove_option(opt));
     CHECK(!app.remove_option(opt));
@@ -1608,8 +1610,8 @@ TEST_CASE_METHOD(TApp, "RemoveOption", "[app]") {
 }
 
 TEST_CASE_METHOD(TApp, "RemoveNeedsLinks", "[app]") {
-    auto one = app.add_flag("--one");
-    auto two = app.add_flag("--two");
+    auto *one = app.add_flag("--one");
+    auto *two = app.add_flag("--two");
 
     two->needs(one);
     one->needs(two);
@@ -1622,8 +1624,8 @@ TEST_CASE_METHOD(TApp, "RemoveNeedsLinks", "[app]") {
 }
 
 TEST_CASE_METHOD(TApp, "RemoveExcludesLinks", "[app]") {
-    auto one = app.add_flag("--one");
-    auto two = app.add_flag("--two");
+    auto *one = app.add_flag("--one");
+    auto *two = app.add_flag("--two");
 
     two->excludes(one);
     one->excludes(two);
@@ -1640,7 +1642,7 @@ TEST_CASE_METHOD(TApp, "FileNotExists", "[app]") {
     REQUIRE_NOTHROW(CLI::NonexistentPath(myfile));
 
     std::string filename;
-    auto opt = app.add_option("--file", filename)->check(CLI::NonexistentPath, "path_check");
+    auto *opt = app.add_option("--file", filename)->check(CLI::NonexistentPath, "path_check");
     args = {"--file", myfile};
 
     run();
@@ -1696,15 +1698,15 @@ TEST_CASE_METHOD(TApp, "NotFileExists", "[app]") {
 TEST_CASE_METHOD(TApp, "DefaultedResult", "[app]") {
     std::string sval = "NA";
     int ival{0};
-    auto opts = app.add_option("--string", sval)->capture_default_str();
-    auto optv = app.add_option("--val", ival);
+    auto *opts = app.add_option("--string", sval)->capture_default_str();
+    auto *optv = app.add_option("--val", ival);
     args = {};
     run();
     CHECK("NA" == sval);
     std::string nString;
     opts->results(nString);
     CHECK("NA" == nString);
-    int newIval;
+    int newIval = 0;
     // CHECK_THROWS_AS (optv->results(newIval), CLI::ConversionError);
     optv->default_str("442");
     optv->results(newIval);
@@ -1791,7 +1793,7 @@ TEST_CASE_METHOD(TApp, "NeedsMultiFlags", "[app]") {
     CLI::Option *opt1 = app.add_flag("--opt1");
     CLI::Option *opt2 = app.add_flag("--opt2");
     CLI::Option *opt3 = app.add_flag("--opt3");
-    app.add_flag("--optall")->needs(opt1, opt2, opt3);
+    app.add_flag("--optall")->needs(opt1, opt2, opt3);  // NOLINT(readability-suspicious-call-argument)
 
     run();
 
@@ -2121,20 +2123,20 @@ TEST_CASE_METHOD(TApp, "FallthroughParentFail", "[app]") {
 }
 
 TEST_CASE_METHOD(TApp, "FallthroughParents", "[app]") {
-    auto sub = app.add_subcommand("test");
+    auto *sub = app.add_subcommand("test");
     CHECK(&app == CLI::detail::AppFriend::get_fallthrough_parent(sub));
 
-    auto ssub = sub->add_subcommand("sub2");
+    auto *ssub = sub->add_subcommand("sub2");
     CHECK(sub == CLI::detail::AppFriend::get_fallthrough_parent(ssub));
 
-    auto og1 = app.add_option_group("g1");
-    auto og2 = og1->add_option_group("g2");
-    auto og3 = og2->add_option_group("g3");
+    auto *og1 = app.add_option_group("g1");
+    auto *og2 = og1->add_option_group("g2");
+    auto *og3 = og2->add_option_group("g3");
     CHECK(&app == CLI::detail::AppFriend::get_fallthrough_parent(og3));
 
-    auto ogb1 = sub->add_option_group("g1");
-    auto ogb2 = ogb1->add_option_group("g2");
-    auto ogb3 = ogb2->add_option_group("g3");
+    auto *ogb1 = sub->add_option_group("g1");
+    auto *ogb2 = ogb1->add_option_group("g2");
+    auto *ogb3 = ogb2->add_option_group("g3");
     CHECK(sub == CLI::detail::AppFriend::get_fallthrough_parent(ogb3));
 
     ogb2->name("groupb");
@@ -2153,7 +2155,7 @@ TEST_CASE_METHOD(TApp, "OptionWithDefaults", "[app]") {
 // Added to test ->transform
 TEST_CASE_METHOD(TApp, "OrderedModifyingTransforms", "[app]") {
     std::vector<std::string> val;
-    auto m = app.add_option("-m", val);
+    auto *m = app.add_option("-m", val);
     m->transform([](std::string x) { return x + "1"; });
     m->transform([](std::string x) { return x + "2"; });
 
@@ -2166,7 +2168,7 @@ TEST_CASE_METHOD(TApp, "OrderedModifyingTransforms", "[app]") {
 
 TEST_CASE_METHOD(TApp, "ThrowingTransform", "[app]") {
     std::string val;
-    auto m = app.add_option("-m,--mess", val);
+    auto *m = app.add_option("-m,--mess", val);
     m->transform([](std::string) -> std::string { throw CLI::ValidationError("My Message"); });
 
     REQUIRE_NOTHROW(run());
@@ -2188,7 +2190,7 @@ TEST_CASE_METHOD(TApp, "EachItem", "[app]") {
     std::vector<std::string> results;
     std::vector<std::string> dummy;
 
-    auto opt = app.add_option("--vec", dummy);
+    auto *opt = app.add_option("--vec", dummy);
 
     opt->each([&results](std::string item) { results.push_back(item); });
 
@@ -2259,7 +2261,7 @@ TEST_CASE_METHOD(TApp, "CustomUserSepParse", "[app]") {
 
     std::vector<int> vals{1, 2, 3};
     args = {"--idx", "1,2,3"};
-    auto opt = app.add_option("--idx", vals)->delimiter(',');
+    auto *opt = app.add_option("--idx", vals)->delimiter(',');
     run();
     CHECK(std::vector<int>({1, 2, 3}) == vals);
     std::vector<int> vals2;
@@ -2279,7 +2281,7 @@ TEST_CASE_METHOD(TApp, "DefaultUserSepParse", "[app]") {
 
     std::vector<std::string> vals;
     args = {"--idx", "1 2 3", "4 5 6"};
-    auto opt = app.add_option("--idx", vals, "");
+    auto *opt = app.add_option("--idx", vals, "");
     run();
     CHECK(std::vector<std::string>({"1 2 3", "4 5 6"}) == vals);
     opt->delimiter(',');
@@ -2303,7 +2305,7 @@ TEST_CASE_METHOD(TApp, "CustomUserSepParse2", "[app]") {
 
     std::vector<int> vals{1, 2, 3};
     args = {"--idx", "1,2,"};
-    auto opt = app.add_option("--idx", vals)->delimiter(',');
+    auto *opt = app.add_option("--idx", vals)->delimiter(',');
     run();
     CHECK(std::vector<int>({1, 2}) == vals);
 
@@ -2329,7 +2331,7 @@ TEST_CASE_METHOD(TApp, "CustomUserSepParseToggle", "[app]") {
 
     std::vector<std::string> vals;
     args = {"--idx", "1,2,3"};
-    auto opt = app.add_option("--idx", vals)->delimiter(',');
+    auto *opt = app.add_option("--idx", vals)->delimiter(',');
     run();
     CHECK(std::vector<std::string>({"1", "2", "3"}) == vals);
     opt->delimiter('\0');
@@ -2348,7 +2350,7 @@ TEST_CASE_METHOD(TApp, "CustomUserSepParse3", "[app]") {
             "1",
             ","
             "2"};
-    auto opt = app.add_option("--idx", vals)->delimiter(',');
+    auto *opt = app.add_option("--idx", vals)->delimiter(',');
     run();
     CHECK(std::vector<int>({1, 2}) == vals);
     app.remove_option(opt);
@@ -2363,7 +2365,7 @@ TEST_CASE_METHOD(TApp, "CustomUserSepParse4", "[app]") {
 
     std::vector<int> vals;
     args = {"--idx", "1,    2"};
-    auto opt = app.add_option("--idx", vals)->delimiter(',')->capture_default_str();
+    auto *opt = app.add_option("--idx", vals)->delimiter(',')->capture_default_str();
     run();
     CHECK(std::vector<int>({1, 2}) == vals);
 
@@ -2379,7 +2381,7 @@ TEST_CASE_METHOD(TApp, "CustomUserSepParse5", "[app]") {
 
     std::vector<std::string> bar;
     args = {"this", "is", "a", "test"};
-    auto opt = app.add_option("bar", bar, "bar");
+    auto *opt = app.add_option("bar", bar, "bar");
     run();
     CHECK(std::vector<std::string>({"this", "is", "a", "test"}) == bar);
 
@@ -2421,7 +2423,7 @@ TEST_CASE_METHOD(TApp, "logFormSingleDash", "[app]") {
 
 TEST_CASE("C20_compile", "simple") {
     CLI::App app{"test"};
-    auto flag = app.add_flag("--flag", "desc");
+    auto *flag = app.add_flag("--flag", "desc");
 
     app.parse("--flag");
     CHECK_FALSE(flag->empty());

--- a/tests/ComplexTypeTest.cpp
+++ b/tests/ComplexTypeTest.cpp
@@ -16,7 +16,7 @@ using cx = std::complex<double>;
 CLI::Option *
 add_option(CLI::App &app, std::string name, cx &variable, std::string description = "", bool defaulted = false) {
     CLI::callback_t fun = [&variable](CLI::results_t res) {
-        double x, y;
+        double x = 0, y = 0;
         bool worked = CLI::detail::lexical_cast(res[0], x) && CLI::detail::lexical_cast(res[1], y);
         if(worked)
             variable = cx(x, y);
@@ -89,7 +89,7 @@ template <> bool lexical_cast<std::complex<double>>(const std::string &input, st
 
     std::smatch m;
     double x{0.0}, y{0.0};
-    bool worked;
+    bool worked = false;
     std::regex_search(input, m, creg);
     if(m.size() == 9) {
         worked = CLI::detail::lexical_cast(m[1], x) && CLI::detail::lexical_cast(m[6], y);
@@ -162,8 +162,8 @@ class complex_new {
   public:
     complex_new() = default;
     complex_new(double v1, double v2) : val1_{v1}, val2_{v2} {};
-    double real() { return val1_; }
-    double imag() { return val2_; }
+    [[nodiscard]] double real() const { return val1_; }
+    [[nodiscard]] double imag() const { return val2_; }
 
   private:
     double val1_{0.0};

--- a/tests/ComplexTypeTest.cpp
+++ b/tests/ComplexTypeTest.cpp
@@ -162,8 +162,8 @@ class complex_new {
   public:
     complex_new() = default;
     complex_new(double v1, double v2) : val1_{v1}, val2_{v2} {};
-    [[nodiscard]] double real() const { return val1_; }
-    [[nodiscard]] double imag() const { return val2_; }
+    CLI11_NODISCARD double real() const { return val1_; }
+    CLI11_NODISCARD double imag() const { return val2_; }
 
   private:
     double val1_{0.0};

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -717,7 +717,7 @@ class Unstreamable {
 
   public:
     Unstreamable() = default;
-    [[nodiscard]] int get_x() const { return x_; }
+    CLI11_NODISCARD int get_x() const { return x_; }
     void set_x(int x) { x_ = x; }
 };
 

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -41,7 +41,7 @@ TEST_CASE_METHOD(TApp, "AddingExistingWithCase", "[creation]") {
 }
 
 TEST_CASE_METHOD(TApp, "AddingExistingWithCaseAfter", "[creation]") {
-    auto count = app.add_flag("-c,--count");
+    auto *count = app.add_flag("-c,--count");
     app.add_flag("--Cat,-C");
 
     CHECK_THROWS_AS(count->ignore_case(), CLI::OptionAlreadyAdded);
@@ -49,20 +49,20 @@ TEST_CASE_METHOD(TApp, "AddingExistingWithCaseAfter", "[creation]") {
 
 TEST_CASE_METHOD(TApp, "AddingExistingWithCaseAfter2", "[creation]") {
     app.add_flag("-c,--count");
-    auto cat = app.add_flag("--Cat,-C");
+    auto *cat = app.add_flag("--Cat,-C");
 
     CHECK_THROWS_AS(cat->ignore_case(), CLI::OptionAlreadyAdded);
 }
 
 TEST_CASE_METHOD(TApp, "AddingExistingWithUnderscoreAfter", "[creation]") {
-    auto count = app.add_flag("--underscore");
+    auto *count = app.add_flag("--underscore");
     app.add_flag("--under_score");
 
     CHECK_THROWS_AS(count->ignore_underscore(), CLI::OptionAlreadyAdded);
 }
 
 TEST_CASE_METHOD(TApp, "AddingExistingWithUnderscoreAfter2", "[creation]") {
-    auto count = app.add_flag("--under_score");
+    auto *count = app.add_flag("--under_score");
     app.add_flag("--underscore");
 
     CHECK_THROWS_AS(count->ignore_underscore(), CLI::OptionAlreadyAdded);
@@ -125,13 +125,13 @@ TEST_CASE_METHOD(TApp, "MultipleSubcomMatchingWithUnderscoreFirst", "[creation]"
 
 TEST_CASE_METHOD(TApp, "MultipleSubcomMatchingWithCaseInplace", "[creation]") {
     app.add_subcommand("first");
-    auto first = app.add_subcommand("fIrst");
+    auto *first = app.add_subcommand("fIrst");
 
     CHECK_THROWS_AS(first->ignore_case(), CLI::OptionAlreadyAdded);
 }
 
 TEST_CASE_METHOD(TApp, "MultipleSubcomMatchingWithCaseInplace2", "[creation]") {
-    auto first = app.add_subcommand("first");
+    auto *first = app.add_subcommand("first");
     app.add_subcommand("fIrst");
 
     CHECK_THROWS_AS(first->ignore_case(), CLI::OptionAlreadyAdded);
@@ -139,29 +139,29 @@ TEST_CASE_METHOD(TApp, "MultipleSubcomMatchingWithCaseInplace2", "[creation]") {
 
 TEST_CASE_METHOD(TApp, "MultipleSubcomMatchingWithUnderscoreInplace", "[creation]") {
     app.add_subcommand("first_option");
-    auto first = app.add_subcommand("firstoption");
+    auto *first = app.add_subcommand("firstoption");
 
     CHECK_THROWS_AS(first->ignore_underscore(), CLI::OptionAlreadyAdded);
 }
 
 TEST_CASE_METHOD(TApp, "MultipleSubcomMatchingWithUnderscoreInplace2", "[creation]") {
-    auto first = app.add_subcommand("firstoption");
+    auto *first = app.add_subcommand("firstoption");
     app.add_subcommand("first_option");
 
     CHECK_THROWS_AS(first->ignore_underscore(), CLI::OptionAlreadyAdded);
 }
 
 TEST_CASE_METHOD(TApp, "MultipleSubcomNoMatchingInplace2", "[creation]") {
-    auto first = app.add_subcommand("first");
-    auto second = app.add_subcommand("second");
+    auto *first = app.add_subcommand("first");
+    auto *second = app.add_subcommand("second");
 
     CHECK_NOTHROW(first->ignore_case());
     CHECK_NOTHROW(second->ignore_case());
 }
 
 TEST_CASE_METHOD(TApp, "MultipleSubcomNoMatchingInplaceUnderscore2", "[creation]") {
-    auto first = app.add_subcommand("first_option");
-    auto second = app.add_subcommand("second_option");
+    auto *first = app.add_subcommand("first_option");
+    auto *second = app.add_subcommand("second_option");
 
     CHECK_NOTHROW(first->ignore_underscore());
     CHECK_NOTHROW(second->ignore_underscore());
@@ -183,25 +183,25 @@ TEST_CASE_METHOD(TApp, "IncorrectConstructionFlagPositional3", "[creation]") {
 }
 
 TEST_CASE_METHOD(TApp, "IncorrectConstructionNeedsCannotFind", "[creation]") {
-    auto cat = app.add_flag("--cat");
+    auto *cat = app.add_flag("--cat");
     CHECK_THROWS_AS(cat->needs("--nothing"), CLI::IncorrectConstruction);
 }
 
 TEST_CASE_METHOD(TApp, "IncorrectConstructionExcludesCannotFind", "[creation]") {
-    auto cat = app.add_flag("--cat");
+    auto *cat = app.add_flag("--cat");
     CHECK_THROWS_AS(cat->excludes("--nothing"), CLI::IncorrectConstruction);
 }
 
 TEST_CASE_METHOD(TApp, "IncorrectConstructionDuplicateNeeds", "[creation]") {
-    auto cat = app.add_flag("--cat");
-    auto other = app.add_flag("--other");
+    auto *cat = app.add_flag("--cat");
+    auto *other = app.add_flag("--other");
     REQUIRE_NOTHROW(cat->needs(other));
     // duplicated needs is redundant but not an error
     CHECK_NOTHROW(cat->needs(other));
 }
 
 TEST_CASE_METHOD(TApp, "IncorrectConstructionDuplicateNeedsTxt", "[creation]") {
-    auto cat = app.add_flag("--cat");
+    auto *cat = app.add_flag("--cat");
     app.add_flag("--other");
     REQUIRE_NOTHROW(cat->needs("--other"));
     // duplicate needs is redundant but not an error
@@ -210,28 +210,28 @@ TEST_CASE_METHOD(TApp, "IncorrectConstructionDuplicateNeedsTxt", "[creation]") {
 
 // Now allowed
 TEST_CASE_METHOD(TApp, "CorrectConstructionDuplicateExcludes", "[creation]") {
-    auto cat = app.add_flag("--cat");
-    auto other = app.add_flag("--other");
+    auto *cat = app.add_flag("--cat");
+    auto *other = app.add_flag("--other");
     REQUIRE_NOTHROW(cat->excludes(other));
     REQUIRE_NOTHROW(other->excludes(cat));
 }
 
 // Now allowed
 TEST_CASE_METHOD(TApp, "CorrectConstructionDuplicateExcludesTxt", "[creation]") {
-    auto cat = app.add_flag("--cat");
-    auto other = app.add_flag("--other");
+    auto *cat = app.add_flag("--cat");
+    auto *other = app.add_flag("--other");
     REQUIRE_NOTHROW(cat->excludes("--other"));
     REQUIRE_NOTHROW(other->excludes("--cat"));
 }
 
 TEST_CASE_METHOD(TApp, "CheckName", "[creation]") {
-    auto long1 = app.add_flag("--long1");
-    auto long2 = app.add_flag("--Long2");
-    auto short1 = app.add_flag("-a");
-    auto short2 = app.add_flag("-B");
+    auto *long1 = app.add_flag("--long1");
+    auto *long2 = app.add_flag("--Long2");
+    auto *short1 = app.add_flag("-a");
+    auto *short2 = app.add_flag("-B");
     int x{0}, y{0};
-    auto pos1 = app.add_option("pos1", x);
-    auto pos2 = app.add_option("pOs2", y);
+    auto *pos1 = app.add_option("pos1", x);
+    auto *pos2 = app.add_option("pOs2", y);
 
     CHECK(long1->check_name("--long1"));
     CHECK(!long1->check_name("--lonG1"));
@@ -253,13 +253,13 @@ TEST_CASE_METHOD(TApp, "CheckName", "[creation]") {
 }
 
 TEST_CASE_METHOD(TApp, "CheckNameNoCase", "[creation]") {
-    auto long1 = app.add_flag("--long1")->ignore_case();
-    auto long2 = app.add_flag("--Long2")->ignore_case();
-    auto short1 = app.add_flag("-a")->ignore_case();
-    auto short2 = app.add_flag("-B")->ignore_case();
+    auto *long1 = app.add_flag("--long1")->ignore_case();
+    auto *long2 = app.add_flag("--Long2")->ignore_case();
+    auto *short1 = app.add_flag("-a")->ignore_case();
+    auto *short2 = app.add_flag("-B")->ignore_case();
     int x{0}, y{0};
-    auto pos1 = app.add_option("pos1", x)->ignore_case();
-    auto pos2 = app.add_option("pOs2", y)->ignore_case();
+    auto *pos1 = app.add_option("pos1", x)->ignore_case();
+    auto *pos2 = app.add_option("pOs2", y)->ignore_case();
 
     CHECK(long1->check_name("--long1"));
     CHECK(long1->check_name("--lonG1"));
@@ -281,12 +281,12 @@ TEST_CASE_METHOD(TApp, "CheckNameNoCase", "[creation]") {
 }
 
 TEST_CASE_METHOD(TApp, "CheckNameNoUnderscore", "[creation]") {
-    auto long1 = app.add_flag("--longoption1")->ignore_underscore();
-    auto long2 = app.add_flag("--long_option2")->ignore_underscore();
+    auto *long1 = app.add_flag("--longoption1")->ignore_underscore();
+    auto *long2 = app.add_flag("--long_option2")->ignore_underscore();
 
     int x{0}, y{0};
-    auto pos1 = app.add_option("pos_option_1", x)->ignore_underscore();
-    auto pos2 = app.add_option("posoption2", y)->ignore_underscore();
+    auto *pos1 = app.add_option("pos_option_1", x)->ignore_underscore();
+    auto *pos2 = app.add_option("posoption2", y)->ignore_underscore();
 
     CHECK(long1->check_name("--long_option1"));
     CHECK(long1->check_name("--longoption_1"));
@@ -312,12 +312,12 @@ TEST_CASE_METHOD(TApp, "CheckNameNoUnderscore", "[creation]") {
 }
 
 TEST_CASE_METHOD(TApp, "CheckNameNoCaseNoUnderscore", "[creation]") {
-    auto long1 = app.add_flag("--LongoptioN1")->ignore_underscore()->ignore_case();
-    auto long2 = app.add_flag("--long_Option2")->ignore_case()->ignore_underscore();
+    auto *long1 = app.add_flag("--LongoptioN1")->ignore_underscore()->ignore_case();
+    auto *long2 = app.add_flag("--long_Option2")->ignore_case()->ignore_underscore();
 
     int x{0}, y{0};
-    auto pos1 = app.add_option("pos_Option_1", x)->ignore_underscore()->ignore_case();
-    auto pos2 = app.add_option("posOption2", y)->ignore_case()->ignore_underscore();
+    auto *pos1 = app.add_option("pos_Option_1", x)->ignore_underscore()->ignore_case();
+    auto *pos2 = app.add_option("posOption2", y)->ignore_case()->ignore_underscore();
 
     CHECK(long1->check_name("--Long_Option1"));
     CHECK(long1->check_name("--lONgoption_1"));
@@ -344,7 +344,7 @@ TEST_CASE_METHOD(TApp, "CheckNameNoCaseNoUnderscore", "[creation]") {
 
 TEST_CASE_METHOD(TApp, "PreSpaces", "[creation]") {
     int x{0};
-    auto myapp = app.add_option(" -a, --long, other", x);
+    auto *myapp = app.add_option(" -a, --long, other", x);
 
     CHECK(myapp->check_lname("long"));
     CHECK(myapp->check_sname("a"));
@@ -353,7 +353,7 @@ TEST_CASE_METHOD(TApp, "PreSpaces", "[creation]") {
 
 TEST_CASE_METHOD(TApp, "AllSpaces", "[creation]") {
     int x{0};
-    auto myapp = app.add_option(" -a , --long , other ", x);
+    auto *myapp = app.add_option(" -a , --long , other ", x);
 
     CHECK(myapp->check_lname("long"));
     CHECK(myapp->check_sname("a"));
@@ -365,26 +365,26 @@ TEST_CASE_METHOD(TApp, "OptionFromDefaults", "[creation]") {
 
     // Options should remember defaults
     int x{0};
-    auto opt = app.add_option("--simple", x);
+    auto *opt = app.add_option("--simple", x);
     CHECK(opt->get_required());
 
     // Flags cannot be required
-    auto flag = app.add_flag("--other");
+    auto *flag = app.add_flag("--other");
     CHECK(!flag->get_required());
 
     app.option_defaults()->required(false);
-    auto opt2 = app.add_option("--simple2", x);
+    auto *opt2 = app.add_option("--simple2", x);
     CHECK(!opt2->get_required());
 
     app.option_defaults()->required()->ignore_case();
 
-    auto opt3 = app.add_option("--simple3", x);
+    auto *opt3 = app.add_option("--simple3", x);
     CHECK(opt3->get_required());
     CHECK(opt3->get_ignore_case());
 
     app.option_defaults()->required()->ignore_underscore();
 
-    auto opt4 = app.add_option("--simple4", x);
+    auto *opt4 = app.add_option("--simple4", x);
     CHECK(opt4->get_required());
     CHECK(opt4->get_ignore_underscore());
 }
@@ -408,7 +408,7 @@ TEST_CASE_METHOD(TApp, "OptionFromDefaultsSubcommands", "[creation]") {
         ->disable_flag_override()
         ->group("Something");
 
-    auto app2 = app.add_subcommand("app2");
+    auto *app2 = app.add_subcommand("app2");
 
     CHECK(app2->option_defaults()->get_required());
     CHECK(CLI::MultiOptionPolicy::TakeLast == app2->option_defaults()->get_multi_option_policy());
@@ -421,10 +421,10 @@ TEST_CASE_METHOD(TApp, "OptionFromDefaultsSubcommands", "[creation]") {
 
 TEST_CASE_METHOD(TApp, "GetNameCheck", "[creation]") {
     int x{0};
-    auto a = app.add_flag("--that");
-    auto b = app.add_flag("-x");
-    auto c = app.add_option("pos", x);
-    auto d = app.add_option("one,-o,--other", x);
+    auto *a = app.add_flag("--that");
+    auto *b = app.add_flag("-x");
+    auto *c = app.add_option("pos", x);
+    auto *d = app.add_option("one,-o,--other", x);
 
     CHECK("--that" == a->get_name(false, true));
     CHECK("-x" == b->get_name(false, true));
@@ -455,7 +455,7 @@ TEST_CASE_METHOD(TApp, "SubcommandDefaults", "[creation]") {
     CHECK(!app.get_configurable());
     CHECK(!app.get_validate_positionals());
 
-    CHECK("" == app.get_footer());
+    CHECK(app.get_footer().empty());
     CHECK("Subcommands" == app.get_group());
     CHECK(0u == app.get_require_subcommand_min());
     CHECK(0u == app.get_require_subcommand_max());
@@ -478,7 +478,7 @@ TEST_CASE_METHOD(TApp, "SubcommandDefaults", "[creation]") {
     app.group("Stuff");
     app.require_subcommand(2, 3);
 
-    auto app2 = app.add_subcommand("app2");
+    auto *app2 = app.add_subcommand("app2");
 
     // Initial defaults
     CHECK(app2->get_allow_extras());
@@ -533,8 +533,8 @@ TEST_CASE_METHOD(TApp, "SubcommandMinMax", "[creation]") {
 
 TEST_CASE_METHOD(TApp, "GetOptionList", "[creation]") {
     int two{0};
-    auto flag = app.add_flag("--one");
-    auto opt = app.add_option("--two", two);
+    auto *flag = app.add_flag("--one");
+    auto *opt = app.add_option("--two", two);
 
     const CLI::App &const_app = app;  // const alias to force use of const-methods
     std::vector<const CLI::Option *> opt_list = const_app.get_options();
@@ -561,9 +561,9 @@ TEST_CASE("ValidatorTests: TestValidatorCreation", "[creation]") {
     CHECK(V.get_active());
 
     CHECK("test" == V("test"));
-    CHECK(std::string{} == V("test5"));
+    CHECK(V("test5").empty());
 
-    CHECK(std::string{} == V.get_description());
+    CHECK(V.get_description().empty());
     V.description("this is a description");
     CHECK("this is a description" == V.get_description());
 }
@@ -717,7 +717,7 @@ class Unstreamable {
 
   public:
     Unstreamable() = default;
-    int get_x() const { return x_; }
+    [[nodiscard]] int get_x() const { return x_; }
     void set_x(int x) { x_ = x; }
 };
 
@@ -725,7 +725,7 @@ class Unstreamable {
 static_assert(!CLI::detail::is_istreamable<Unstreamable, std::istream>::value, "Unstreamable type is streamable");
 
 std::istream &operator>>(std::istream &in, Unstreamable &value) {
-    int x;
+    int x = 0;
     in >> x;
     value.set_x(x);
     return in;

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -105,7 +105,7 @@ TEST_CASE("THelp: deprecatedOptions", "[help]") {
     CLI::App app{"My prog"};
 
     std::string x;
-    auto soption = app.add_option("--something", x, "My option here");
+    auto *soption = app.add_option("--something", x, "My option here");
     app.add_option("--something_else", x, "My option here");
     std::string y;
     app.add_option("--another", y);
@@ -159,7 +159,7 @@ TEST_CASE("THelp: retiredOptions", "[help]") {
     CLI::App app{"My prog"};
 
     std::string x;
-    auto opt1 = app.add_option("--something", x, "My option here");
+    auto *opt1 = app.add_option("--something", x, "My option here");
     app.add_option("--something_else", x, "My option here");
     std::string y;
     app.add_option("--another", y);
@@ -213,7 +213,7 @@ TEST_CASE("THelp: retiredOptions3", "[help]") {
 TEST_CASE("THelp: HiddenGroup", "[help]") {
     CLI::App app{"My prog"};
     // empty option group name should be hidden
-    auto hgroup = app.add_option_group("");
+    auto *hgroup = app.add_option_group("");
     std::string x;
     hgroup->add_option("something", x, "My option here");
     std::string y;
@@ -442,7 +442,7 @@ TEST_CASE("THelp: ManualSetterOverFunction", "[help]") {
 TEST_CASE("THelp: Subcom", "[help]") {
     CLI::App app{"My prog"};
 
-    auto sub1 = app.add_subcommand("sub1");
+    auto *sub1 = app.add_subcommand("sub1");
     app.add_subcommand("sub2");
 
     std::string help = app.help();
@@ -456,8 +456,8 @@ TEST_CASE("THelp: Subcom", "[help]") {
     help = sub1->help();
     CHECK_THAT(help, Contains("Usage: sub1"));
 
-    char x[] = "./myprogram";
-    char y[] = "sub2";
+    char x[] = "./myprogram";  // NOLINT(modernize-avoid-c-arrays)
+    char y[] = "sub2";         // NOLINT(modernize-avoid-c-arrays)
 
     std::vector<char *> args = {x, y};
     app.parse(static_cast<int>(args.size()), args.data());
@@ -469,7 +469,7 @@ TEST_CASE("THelp: Subcom", "[help]") {
 TEST_CASE("THelp: Subcom_alias", "[help]") {
     CLI::App app{"My prog"};
 
-    auto sub1 = app.add_subcommand("sub1", "Subcommand1 description test");
+    auto *sub1 = app.add_subcommand("sub1", "Subcommand1 description test");
     sub1->alias("sub_alias1");
     sub1->alias("sub_alias2");
 
@@ -484,7 +484,7 @@ TEST_CASE("THelp: Subcom_alias", "[help]") {
 TEST_CASE("THelp: Subcom_alias_group", "[help]") {
     CLI::App app{"My prog"};
 
-    auto sub1 = app.add_subcommand("", "Subcommand1 description test");
+    auto *sub1 = app.add_subcommand("", "Subcommand1 description test");
     sub1->alias("sub_alias1");
     sub1->alias("sub_alias2");
 
@@ -499,7 +499,7 @@ TEST_CASE("THelp: Subcom_alias_group", "[help]") {
 TEST_CASE("THelp: MasterName", "[help]") {
     CLI::App app{"My prog", "MyRealName"};
 
-    char x[] = "./myprogram";
+    char x[] = "./myprogram";  // NOLINT(modernize-avoid-c-arrays)
 
     std::vector<char *> args = {x};
     app.parse(static_cast<int>(args.size()), args.data());
@@ -699,9 +699,9 @@ TEST_CASE("THelp: NiceName", "[help]") {
     CLI::App app;
 
     int x{0};
-    auto long_name = app.add_option("-s,--long,-q,--other,that", x);
-    auto short_name = app.add_option("more,-x,-y", x);
-    auto positional = app.add_option("posit", x);
+    auto *long_name = app.add_option("-s,--long,-q,--other,that", x);
+    auto *short_name = app.add_option("more,-x,-y", x);
+    auto *positional = app.add_option("posit", x);
 
     CHECK("--long" == long_name->get_name());
     CHECK("-x" == short_name->get_name());
@@ -768,25 +768,25 @@ struct CapturedHelp {
 
 TEST_CASE_METHOD(CapturedHelp, "Successful", "[help]") {
     CHECK(0 == run(CLI::Success()));
-    CHECK("" == out.str());
-    CHECK("" == err.str());
+    CHECK(out.str().empty());
+    CHECK(err.str().empty());
 }
 
 TEST_CASE_METHOD(CapturedHelp, "JustAnError", "[help]") {
     CHECK(42 == run(CLI::RuntimeError(42)));
-    CHECK("" == out.str());
-    CHECK("" == err.str());
+    CHECK(out.str().empty());
+    CHECK(err.str().empty());
 }
 
 TEST_CASE_METHOD(CapturedHelp, "CallForHelp", "[help]") {
     CHECK(0 == run(CLI::CallForHelp()));
     CHECK(app.help() == out.str());
-    CHECK("" == err.str());
+    CHECK(err.str().empty());
 }
 TEST_CASE_METHOD(CapturedHelp, "CallForAllHelp", "[help]") {
     CHECK(0 == run(CLI::CallForAllHelp()));
     CHECK(app.help("", CLI::AppFormatMode::All) == out.str());
-    CHECK("" == err.str());
+    CHECK(err.str().empty());
 }
 TEST_CASE_METHOD(CapturedHelp, "CallForAllHelpOutput", "[help]") {
     app.set_help_all_flag("--help-all", "Help all");
@@ -796,7 +796,7 @@ TEST_CASE_METHOD(CapturedHelp, "CallForAllHelpOutput", "[help]") {
 
     CHECK(0 == run(CLI::CallForAllHelp()));
     CHECK(app.help("", CLI::AppFormatMode::All) == out.str());
-    CHECK("" == err.str());
+    CHECK(err.str().empty());
     CHECK_THAT(out.str(), Contains("one"));
     CHECK_THAT(out.str(), Contains("two"));
     CHECK_THAT(out.str(), Contains("--three"));
@@ -819,12 +819,12 @@ TEST_CASE_METHOD(CapturedHelp, "NewFormattedHelp", "[help]") {
     app.formatter_fn([](const CLI::App *, std::string, CLI::AppFormatMode) { return "New Help"; });
     CHECK(0 == run(CLI::CallForHelp()));
     CHECK("New Help" == out.str());
-    CHECK("" == err.str());
+    CHECK(err.str().empty());
 }
 
 TEST_CASE_METHOD(CapturedHelp, "NormalError", "[help]") {
     CHECK(static_cast<int>(CLI::ExitCodes::ExtrasError) == run(CLI::ExtrasError({"Thing"})));
-    CHECK("" == out.str());
+    CHECK(out.str().empty());
     CHECK_THAT(err.str(), Contains("for more information"));
     CHECK_THAT(err.str(), !Contains("ExtrasError"));
     CHECK_THAT(err.str(), Contains("Thing"));
@@ -835,7 +835,7 @@ TEST_CASE_METHOD(CapturedHelp, "NormalError", "[help]") {
 TEST_CASE_METHOD(CapturedHelp, "DoubleError", "[help]") {
     app.set_help_all_flag("--help-all");
     CHECK(static_cast<int>(CLI::ExitCodes::ExtrasError) == run(CLI::ExtrasError({"Thing"})));
-    CHECK("" == out.str());
+    CHECK(out.str().empty());
     CHECK_THAT(err.str(), Contains("for more information"));
     CHECK_THAT(err.str(), Contains(" --help "));
     CHECK_THAT(err.str(), Contains(" --help-all "));
@@ -849,7 +849,7 @@ TEST_CASE_METHOD(CapturedHelp, "AllOnlyError", "[help]") {
     app.set_help_all_flag("--help-all");
     app.set_help_flag();
     CHECK(static_cast<int>(CLI::ExitCodes::ExtrasError) == run(CLI::ExtrasError({"Thing"})));
-    CHECK("" == out.str());
+    CHECK(out.str().empty());
     CHECK_THAT(err.str(), Contains("for more information"));
     CHECK_THAT(err.str(), !Contains(" --help "));
     CHECK_THAT(err.str(), Contains(" --help-all "));
@@ -863,7 +863,7 @@ TEST_CASE_METHOD(CapturedHelp, "ReplacedError", "[help]") {
     app.failure_message(CLI::FailureMessage::help);
 
     CHECK(static_cast<int>(CLI::ExitCodes::ExtrasError) == run(CLI::ExtrasError({"Thing"})));
-    CHECK("" == out.str());
+    CHECK(out.str().empty());
     CHECK_THAT(err.str(), !Contains("for more information"));
     CHECK_THAT(err.str(), Contains("ERROR: ExtrasError"));
     CHECK_THAT(err.str(), Contains("Thing"));
@@ -877,7 +877,7 @@ TEST_CASE("THelp: CustomDoubleOption", "[help]") {
 
     CLI::App app;
 
-    auto opt = app.add_option("posit", [&custom_opt](CLI::results_t vals) {
+    auto *opt = app.add_option("posit", [&custom_opt](CLI::results_t vals) {
         custom_opt = {stol(vals.at(0)), stod(vals.at(1))};
         return true;
     });
@@ -889,7 +889,7 @@ TEST_CASE("THelp: CustomDoubleOption", "[help]") {
 TEST_CASE("THelp: CheckEmptyTypeName", "[help]") {
     CLI::App app;
 
-    auto opt = app.add_flag("-f,--flag");
+    auto *opt = app.add_flag("-f,--flag");
     std::string name = opt->get_type_name();
     CHECK(name.empty());
 }
@@ -921,7 +921,7 @@ TEST_CASE("THelp: AccessOptionDescription", "[help]") {
     CLI::App app{};
 
     int x{0};
-    auto opt = app.add_option("-a,--alpha", x, "My description goes here");
+    auto *opt = app.add_option("-a,--alpha", x, "My description goes here");
 
     CHECK("My description goes here" == opt->get_description());
 }
@@ -930,7 +930,7 @@ TEST_CASE("THelp: SetOptionDescriptionAfterCreation", "[help]") {
     CLI::App app{};
 
     int x{0};
-    auto opt = app.add_option("-a,--alpha", x);
+    auto *opt = app.add_option("-a,--alpha", x);
     opt->description("My description goes here");
 
     CHECK("My description goes here" == opt->get_description());
@@ -941,7 +941,7 @@ TEST_CASE("THelp: CleanNeeds", "[help]") {
     CLI::App app;
 
     int x{0};
-    auto a_name = app.add_option("-a,--alpha", x);
+    auto *a_name = app.add_option("-a,--alpha", x);
     app.add_option("-b,--boo", x)->needs(a_name);
 
     CHECK_THAT(app.help(), !Contains("Requires"));
@@ -1260,7 +1260,7 @@ TEST_CASE("TVersion: parse_throw", "[help]") {
     CHECK_THROWS_AS(app.parse("--version"), CLI::CallForVersion);
     CHECK_THROWS_AS(app.parse("--version --arg2 5"), CLI::CallForVersion);
 
-    auto ptr = app.get_version_ptr();
+    auto *ptr = app.get_version_ptr();
 
     ptr->ignore_case();
     try {
@@ -1269,7 +1269,7 @@ TEST_CASE("TVersion: parse_throw", "[help]") {
         CHECK_THAT(CLI11_VERSION, Catch::Equals(v.what()));
         CHECK(0 == v.get_exit_code());
         const auto &appc = app;
-        auto cptr = appc.get_version_ptr();
+        const auto *cptr = appc.get_version_ptr();
         CHECK(1U == cptr->count());
     }
 }

--- a/tests/NewParseTest.cpp
+++ b/tests/NewParseTest.cpp
@@ -210,11 +210,12 @@ template <class X> class objWrapper {
     objWrapper(const objWrapper &ow) = default;
     template <class TT> objWrapper(const TT &obj) = delete;
     objWrapper &operator=(const objWrapper &) = default;
-    objWrapper &operator=(objWrapper &&) noexcept = default;
+    // noexcept not allowed below by GCC 4.8
+    objWrapper &operator=(objWrapper &&) = default;  // NOLINT(performance-noexcept-move-constructor)
     // delete all other assignment operators
     template <typename TT> void operator=(TT &&obj) = delete;
 
-    [[nodiscard]] const X &value() const { return val_; }
+    CLI11_NODISCARD const X &value() const { return val_; }
 
   private:
     X val_{};
@@ -313,8 +314,8 @@ class dobjWrapper {
     explicit dobjWrapper(double obj) : dval_{obj} {};
     explicit dobjWrapper(int obj) : ival_{obj} {};
 
-    [[nodiscard]] double dvalue() const { return dval_; }
-    [[nodiscard]] int ivalue() const { return ival_; }
+    CLI11_NODISCARD double dvalue() const { return dval_; }
+    CLI11_NODISCARD int ivalue() const { return ival_; }
 
   private:
     double dval_{0.0};
@@ -358,7 +359,7 @@ template <class X> class AobjWrapper {
     // delete all other assignment operators
     template <typename TT> void operator=(TT &&obj) = delete;
 
-    [[nodiscard]] const X &value() const { return val_; }
+    CLI11_NODISCARD const X &value() const { return val_; }
 
   private:
     X val_{};
@@ -391,7 +392,7 @@ TEST_CASE_METHOD(TApp, "uint16Wrapper", "[newparse]") {
 template <class T> class SimpleWrapper {
   public:
     SimpleWrapper() = default;
-    ;
+
     explicit SimpleWrapper(T initial) : val_{std::move(initial)} {};
     T &getRef() { return val_; }
     using value_type = T;

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -421,7 +421,7 @@ struct ManyGroups : public TApp {
         g3->add_option("--val3", val3);
     }
 
-    void remove_required() const {
+    void remove_required() {  // NOLINT(readability-make-member-function-const)
         g1->get_option("--name1")->required(false);
         g2->get_option("--name2")->required(false);
         g3->get_option("--name3")->required(false);

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -11,8 +11,8 @@ using Catch::Matchers::Contains;
 using vs_t = std::vector<std::string>;
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroup", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
-    int res;
+    auto *ogroup = app.add_option_group("clusters");
+    int res = 0;
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
     ogroup->add_option("--test3", res);
@@ -34,7 +34,7 @@ TEST_CASE_METHOD(TApp, "OptionGroupInvalidNames", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroupExact", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
@@ -58,7 +58,7 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupExact", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroupExactTooMany", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
@@ -71,7 +71,7 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupExactTooMany", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroupMinMax", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
@@ -95,7 +95,7 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupMinMax", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroupMinMaxDifferent", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
@@ -123,7 +123,7 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupMinMaxDifferent", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroupMinMaxDifferentReversed", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
@@ -155,12 +155,12 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupMinMaxDifferentReversed", "[optiongroup]
 }
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroupMax", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
     ogroup->add_option("--test3", res);
-    int val2;
+    int val2 = 0;
     app.add_option("--option", val2);
     ogroup->require_option(-2);
     args = {"--test1", "5"};
@@ -179,7 +179,7 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupMax", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroupMax1", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
@@ -203,7 +203,7 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupMax1", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroupMin", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
@@ -224,7 +224,7 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupMin", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroupExact2", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
@@ -248,7 +248,7 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupExact2", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroupMin2", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
     ogroup->add_option("--test2", res);
@@ -271,13 +271,13 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupMin2", "[optiongroup]") {
 TEST_CASE_METHOD(TApp, "BasicOptionGroupMinMoved", "[optiongroup]") {
 
     int res{0};
-    auto opt1 = app.add_option("--test1", res);
-    auto opt2 = app.add_option("--test2", res);
-    auto opt3 = app.add_option("--test3", res);
+    auto *opt1 = app.add_option("--test1", res);
+    auto *opt2 = app.add_option("--test2", res);
+    auto *opt3 = app.add_option("--test3", res);
     int val2{0};
     app.add_option("--option", val2);
 
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     ogroup->require_option();
     ogroup->add_option(opt1);
     ogroup->add_option(opt2);
@@ -300,13 +300,13 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupMinMoved", "[optiongroup]") {
 TEST_CASE_METHOD(TApp, "BasicOptionGroupMinMovedAsGroup", "[optiongroup]") {
 
     int res{0};
-    auto opt1 = app.add_option("--test1", res);
-    auto opt2 = app.add_option("--test2", res);
-    auto opt3 = app.add_option("--test3", res);
+    auto *opt1 = app.add_option("--test1", res);
+    auto *opt2 = app.add_option("--test2", res);
+    auto *opt3 = app.add_option("--test3", res);
     int val2{0};
     app.add_option("--option", val2);
 
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     ogroup->require_option();
     ogroup->add_options(opt1, opt2, opt3);
 
@@ -328,17 +328,17 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupMinMovedAsGroup", "[optiongroup]") {
 TEST_CASE_METHOD(TApp, "BasicOptionGroupAddFailures", "[optiongroup]") {
 
     int res{0};
-    auto opt1 = app.add_option("--test1", res);
+    auto *opt1 = app.add_option("--test1", res);
     app.set_config("--config");
     int val2{0};
     app.add_option("--option", val2);
 
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     CHECK_THROWS_AS(ogroup->add_options(app.get_config_ptr()), CLI::OptionAlreadyAdded);
     CHECK_THROWS_AS(ogroup->add_options(app.get_help_ptr()), CLI::OptionAlreadyAdded);
 
-    auto sub = app.add_subcommand("sub", "subcommand");
-    auto opt2 = sub->add_option("--option2", val2);
+    auto *sub = app.add_subcommand("sub", "subcommand");
+    auto *opt2 = sub->add_option("--option2", val2);
 
     CHECK_THROWS_AS(ogroup->add_option(opt2), CLI::OptionNotFound);
 
@@ -346,7 +346,7 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupAddFailures", "[optiongroup]") {
 
     ogroup->add_option(opt1);
 
-    auto opt3 = app.add_option("--test1", res);
+    auto *opt3 = app.add_option("--test1", res);
 
     CHECK_THROWS_AS(ogroup->add_option(opt3), CLI::OptionAlreadyAdded);
 }
@@ -354,14 +354,14 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupAddFailures", "[optiongroup]") {
 TEST_CASE_METHOD(TApp, "BasicOptionGroupScrewedUpMove", "[optiongroup]") {
 
     int res{0};
-    auto opt1 = app.add_option("--test1", res);
-    auto opt2 = app.add_option("--test2", res);
+    auto *opt1 = app.add_option("--test1", res);
+    auto *opt2 = app.add_option("--test2", res);
     int val2{0};
     app.add_option("--option", val2);
 
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     ogroup->require_option();
-    auto ogroup2 = ogroup->add_option_group("clusters2");
+    auto *ogroup2 = ogroup->add_option_group("clusters2");
     CHECK_THROWS_AS(ogroup2->add_options(opt1, opt2), CLI::OptionNotFound);
 
     CLI::Option_group EmptyGroup("description", "new group", nullptr);
@@ -371,7 +371,7 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupScrewedUpMove", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(TApp, "InvalidOptions", "[optiongroup]") {
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     CLI::Option *opt = nullptr;
     CHECK_THROWS_AS(ogroup->excludes(opt), CLI::OptionNotFound);
     CLI::App *app_p = nullptr;
@@ -382,7 +382,7 @@ TEST_CASE_METHOD(TApp, "InvalidOptions", "[optiongroup]") {
 
 TEST_CASE_METHOD(TApp, "OptionGroupInheritedOptionDefaults", "[optiongroup]") {
     app.option_defaults()->ignore_case();
-    auto ogroup = app.add_option_group("clusters");
+    auto *ogroup = app.add_option_group("clusters");
     int res{0};
     ogroup->add_option("--test1", res);
 
@@ -421,7 +421,7 @@ struct ManyGroups : public TApp {
         g3->add_option("--val3", val3);
     }
 
-    void remove_required() {
+    void remove_required() const {
         g1->get_option("--name1")->required(false);
         g2->get_option("--name2")->required(false);
         g3->get_option("--name3")->required(false);
@@ -486,8 +486,8 @@ TEST_CASE_METHOD(ManyGroups, "NeedsGroup", "[optiongroup]") {
 // test adding an option group with existing subcommands to an app
 TEST_CASE_METHOD(TApp, "ExistingSubcommandMatch", "[optiongroup]") {
     auto sshared = std::make_shared<CLI::Option_group>("documenting the subcommand", "sub1g", nullptr);
-    auto s1 = sshared->add_subcommand("sub1");
-    auto o1 = sshared->add_option_group("opt1");
+    auto *s1 = sshared->add_subcommand("sub1");
+    auto *o1 = sshared->add_option_group("opt1");
     o1->add_subcommand("sub3")->alias("sub4");
 
     app.add_subcommand("sub1");
@@ -597,9 +597,9 @@ TEST_CASE_METHOD(ManyGroups, "DisableFirst", "[optiongroup]") {
 TEST_CASE_METHOD(ManyGroups, "SameSubcommand", "[optiongroup]") {
     // only 1 group can be used if remove_required not used
     remove_required();
-    auto sub1 = g1->add_subcommand("sub1")->disabled();
-    auto sub2 = g2->add_subcommand("sub1")->disabled();
-    auto sub3 = g3->add_subcommand("sub1");
+    auto *sub1 = g1->add_subcommand("sub1")->disabled();
+    auto *sub2 = g2->add_subcommand("sub1")->disabled();
+    auto *sub3 = g3->add_subcommand("sub1");
     // so when the subcommands are disabled they can have the same name
     sub1->disabled(false);
     sub2->disabled(false);
@@ -679,7 +679,7 @@ TEST_CASE_METHOD(ManyGroups, "Inheritance", "[optiongroup]") {
     remove_required();
     g1->ignore_case();
     g1->ignore_underscore();
-    auto t2 = g1->add_subcommand("t2");
+    auto *t2 = g1->add_subcommand("t2");
     args = {"T2", "t_2"};
     CHECK(t2->get_ignore_underscore());
     CHECK(t2->get_ignore_case());
@@ -689,7 +689,7 @@ TEST_CASE_METHOD(ManyGroups, "Inheritance", "[optiongroup]") {
 
 TEST_CASE_METHOD(ManyGroups, "Moving", "[optiongroup]") {
     remove_required();
-    auto mg = app.add_option_group("maing");
+    auto *mg = app.add_option_group("maing");
     mg->add_subcommand(g1);
     mg->add_subcommand(g2);
 
@@ -767,11 +767,11 @@ TEST_CASE_METHOD(ManyGroupsPreTrigger, "PreTriggerTestsPositionals", "[optiongro
 
 TEST_CASE_METHOD(ManyGroupsPreTrigger, "PreTriggerTestsSubcommand", "[optiongroup]") {
 
-    auto sub1 = g1->add_subcommand("sub1")->fallthrough();
+    auto *sub1 = g1->add_subcommand("sub1")->fallthrough();
     g2->add_subcommand("sub2")->fallthrough();
     g3->add_subcommand("sub3")->fallthrough();
 
-    std::size_t subtrigger;
+    std::size_t subtrigger = 0;
     sub1->preparse_callback([&subtrigger](std::size_t count) { subtrigger = count; });
     args = {"sub1"};
     run();

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-using Catch::literals::operator""_a;
+using Catch::literals::operator"" _a;
 
 TEST_CASE_METHOD(TApp, "OneStringAgain", "[optiontype]") {
     std::string str;

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -5,7 +5,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "app_helper.hpp"
+
 #include <atomic>
+#include <cmath>
 #include <complex>
 #include <cstdint>
 #include <cstdlib>
@@ -17,7 +19,10 @@
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
+
+using Catch::literals::operator""_a;
 
 TEST_CASE_METHOD(TApp, "OneStringAgain", "[optiontype]") {
     std::string str;
@@ -44,13 +49,13 @@ TEST_CASE_METHOD(TApp, "doubleFunction", "[optiontype]") {
     app.add_option_function<double>("--val", [&res](double val) { res = std::abs(val + 54); });
     args = {"--val", "-354.356"};
     run();
-    CHECK(300.356 == res);
+    CHECK(300.356_a == res);
     // get the original value as entered as an integer
-    CHECK(-354.356f == app["--val"]->as<float>());
+    CHECK(-354.356_a == app["--val"]->as<float>());
 }
 
 TEST_CASE_METHOD(TApp, "doubleFunctionFail", "[optiontype]") {
-    double res;
+    double res = NAN;
     app.add_option_function<double>("--val", [&res](double val) { res = std::abs(val + 54); });
     args = {"--val", "not_double"};
     CHECK_THROWS_AS(run(), CLI::ConversionError);
@@ -65,8 +70,8 @@ TEST_CASE_METHOD(TApp, "doubleVectorFunction", "[optiontype]") {
     args = {"--val", "5", "--val", "6", "--val", "7"};
     run();
     CHECK(3u == res.size());
-    CHECK(10.0 == res[0]);
-    CHECK(12.0 == res[2]);
+    CHECK(10.0_a == res[0]);
+    CHECK(12.0_a == res[2]);
 }
 
 TEST_CASE_METHOD(TApp, "doubleVectorFunctionFail", "[optiontype]") {
@@ -86,7 +91,7 @@ TEST_CASE_METHOD(TApp, "doubleVectorFunctionFail", "[optiontype]") {
 
 TEST_CASE_METHOD(TApp, "doubleVectorFunctionRunCallbackOnDefault", "[optiontype]") {
     std::vector<double> res;
-    auto opt = app.add_option_function<std::vector<double>>("--val", [&res](const std::vector<double> &val) {
+    auto *opt = app.add_option_function<std::vector<double>>("--val", [&res](const std::vector<double> &val) {
         res = val;
         std::transform(res.begin(), res.end(), res.begin(), [](double v) { return v + 5.0; });
     });
@@ -195,7 +200,7 @@ TEST_CASE_METHOD(TApp, "BoolOption", "[optiontype]") {
 
 TEST_CASE_METHOD(TApp, "atomic_int_option", "[optiontype]") {
     std::atomic<int> i{0};
-    auto aopt = app.add_option("-i,--int", i);
+    auto *aopt = app.add_option("-i,--int", i);
     args = {"-i4"};
     run();
     CHECK(app.count("--int") == 1u);
@@ -240,7 +245,7 @@ TEST_CASE_METHOD(TApp, "CharOption", "[optiontype]") {
 
 TEST_CASE_METHOD(TApp, "vectorDefaults", "[optiontype]") {
     std::vector<int> vals{4, 5};
-    auto opt = app.add_option("--long", vals)->capture_default_str();
+    auto *opt = app.add_option("--long", vals)->capture_default_str();
 
     args = {"--long", "[1,2,3]"};
 
@@ -286,7 +291,7 @@ TEST_CASE_METHOD(TApp, "CallbackBoolFlags", "[optiontype]") {
 
     auto func = [&value]() { value = true; };
 
-    auto cback = app.add_flag_callback("--val", func);
+    auto *cback = app.add_flag_callback("--val", func);
     args = {"--val"};
     run();
     CHECK(value);
@@ -339,7 +344,7 @@ TEST_CASE_METHOD(TApp, "pair_check_take_first", "[optiontype]") {
     CHECK(CLI::ExistingFile(myfile).empty());
     std::pair<std::string, int> findex;
 
-    auto opt = app.add_option("--file", findex)->check(CLI::ExistingFile)->check(CLI::PositiveNumber);
+    auto *opt = app.add_option("--file", findex)->check(CLI::ExistingFile)->check(CLI::PositiveNumber);
     CHECK_THROWS_AS(opt->get_validator(3), CLI::OptionNotFound);
     opt->get_validator(0)->application_index(0);
     opt->get_validator(1)->application_index(1);
@@ -422,7 +427,7 @@ TEST_CASE_METHOD(TApp, "VectorUnlimString", "[optiontype]") {
 // From https://github.com/CLIUtils/CLI11/issues/420
 TEST_CASE_METHOD(TApp, "stringLikeTests", "[optiontype]") {
     struct nType {
-        explicit nType(const std::string &a_value) : m_value{a_value} {}
+        explicit nType(std::string a_value) : m_value{std::move(a_value)} {}
 
         explicit operator std::string() const { return std::string{"op str"}; }
 
@@ -492,7 +497,7 @@ TEST_CASE_METHOD(TApp, "CustomDoubleOption", "[optiontype]") {
 
     std::pair<int, double> custom_opt;
 
-    auto opt = app.add_option("posit", [&custom_opt](CLI::results_t vals) {
+    auto *opt = app.add_option("posit", [&custom_opt](CLI::results_t vals) {
         custom_opt = {stol(vals.at(0)), stod(vals.at(1))};
         return true;
     });
@@ -544,7 +549,7 @@ TEST_CASE_METHOD(TApp, "vectorPair", "[optiontype]") {
 
     std::vector<std::pair<int, std::string>> custom_opt;
 
-    auto opt = app.add_option("--dict", custom_opt);
+    auto *opt = app.add_option("--dict", custom_opt);
 
     args = {"--dict", "1", "str1", "--dict", "3", "str3"};
 
@@ -578,7 +583,7 @@ TEST_CASE_METHOD(TApp, "vectorPairFail2", "[optiontype]") {
 
     std::vector<std::pair<int, int>> custom_opt;
 
-    auto opt = app.add_option("--pairs", custom_opt);
+    auto *opt = app.add_option("--pairs", custom_opt);
 
     args = {"--pairs", "1", "2", "3", "4"};
 
@@ -599,7 +604,7 @@ TEST_CASE_METHOD(TApp, "vectorPairTypeRange", "[optiontype]") {
 
     std::vector<std::pair<int, std::string>> custom_opt;
 
-    auto opt = app.add_option("--dict", custom_opt);
+    auto *opt = app.add_option("--dict", custom_opt);
 
     opt->type_size(2, 1);  // just test switched arguments
     CHECK(1 == opt->get_type_size_min());
@@ -635,7 +640,7 @@ TEST_CASE_METHOD(TApp, "vectorTuple", "[optiontype]") {
 
     std::vector<std::tuple<int, std::string, double>> custom_opt;
 
-    auto opt = app.add_option("--dict", custom_opt);
+    auto *opt = app.add_option("--dict", custom_opt);
 
     args = {"--dict", "1", "str1", "4.3", "--dict", "3", "str3", "2.7"};
 
@@ -665,7 +670,7 @@ TEST_CASE_METHOD(TApp, "vectorVector", "[optiontype]") {
 
     std::vector<std::vector<int>> custom_opt;
 
-    auto opt = app.add_option("--dict", custom_opt);
+    auto *opt = app.add_option("--dict", custom_opt);
 
     args = {"--dict", "1", "2", "4", "--dict", "3", "1"};
 
@@ -701,7 +706,7 @@ TEST_CASE_METHOD(TApp, "vectorVectorFixedSize", "[optiontype]") {
 
     std::vector<std::vector<int>> custom_opt;
 
-    auto opt = app.add_option("--dict", custom_opt)->type_size(4);
+    auto *opt = app.add_option("--dict", custom_opt)->type_size(4);
 
     args = {"--dict", "1", "2", "4", "3", "--dict", "3", "1", "2", "8"};
 
@@ -905,7 +910,7 @@ TEST_CASE_METHOD(TApp, "unknownContainerWrapper", "[optiontype]") {
     class vopt {
       public:
         vopt() = default;
-        explicit vopt(const std::vector<double> &vdub) : val_{vdub} {};
+        explicit vopt(std::vector<double> vdub) : val_{std::move(vdub)} {};
         std::vector<double> val_{};
     };
 

--- a/tests/SetTest.cpp
+++ b/tests/SetTest.cpp
@@ -6,6 +6,7 @@
 
 #include "app_helper.hpp"
 #include <map>
+#include <memory>
 
 static_assert(CLI::is_shared_ptr<std::shared_ptr<int>>::value == true, "is_shared_ptr should work on shared pointers");
 static_assert(CLI::is_shared_ptr<int *>::value == false, "is_shared_ptr should work on pointers");
@@ -34,7 +35,7 @@ static_assert(CLI::detail::pair_adaptor<std::vector<std::pair<int, int>>>::value
 TEST_CASE_METHOD(TApp, "SimpleMaps", "[set]") {
     int value{0};
     std::map<std::string, int> map = {{"one", 1}, {"two", 2}};
-    auto opt = app.add_option("-s,--set", value)->transform(CLI::Transformer(map));
+    auto *opt = app.add_option("-s,--set", value)->transform(CLI::Transformer(map));
     args = {"-s", "one"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -78,9 +79,9 @@ TEST_CASE_METHOD(TApp, "StringStringMapNoModify", "[set]") {
 enum SimpleEnum { SE_one = 1, SE_two = 2 };
 
 TEST_CASE_METHOD(TApp, "EnumMap", "[set]") {
-    SimpleEnum value;
+    SimpleEnum value;  // NOLINT(cppcoreguidelines-init-variables)
     std::map<std::string, SimpleEnum> map = {{"one", SE_one}, {"two", SE_two}};
-    auto opt = app.add_option("-s,--set", value)->transform(CLI::Transformer(map));
+    auto *opt = app.add_option("-s,--set", value)->transform(CLI::Transformer(map));
     args = {"-s", "one"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -92,9 +93,9 @@ TEST_CASE_METHOD(TApp, "EnumMap", "[set]") {
 enum class SimpleEnumC { one = 1, two = 2 };
 
 TEST_CASE_METHOD(TApp, "EnumCMap", "[set]") {
-    SimpleEnumC value;
+    SimpleEnumC value;  // NOLINT(cppcoreguidelines-init-variables)
     std::map<std::string, SimpleEnumC> map = {{"one", SimpleEnumC::one}, {"two", SimpleEnumC::two}};
-    auto opt = app.add_option("-s,--set", value)->transform(CLI::Transformer(map));
+    auto *opt = app.add_option("-s,--set", value)->transform(CLI::Transformer(map));
     args = {"-s", "one"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -111,7 +112,7 @@ TEST_CASE_METHOD(TApp, "structMap", "[set]") {
     };
     std::string struct_name;
     std::map<std::string, struct tstruct> map = {{"sone", {4, 32.4, "foo"}}, {"stwo", {5, 99.7, "bar"}}};
-    auto opt = app.add_option("-s,--set", struct_name)->check(CLI::IsMember(map));
+    auto *opt = app.add_option("-s,--set", struct_name)->check(CLI::IsMember(map));
     args = {"-s", "sone"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -131,8 +132,8 @@ TEST_CASE_METHOD(TApp, "structMapChange", "[set]") {
     };
     std::string struct_name;
     std::map<std::string, struct tstruct> map = {{"sone", {4, 32.4, "foo"}}, {"stwo", {5, 99.7, "bar"}}};
-    auto opt = app.add_option("-s,--set", struct_name)
-                   ->transform(CLI::IsMember(map, CLI::ignore_case, CLI::ignore_underscore, CLI::ignore_space));
+    auto *opt = app.add_option("-s,--set", struct_name)
+                    ->transform(CLI::IsMember(map, CLI::ignore_case, CLI::ignore_underscore, CLI::ignore_space));
     args = {"-s", "s one"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -159,8 +160,8 @@ TEST_CASE_METHOD(TApp, "structMapNoChange", "[set]") {
     };
     std::string struct_name;
     std::map<std::string, struct tstruct> map = {{"sone", {4, 32.4, "foo"}}, {"stwo", {5, 99.7, "bar"}}};
-    auto opt = app.add_option("-s,--set", struct_name)
-                   ->check(CLI::IsMember(map, CLI::ignore_case, CLI::ignore_underscore, CLI::ignore_space));
+    auto *opt = app.add_option("-s,--set", struct_name)
+                    ->check(CLI::IsMember(map, CLI::ignore_case, CLI::ignore_underscore, CLI::ignore_space));
     args = {"-s", "SONE"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -184,9 +185,9 @@ TEST_CASE_METHOD(TApp, "NonCopyableMap", "[set]") {
 
     std::string map_name;
     std::map<std::string, std::unique_ptr<double>> map;
-    map["e1"] = std::unique_ptr<double>(new double(5.7));
-    map["e3"] = std::unique_ptr<double>(new double(23.8));
-    auto opt = app.add_option("-s,--set", map_name)->check(CLI::IsMember(&map));
+    map["e1"] = std::make_unique<double>(5.7);
+    map["e3"] = std::make_unique<double>(23.8);
+    auto *opt = app.add_option("-s,--set", map_name)->check(CLI::IsMember(&map));
     args = {"-s", "e1"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -202,9 +203,9 @@ TEST_CASE_METHOD(TApp, "NonCopyableMapWithFunction", "[set]") {
 
     std::string map_name;
     std::map<std::string, std::unique_ptr<double>> map;
-    map["e1"] = std::unique_ptr<double>(new double(5.7));
-    map["e3"] = std::unique_ptr<double>(new double(23.8));
-    auto opt = app.add_option("-s,--set", map_name)->transform(CLI::IsMember(&map, CLI::ignore_underscore));
+    map["e1"] = std::make_unique<double>(5.7);
+    map["e3"] = std::make_unique<double>(23.8);
+    auto *opt = app.add_option("-s,--set", map_name)->transform(CLI::IsMember(&map, CLI::ignore_underscore));
     args = {"-s", "e_1"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -220,9 +221,9 @@ TEST_CASE_METHOD(TApp, "NonCopyableMapNonStringMap", "[set]") {
 
     std::string map_name;
     std::map<int, std::unique_ptr<double>> map;
-    map[4] = std::unique_ptr<double>(new double(5.7));
-    map[17] = std::unique_ptr<double>(new double(23.8));
-    auto opt = app.add_option("-s,--set", map_name)->check(CLI::IsMember(&map));
+    map[4] = std::make_unique<double>(5.7);
+    map[17] = std::make_unique<double>(23.8);
+    auto *opt = app.add_option("-s,--set", map_name)->check(CLI::IsMember(&map));
     args = {"-s", "4"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -240,7 +241,7 @@ TEST_CASE_METHOD(TApp, "CopyableMapMove", "[set]") {
     std::map<int, double> map;
     map[4] = 5.7;
     map[17] = 23.8;
-    auto opt = app.add_option("-s,--set", map_name)->check(CLI::IsMember(std::move(map)));
+    auto *opt = app.add_option("-s,--set", map_name)->check(CLI::IsMember(std::move(map)));
     args = {"-s", "4"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -254,7 +255,7 @@ TEST_CASE_METHOD(TApp, "CopyableMapMove", "[set]") {
 
 TEST_CASE_METHOD(TApp, "SimpleSets", "[set]") {
     std::string value;
-    auto opt = app.add_option("-s,--set", value)->check(CLI::IsMember{std::set<std::string>({"one", "two", "three"})});
+    auto *opt = app.add_option("-s,--set", value)->check(CLI::IsMember{std::set<std::string>({"one", "two", "three"})});
     args = {"-s", "one"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -264,9 +265,9 @@ TEST_CASE_METHOD(TApp, "SimpleSets", "[set]") {
 }
 
 TEST_CASE_METHOD(TApp, "SimpleSetsPtrs", "[set]") {
-    auto set = std::shared_ptr<std::set<std::string>>(new std::set<std::string>{"one", "two", "three"});
+    auto set = std::make_shared<std::set<std::string>>(std::set<std::string>{"one", "two", "three"});
     std::string value;
-    auto opt = app.add_option("-s,--set", value)->check(CLI::IsMember{set});
+    auto *opt = app.add_option("-s,--set", value)->check(CLI::IsMember{set});
     args = {"-s", "one"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -286,7 +287,7 @@ TEST_CASE_METHOD(TApp, "SimpleSetsPtrs", "[set]") {
 
 TEST_CASE_METHOD(TApp, "SimiShortcutSets", "[set]") {
     std::string value;
-    auto opt = app.add_option("--set", value)->check(CLI::IsMember({"one", "two", "three"}));
+    auto *opt = app.add_option("--set", value)->check(CLI::IsMember({"one", "two", "three"}));
     args = {"--set", "one"};
     run();
     CHECK(app.count("--set") == 1u);
@@ -294,7 +295,7 @@ TEST_CASE_METHOD(TApp, "SimiShortcutSets", "[set]") {
     CHECK("one" == value);
 
     std::string value2;
-    auto opt2 = app.add_option("--set2", value2)->transform(CLI::IsMember({"One", "two", "three"}, CLI::ignore_case));
+    auto *opt2 = app.add_option("--set2", value2)->transform(CLI::IsMember({"One", "two", "three"}, CLI::ignore_case));
     args = {"--set2", "onE"};
     run();
     CHECK(app.count("--set2") == 1u);
@@ -302,8 +303,8 @@ TEST_CASE_METHOD(TApp, "SimiShortcutSets", "[set]") {
     CHECK("One" == value2);
 
     std::string value3;
-    auto opt3 = app.add_option("--set3", value3)
-                    ->transform(CLI::IsMember({"O_ne", "two", "three"}, CLI::ignore_case, CLI::ignore_underscore));
+    auto *opt3 = app.add_option("--set3", value3)
+                     ->transform(CLI::IsMember({"O_ne", "two", "three"}, CLI::ignore_case, CLI::ignore_underscore));
     args = {"--set3", "onE"};
     run();
     CHECK(app.count("--set3") == 1u);
@@ -312,10 +313,10 @@ TEST_CASE_METHOD(TApp, "SimiShortcutSets", "[set]") {
 }
 
 TEST_CASE_METHOD(TApp, "SetFromCharStarArrayVector", "[set]") {
-    constexpr const char *names[3]{"one", "two", "three"};
+    constexpr const char *names[3]{"one", "two", "three"};  // NOLINT(modernize-avoid-c-arrays)
     std::string value;
-    auto opt = app.add_option("-s,--set", value)
-                   ->check(CLI::IsMember{std::vector<std::string>(std::begin(names), std::end(names))});
+    auto *opt = app.add_option("-s,--set", value)
+                    ->check(CLI::IsMember{std::vector<std::string>(std::begin(names), std::end(names))});
     args = {"-s", "one"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -327,7 +328,7 @@ TEST_CASE_METHOD(TApp, "SetFromCharStarArrayVector", "[set]") {
 TEST_CASE_METHOD(TApp, "OtherTypeSets", "[set]") {
     int value{0};
     std::vector<int> set = {2, 3, 4};
-    auto opt = app.add_option("--set", value)->check(CLI::IsMember(set));
+    auto *opt = app.add_option("--set", value)->check(CLI::IsMember(set));
     args = {"--set", "3"};
     run();
     CHECK(app.count("--set") == 1u);
@@ -338,7 +339,7 @@ TEST_CASE_METHOD(TApp, "OtherTypeSets", "[set]") {
     CHECK_THROWS_AS(run(), CLI::ValidationError);
 
     std::vector<int> set2 = {-2, 3, 4};
-    auto opt2 = app.add_option("--set2", value)->transform(CLI::IsMember(set2, [](int x) { return std::abs(x); }));
+    auto *opt2 = app.add_option("--set2", value)->transform(CLI::IsMember(set2, [](int x) { return std::abs(x); }));
     args = {"--set2", "-3"};
     run();
     CHECK(app.count("--set2") == 1u);
@@ -360,7 +361,7 @@ TEST_CASE_METHOD(TApp, "OtherTypeSets", "[set]") {
 
 TEST_CASE_METHOD(TApp, "NumericalSets", "[set]") {
     int value{0};
-    auto opt = app.add_option("-s,--set", value)->check(CLI::IsMember{std::set<int>({1, 2, 3})});
+    auto *opt = app.add_option("-s,--set", value)->check(CLI::IsMember{std::set<int>({1, 2, 3})});
     args = {"-s", "1"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -494,7 +495,7 @@ TEST_CASE_METHOD(TApp, "FailSet", "[set]") {
 TEST_CASE_METHOD(TApp, "FailMutableSet", "[set]") {
 
     int choice{0};
-    auto vals = std::shared_ptr<std::set<int>>(new std::set<int>({1, 2, 3}));
+    auto vals = std::make_shared<std::set<int>>(std::set<int>{1, 2, 3});
     app.add_option("-q,--quick", choice)->check(CLI::IsMember(vals));
     app.add_option("-s,--slow", choice)->capture_default_str()->check(CLI::IsMember(vals));
 
@@ -554,7 +555,7 @@ TEST_CASE_METHOD(TApp, "InSetIgnoreCaseMutableValue", "[set]") {
 
 TEST_CASE_METHOD(TApp, "InSetIgnoreCasePointer", "[set]") {
 
-    std::set<std::string> *options = new std::set<std::string>{"one", "Two", "THREE"};
+    auto *options = new std::set<std::string>{"one", "Two", "THREE"};
     std::string choice;
     app.add_option("-q,--quick", choice)->transform(CLI::IsMember(*options, CLI::ignore_case));
 
@@ -584,7 +585,7 @@ TEST_CASE_METHOD(TApp, "InSetIgnoreCasePointer", "[set]") {
 
 TEST_CASE_METHOD(TApp, "NotInSetIgnoreCasePointer", "[set]") {
 
-    std::set<std::string> *options = new std::set<std::string>{"one", "Two", "THREE"};
+    auto *options = new std::set<std::string>{"one", "Two", "THREE"};
     std::string choice;
     app.add_option("-q,--quick", choice)->check(!CLI::IsMember(*options, CLI::ignore_case));
 

--- a/tests/SetTest.cpp
+++ b/tests/SetTest.cpp
@@ -185,8 +185,8 @@ TEST_CASE_METHOD(TApp, "NonCopyableMap", "[set]") {
 
     std::string map_name;
     std::map<std::string, std::unique_ptr<double>> map;
-    map["e1"] = std::make_unique<double>(5.7);
-    map["e3"] = std::make_unique<double>(23.8);
+    map["e1"].reset(new double(5.7));
+    map["e3"].reset(new double(23.8));
     auto *opt = app.add_option("-s,--set", map_name)->check(CLI::IsMember(&map));
     args = {"-s", "e1"};
     run();
@@ -203,8 +203,8 @@ TEST_CASE_METHOD(TApp, "NonCopyableMapWithFunction", "[set]") {
 
     std::string map_name;
     std::map<std::string, std::unique_ptr<double>> map;
-    map["e1"] = std::make_unique<double>(5.7);
-    map["e3"] = std::make_unique<double>(23.8);
+    map["e1"].reset(new double(5.7));
+    map["e3"].reset(new double(23.8));
     auto *opt = app.add_option("-s,--set", map_name)->transform(CLI::IsMember(&map, CLI::ignore_underscore));
     args = {"-s", "e_1"};
     run();
@@ -221,8 +221,8 @@ TEST_CASE_METHOD(TApp, "NonCopyableMapNonStringMap", "[set]") {
 
     std::string map_name;
     std::map<int, std::unique_ptr<double>> map;
-    map[4] = std::make_unique<double>(5.7);
-    map[17] = std::make_unique<double>(23.8);
+    map[4].reset(new double(5.7));
+    map[17].reset(new double(23.8));
     auto *opt = app.add_option("-s,--set", map_name)->check(CLI::IsMember(&map));
     args = {"-s", "4"};
     run();

--- a/tests/StringParseTest.cpp
+++ b/tests/StringParseTest.cpp
@@ -24,7 +24,7 @@ TEST_CASE_METHOD(TApp, "ExistingExeCheck", "[stringparse]") {
     }
 
     app.parse(std::string("./") + std::string(tmpexe) +
-                  " --string=\"this is my quoted string\" -t 'qstring 2' -m=`\"quoted string\"`",
+                  R"( --string="this is my quoted string" -t 'qstring 2' -m=`"quoted string"`)",
               true);
     CHECK("this is my quoted string" == str);
     CHECK("qstring 2" == str2);
@@ -46,7 +46,7 @@ TEST_CASE_METHOD(TApp, "ExistingExeCheckWithSpace", "[stringparse]") {
     }
 
     app.parse(std::string("./") + std::string(tmpexe) +
-                  " --string=\"this is my quoted string\" -t 'qstring 2' -m=`\"quoted string\"`",
+                  R"( --string="this is my quoted string" -t 'qstring 2' -m=`"quoted string"`)",
               true);
     CHECK("this is my quoted string" == str);
     CHECK("qstring 2" == str2);
@@ -70,7 +70,7 @@ TEST_CASE_METHOD(TApp, "ExistingExeCheckWithLotsOfSpace", "[stringparse]") {
     }
 
     app.parse(std::string("./") + std::string(tmpexe) +
-                  " --string=\"this is my quoted string\" -t 'qstring 2' -m=`\"quoted string\"`",
+                  R"( --string="this is my quoted string" -t 'qstring 2' -m=`"quoted string"`)",
               true);
     CHECK("this is my quoted string" == str);
     CHECK("qstring 2" == str2);

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -6,6 +6,8 @@
 
 #include "app_helper.hpp"
 
+#include <cmath>
+
 #include <array>
 #include <chrono>
 #include <cstdint>
@@ -22,7 +24,7 @@
 
 TEST_CASE_METHOD(TApp, "SimpleTransform", "[transform]") {
     int value{0};
-    auto opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", std::string("1")}}));
+    auto *opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", std::string("1")}}));
     args = {"-s", "one"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -32,7 +34,7 @@ TEST_CASE_METHOD(TApp, "SimpleTransform", "[transform]") {
 
 TEST_CASE_METHOD(TApp, "SimpleTransformInitList", "[transform]") {
     int value{0};
-    auto opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", "1"}}));
+    auto *opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", "1"}}));
     args = {"-s", "one"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -42,7 +44,7 @@ TEST_CASE_METHOD(TApp, "SimpleTransformInitList", "[transform]") {
 
 TEST_CASE_METHOD(TApp, "SimpleNumericalTransform", "[transform]") {
     int value{0};
-    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(CLI::TransformPairs<int>{{"one", 1}}));
+    auto *opt = app.add_option("-s", value)->transform(CLI::Transformer(CLI::TransformPairs<int>{{"one", 1}}));
     args = {"-s", "one"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -53,9 +55,9 @@ TEST_CASE_METHOD(TApp, "SimpleNumericalTransform", "[transform]") {
 TEST_CASE_METHOD(TApp, "EnumTransform", "[transform]") {
     enum class test_cli : std::int16_t { val1 = 3, val2 = 4, val3 = 17 };
     test_cli value{test_cli::val2};
-    auto opt = app.add_option("-s", value)
-                   ->transform(CLI::Transformer(CLI::TransformPairs<test_cli>{
-                       {"val1", test_cli::val1}, {"val2", test_cli::val2}, {"val3", test_cli::val3}}));
+    auto *opt = app.add_option("-s", value)
+                    ->transform(CLI::Transformer(CLI::TransformPairs<test_cli>{
+                        {"val1", test_cli::val1}, {"val2", test_cli::val2}, {"val3", test_cli::val3}}));
     args = {"-s", "val1"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -82,9 +84,9 @@ TEST_CASE_METHOD(TApp, "EnumTransform", "[transform]") {
 TEST_CASE_METHOD(TApp, "EnumCheckedTransform", "[transform]") {
     enum class test_cli : std::int16_t { val1 = 3, val2 = 4, val3 = 17 };
     test_cli value{test_cli::val1};
-    auto opt = app.add_option("-s", value)
-                   ->transform(CLI::CheckedTransformer(CLI::TransformPairs<test_cli>{
-                       {"val1", test_cli::val1}, {"val2", test_cli::val2}, {"val3", test_cli::val3}}));
+    auto *opt = app.add_option("-s", value)
+                    ->transform(CLI::CheckedTransformer(CLI::TransformPairs<test_cli>{
+                        {"val1", test_cli::val1}, {"val2", test_cli::val2}, {"val3", test_cli::val3}}));
     args = {"-s", "val1"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -149,7 +151,7 @@ TEST_CASE_METHOD(TApp, "EnumCheckedDefaultTransformCallback", "[transform]") {
 
 TEST_CASE_METHOD(TApp, "SimpleTransformFn", "[transform]") {
     int value{0};
-    auto opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", "1"}}, CLI::ignore_case));
+    auto *opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", "1"}}, CLI::ignore_case));
     args = {"-s", "ONE"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -172,7 +174,7 @@ TEST_CASE_METHOD(TApp, "StringViewTransformFn", "[transform]") {
 
 TEST_CASE_METHOD(TApp, "SimpleNumericalTransformFn", "[transform]") {
     int value{0};
-    auto opt =
+    auto *opt =
         app.add_option("-s", value)
             ->transform(CLI::Transformer(std::vector<std::pair<std::string, int>>{{"one", 1}}, CLI::ignore_case));
     args = {"-s", "ONe"};
@@ -185,7 +187,7 @@ TEST_CASE_METHOD(TApp, "SimpleNumericalTransformFn", "[transform]") {
 TEST_CASE_METHOD(TApp, "SimpleNumericalTransformFnVector", "[transform]") {
     std::vector<std::pair<std::string, int>> conversions{{"one", 1}, {"two", 2}};
     int value{0};
-    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(conversions, CLI::ignore_case));
+    auto *opt = app.add_option("-s", value)->transform(CLI::Transformer(conversions, CLI::ignore_case));
     args = {"-s", "ONe"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -199,7 +201,7 @@ TEST_CASE_METHOD(TApp, "SimpleNumericalTransformFnArray", "[transform]") {
     conversions[1] = std::make_pair(std::string("two"), 2);
 
     int value{0};
-    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(conversions, CLI::ignore_case));
+    auto *opt = app.add_option("-s", value)->transform(CLI::Transformer(conversions, CLI::ignore_case));
     args = {"-s", "ONe"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -215,7 +217,7 @@ TEST_CASE_METHOD(TApp, "SimpleNumericalTransformFnconstexprArray", "[transform]"
     constexpr std::array<std::pair<const char *, int>, 2> conversions_c{{p1, p2}};
 
     int value{0};
-    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(&conversions_c, CLI::ignore_case));
+    auto *opt = app.add_option("-s", value)->transform(CLI::Transformer(&conversions_c, CLI::ignore_case));
     args = {"-s", "ONe"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -233,12 +235,12 @@ TEST_CASE_METHOD(TApp, "SimpleNumericalTransformFnconstexprArray", "[transform]"
 TEST_CASE_METHOD(TApp, "EnumTransformFn", "[transform]") {
     enum class test_cli : std::int16_t { val1 = 3, val2 = 4, val3 = 17 };
     test_cli value{test_cli::val2};
-    auto opt = app.add_option("-s", value)
-                   ->transform(CLI::Transformer(CLI::TransformPairs<test_cli>{{"val1", test_cli::val1},
-                                                                              {"val2", test_cli::val2},
-                                                                              {"val3", test_cli::val3}},
-                                                CLI::ignore_case,
-                                                CLI::ignore_underscore));
+    auto *opt = app.add_option("-s", value)
+                    ->transform(CLI::Transformer(CLI::TransformPairs<test_cli>{{"val1", test_cli::val1},
+                                                                               {"val2", test_cli::val2},
+                                                                               {"val3", test_cli::val3}},
+                                                 CLI::ignore_case,
+                                                 CLI::ignore_underscore));
     args = {"-s", "val_1"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -261,7 +263,7 @@ TEST_CASE_METHOD(TApp, "EnumTransformFnMap", "[transform]") {
     enum class test_cli : std::int16_t { val1 = 3, val2 = 4, val3 = 17 };
     std::map<std::string, test_cli> map{{"val1", test_cli::val1}, {"val2", test_cli::val2}, {"val3", test_cli::val3}};
     test_cli value{test_cli::val3};
-    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(map, CLI::ignore_case, CLI::ignore_underscore));
+    auto *opt = app.add_option("-s", value)->transform(CLI::Transformer(map, CLI::ignore_case, CLI::ignore_underscore));
     args = {"-s", "val_1"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -284,7 +286,8 @@ TEST_CASE_METHOD(TApp, "EnumTransformFnPtrMap", "[transform]") {
     enum class test_cli : std::int16_t { val1 = 3, val2 = 4, val3 = 17, val4 = 37 };
     std::map<std::string, test_cli> map{{"val1", test_cli::val1}, {"val2", test_cli::val2}, {"val3", test_cli::val3}};
     test_cli value{test_cli::val2};
-    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(&map, CLI::ignore_case, CLI::ignore_underscore));
+    auto *opt =
+        app.add_option("-s", value)->transform(CLI::Transformer(&map, CLI::ignore_case, CLI::ignore_underscore));
     args = {"-s", "val_1"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -316,7 +319,7 @@ TEST_CASE_METHOD(TApp, "EnumTransformFnSharedPtrMap", "[transform]") {
     mp["val3"] = test_cli::val3;
 
     test_cli value{test_cli::val2};
-    auto opt = app.add_option("-s", value)->transform(CLI::Transformer(map, CLI::ignore_case, CLI::ignore_underscore));
+    auto *opt = app.add_option("-s", value)->transform(CLI::Transformer(map, CLI::ignore_case, CLI::ignore_underscore));
     args = {"-s", "val_1"};
     run();
     CHECK(app.count("-s") == 1u);
@@ -343,7 +346,7 @@ TEST_CASE_METHOD(TApp, "EnumTransformFnSharedPtrMap", "[transform]") {
 TEST_CASE_METHOD(TApp, "TransformCascade", "[transform]") {
 
     std::string output;
-    auto opt = app.add_option("-s", output);
+    auto *opt = app.add_option("-s", output);
     opt->transform(CLI::Transformer({{"abc", "abcd"}, {"bbc", "bbcd"}, {"cbc", "cbcd"}}, CLI::ignore_case));
     opt->transform(
         CLI::Transformer({{"ab", "abc"}, {"bc", "bbc"}, {"cb", "cbc"}}, CLI::ignore_case, CLI::ignore_underscore));
@@ -370,7 +373,7 @@ TEST_CASE_METHOD(TApp, "TransformCascade", "[transform]") {
 TEST_CASE_METHOD(TApp, "TransformCascadeDeactivate", "[transform]") {
 
     std::string output;
-    auto opt = app.add_option("-s", output);
+    auto *opt = app.add_option("-s", output);
     opt->transform(
         CLI::Transformer({{"abc", "abcd"}, {"bbc", "bbcd"}, {"cbc", "cbcd"}}, CLI::ignore_case).name("tform1"));
     opt->transform(
@@ -390,7 +393,7 @@ TEST_CASE_METHOD(TApp, "TransformCascadeDeactivate", "[transform]") {
     args = {"-s", "C_B"};
     CHECK_THROWS_AS(run(), CLI::ValidationError);
 
-    auto validator = opt->get_validator("tform2");
+    auto *validator = opt->get_validator("tform2");
     CHECK(!validator->get_active());
     CHECK("tform2" == validator->get_name());
     validator->active();
@@ -475,28 +478,28 @@ TEST_CASE_METHOD(TApp, "IntTransformNonMerge", "[transform]") {
     CHECK(help.find("15->5") != std::string::npos);
     CHECK(help.find("25->5") != std::string::npos);
 
-    auto validator = app.get_option("-s")->get_validator();
+    auto *validator = app.get_option("-s")->get_validator();
     help = validator->get_description();
     CHECK(help.find("15->5") != std::string::npos);
     CHECK(help.find("25->5") != std::string::npos);
 
-    auto validator2 = app.get_option("-s")->get_validator("merge");
+    auto *validator2 = app.get_option("-s")->get_validator("merge");
     CHECK(validator == validator2);
 }
 
 TEST_CASE_METHOD(TApp, "IntTransformMergeWithCustomValidator", "[transform]") {
     std::string value;
-    auto opt = app.add_option("-s", value)
-                   ->transform(CLI::Transformer(std::map<int, int>{{15, 5}, {18, 6}, {21, 7}}) |
-                                   CLI::Validator(
-                                       [](std::string &element) {
-                                           if(element == "frog") {
-                                               element = "hops";
-                                           }
-                                           return std::string{};
-                                       },
-                                       std::string{}),
-                               "check");
+    auto *opt = app.add_option("-s", value)
+                    ->transform(CLI::Transformer(std::map<int, int>{{15, 5}, {18, 6}, {21, 7}}) |
+                                    CLI::Validator(
+                                        [](std::string &element) {
+                                            if(element == "frog") {
+                                                element = "hops";
+                                            }
+                                            return std::string{};
+                                        },
+                                        std::string{}),
+                                "check");
     args = {"-s", "15"};
     run();
     CHECK("5" == value);
@@ -518,7 +521,7 @@ TEST_CASE_METHOD(TApp, "IntTransformMergeWithCustomValidator", "[transform]") {
     CHECK(help.find("15->5") != std::string::npos);
     CHECK(help.find("OR") == std::string::npos);
 
-    auto validator = opt->get_validator("check");
+    auto *validator = opt->get_validator("check");
     CHECK("check" == validator->get_name());
     validator->active(false);
     help = app.help();
@@ -526,7 +529,7 @@ TEST_CASE_METHOD(TApp, "IntTransformMergeWithCustomValidator", "[transform]") {
 }
 
 TEST_CASE_METHOD(TApp, "BoundTests", "[transform]") {
-    double value;
+    double value = NAN;
     app.add_option("-s", value)->transform(CLI::Bound(3.4, 5.9));
     args = {"-s", "15"};
     run();
@@ -636,9 +639,8 @@ TEST_CASE_METHOD(TApp, "NumberWithUnitMandatoryUnit", "[transform]") {
 
     int value{0};
     app.add_option("-n", value)
-        ->transform(CLI::AsNumberWithUnit(mapping,
-                                          CLI::AsNumberWithUnit::Options(CLI::AsNumberWithUnit::UNIT_REQUIRED |
-                                                                         CLI::AsNumberWithUnit::CASE_SENSITIVE)));
+        ->transform(CLI::AsNumberWithUnit(
+            mapping, CLI::AsNumberWithUnit::UNIT_REQUIRED | CLI::AsNumberWithUnit::CASE_SENSITIVE));
 
     args = {"-n", "42a"};
     run();
@@ -657,9 +659,8 @@ TEST_CASE_METHOD(TApp, "NumberWithUnitMandatoryUnit2", "[transform]") {
 
     int value{0};
     app.add_option("-n", value)
-        ->transform(CLI::AsNumberWithUnit(mapping,
-                                          CLI::AsNumberWithUnit::Options(CLI::AsNumberWithUnit::UNIT_REQUIRED |
-                                                                         CLI::AsNumberWithUnit::CASE_INSENSITIVE)));
+        ->transform(CLI::AsNumberWithUnit(
+            mapping, CLI::AsNumberWithUnit::UNIT_REQUIRED | CLI::AsNumberWithUnit::CASE_INSENSITIVE));
 
     args = {"-n", "42A"};
     run();
@@ -708,7 +709,7 @@ TEST_CASE_METHOD(TApp, "NumberWithUnitBadInput", "[transform]") {
 TEST_CASE_METHOD(TApp, "NumberWithUnitIntOverflow", "[transform]") {
     std::map<std::string, int> mapping{{"a", 1000000}, {"b", 100}, {"c", 101}};
 
-    std::int32_t value;
+    std::int32_t value = 0;
     app.add_option("-n", value)->transform(CLI::AsNumberWithUnit(mapping));
 
     args = {"-n", "1000 a"};

--- a/tests/app_helper.hpp
+++ b/tests/app_helper.hpp
@@ -46,8 +46,8 @@ class TempFile {
         std::remove(_name.c_str());  // Doesn't matter if returns 0 or not
     }
 
-    operator const std::string &() const { return _name; }
-    const char *c_str() const { return _name.c_str(); }
+    operator const std::string &() const { return _name; }  // NOLINT(google-explicit-constructor)
+    CLI11_NODISCARD const char *c_str() const { return _name.c_str(); }
 };
 
 inline void put_env(std::string name, std::string value) {


### PR DESCRIPTION
```bash
docker run --rm -v $PWD:/cli11 -it silkeh/clang:14 bash
cmake -Scli11 -Bbuild -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);--use-color" -DCMAKE_CXX_STANDARD=17
cmake --build build -j 4
```

This removes the custom clang-tidy option for standard CMake idioms. Clang warnings adjusted, and new tidy checks added.