### PR TITLE
Add missing Macros.hpp include to Error.hpp

### DIFF
--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -16,6 +16,7 @@
 
 // CLI library includes
 #include "StringTools.hpp"
+#include "Macros.hpp"
 
 namespace CLI {
 // [CLI11:error_hpp:verbatim]

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -15,8 +15,8 @@
 // [CLI11:public_includes:end]
 
 // CLI library includes
-#include "StringTools.hpp"
 #include "Macros.hpp"
+#include "StringTools.hpp"
 
 namespace CLI {
 // [CLI11:error_hpp:verbatim]


### PR DESCRIPTION
To address:

```
In file included from /ITKWebAssemblyInterface/include/itkPipeline.h:21:
In file included from /ITKWebAssemblyInterface-build/_deps/cli11-src/include/CLI/App.hpp:25:
In file included from /ITKWebAssemblyInterface-build/_deps/cli11-src/include/CLI/ConfigFwd.hpp:17:
/ITKWebAssemblyInterface-build/_deps/cli11-src/include/CLI/Error.hpp:75:5: error: unknown type name 'CLI11_NODISCARD'
    CLI11_NODISCARD int get_exit_code() const { return actual_exit_code; }
    ^
```
