### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,10 @@ them are unknown yet.
 </br>
 
 ## Installing cli11 using vcpkg
-You can download and install cli11 using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+You can download and install cli11 using the
+[vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
 ```bash
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
@@ -281,7 +284,10 @@ cd vcpkg
 ./vcpkg install cli11
 ```
 
-The cli11 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The cli11 port in vcpkg is kept up to date by Microsoft team members and
+community contributors. If the version is out of date, please
+[create an issue or pull request](https://github.com/Microsoft/vcpkg) on the
+vcpkg repository.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ set with a simple and intuitive interface.
   - [Other parsers](#other-parsers)
   - [Features not supported by this library](#features-not-supported-by-this-library)
 - [Install](#install)
+- [Installing cli11 using vcpkg](#installing-cli11-using-vcpkg)
 - [Usage](#usage)
   - [Adding options](#adding-options)
     - [Option types](#option-types)
@@ -269,6 +270,18 @@ them are unknown yet.
 
 </p></details>
 </br>
+
+## Installing cli11 using vcpkg
+You can download and install cli11 using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install cli11
+```
+
+The cli11 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Usage
 


### PR DESCRIPTION
`cli11` is available as a port in vcpkg, a C++ library manager that simplifies installation for cli11 and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build cli11, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/cli11/portfile.cmake). We try to keep the library maintained as close as possible to the original library.