### PR TITLE
feat: added usage message replacement feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,6 +1062,10 @@ option_groups. These are:
 - `.prefix_command()`: Like `allow_extras`, but stop immediately on the first
   unrecognized item. It is ideal for allowing your app or subcommand to be a
   "prefix" to calling another app.
+- `.usage(message)`: Replace text to appear at the start of the help string
+  after description.
+- `.usage(std::string())`: Set a callback to generate a string that will appear
+  at the start of the help string after description.
 - `.footer(message)`: Set text to appear at the bottom of the help string.
 - `.footer(std::string())`: Set a callback to generate a string that will appear
   at the end of the help string.
@@ -1356,8 +1360,9 @@ multiple calls or using `|` operations with the transform.
 Many of the defaults for subcommands and even options are inherited from their
 creators. The inherited default values for subcommands are `allow_extras`,
 `prefix_command`, `ignore_case`, `ignore_underscore`, `fallthrough`, `group`,
-`footer`,`immediate_callback` and maximum number of required subcommands. The
-help flag existence, name, and description are inherited, as well.
+`usage`, `footer`, `immediate_callback` and maximum number of required
+subcommands. The help flag existence, name, and description are inherited, as
+well.
 
 Options have defaults for `group`, `required`, `multi_option_policy`,
 `ignore_case`, `ignore_underscore`, `delimiter`, and `disable_flag_override`. To

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -147,6 +147,12 @@ class App {
     /// @name Help
     ///@{
 
+    /// Usage to put after program/subcommand description in the help output INHERITABLE
+    std::string usage_{};
+
+    /// This is a function that generates a usage to put after program/subcommand description in help output
+    std::function<std::string()> usage_callback_{};
+
     /// Footer to put after all options in the help output INHERITABLE
     std::string footer_{};
 
@@ -942,6 +948,16 @@ class App {
     /// @name Help
     ///@{
 
+    /// Set usage.
+    App *usage(std::string usage_string) {
+        usage_ = std::move(usage_string);
+        return this;
+    }
+    /// Set usage.
+    App *usage(std::function<std::string()> usage_function) {
+        usage_callback_ = std::move(usage_function);
+        return this;
+    }
     /// Set footer.
     App *footer(std::string footer_string) {
         footer_ = std::move(footer_string);
@@ -1049,6 +1065,11 @@ class App {
 
     /// Get the group of this subcommand
     CLI11_NODISCARD const std::string &get_group() const { return group_; }
+
+    /// Generate and return the usage.
+    CLI11_NODISCARD std::string get_usage() const {
+        return (usage_callback_) ? usage_callback_() + '\n' + usage_ : usage_;
+    }
 
     /// Generate and return the footer.
     CLI11_NODISCARD std::string get_footer() const {

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -46,6 +46,7 @@ CLI11_INLINE App::App(std::string app_description, std::string app_name, App *pa
         configurable_ = parent_->configurable_;
         allow_windows_style_options_ = parent_->allow_windows_style_options_;
         group_ = parent_->group_;
+        usage_ = parent_->usage_;
         footer_ = parent_->footer_;
         formatter_ = parent_->formatter_;
         config_formatter_ = parent_->config_formatter_;

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -137,7 +137,7 @@ CLI11_INLINE std::string Formatter::make_footer(const App *app) const {
     if(footer.empty()) {
         return std::string{};
     }
-    return footer + "\n";
+    return "\n" + footer + "\n";
 }
 
 CLI11_INLINE std::string Formatter::make_help(const App *app, std::string name, AppFormatMode mode) const {
@@ -159,7 +159,7 @@ CLI11_INLINE std::string Formatter::make_help(const App *app, std::string name, 
     out << make_positionals(app);
     out << make_groups(app, mode);
     out << make_subcommands(app, mode);
-    out << '\n' << make_footer(app);
+    out << make_footer(app);
 
     return out.str();
 }

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -91,6 +91,11 @@ CLI11_INLINE std::string Formatter::make_description(const App *app) const {
 }
 
 CLI11_INLINE std::string Formatter::make_usage(const App *app, std::string name) const {
+    std::string usage = app->get_usage();
+    if(!usage.empty()) {
+        return usage + "\n";
+    }
+
     std::stringstream out;
 
     out << get_label("Usage") << ":" << (name.empty() ? "" : " ") << name;

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -455,6 +455,7 @@ TEST_CASE_METHOD(TApp, "SubcommandDefaults", "[creation]") {
     CHECK(!app.get_configurable());
     CHECK(!app.get_validate_positionals());
 
+    CHECK(app.get_usage().empty());
     CHECK(app.get_footer().empty());
     CHECK("Subcommands" == app.get_group());
     CHECK(0u == app.get_require_subcommand_min());
@@ -474,6 +475,7 @@ TEST_CASE_METHOD(TApp, "SubcommandDefaults", "[creation]") {
 
     app.fallthrough();
     app.validate_positionals();
+    app.usage("ussy");
     app.footer("footy");
     app.group("Stuff");
     app.require_subcommand(2, 3);
@@ -494,6 +496,7 @@ TEST_CASE_METHOD(TApp, "SubcommandDefaults", "[creation]") {
     CHECK(app2->get_fallthrough());
     CHECK(app2->get_validate_positionals());
     CHECK(app2->get_configurable());
+    CHECK("ussy" == app2->get_usage());
     CHECK("footy" == app2->get_footer());
     CHECK("Stuff" == app2->get_group());
     CHECK(0u == app2->get_require_subcommand_min());

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -63,7 +63,7 @@ TEST_CASE("Formatter: OptCustomize", "[formatter]") {
                   "Usage: [OPTIONS]\n\n"
                   "Options:\n"
                   "  -h,--help              Print this help message and exit\n"
-                  "  --opt INT (MUST HAVE)  Something\n\n");
+                  "  --opt INT (MUST HAVE)  Something\n");
 }
 
 TEST_CASE("Formatter: OptCustomizeSimple", "[formatter]") {
@@ -82,7 +82,7 @@ TEST_CASE("Formatter: OptCustomizeSimple", "[formatter]") {
                   "Usage: [OPTIONS]\n\n"
                   "Options:\n"
                   "  -h,--help              Print this help message and exit\n"
-                  "  --opt INT (MUST HAVE)  Something\n\n");
+                  "  --opt INT (MUST HAVE)  Something\n");
 }
 
 TEST_CASE("Formatter: OptCustomizeOptionText", "[formatter]") {
@@ -100,7 +100,7 @@ TEST_CASE("Formatter: OptCustomizeOptionText", "[formatter]") {
                   "Usage: [OPTIONS]\n\n"
                   "Options:\n"
                   "  -h,--help              Print this help message and exit\n"
-                  "  --opt (ARG)            Something\n\n");
+                  "  --opt (ARG)            Something\n");
 }
 
 TEST_CASE("Formatter: FalseFlagExample", "[formatter]") {
@@ -140,7 +140,7 @@ TEST_CASE("Formatter: AppCustomize", "[formatter]") {
                   "  -h,--help         Print this help message and exit\n\n"
                   "Subcommands:\n"
                   "  subcom1           This\n"
-                  "  subcom2           This\n\n");
+                  "  subcom2           This\n");
 }
 
 TEST_CASE("Formatter: AppCustomizeSimple", "[formatter]") {
@@ -159,7 +159,7 @@ TEST_CASE("Formatter: AppCustomizeSimple", "[formatter]") {
                   "  -h,--help         Print this help message and exit\n\n"
                   "Subcommands:\n"
                   "  subcom1           This\n"
-                  "  subcom2           This\n\n");
+                  "  subcom2           This\n");
 }
 
 TEST_CASE("Formatter: AllSub", "[formatter]") {

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -53,13 +53,14 @@ TEST_CASE("THelp: UsageCallback", "[help]") {
 TEST_CASE("THelp: UsageCallbackBoth", "[help]") {
     CLI::App app{"My prog"};
     app.usage([]() { return "use: just use it"; });
-    app.usage(", like 1, 2, and 3");
+    app.usage("like 1, 2, and 3");
     std::string help = app.help();
 
     CHECK_THAT(help, Contains("My prog"));
     CHECK_THAT(help, Contains("-h,--help"));
     CHECK_THAT(help, Contains("Options:"));
-    CHECK_THAT(help, Contains("use: just use it, like 1, 2, and 3"));
+    CHECK_THAT(help, Contains("use: just use it"));
+    CHECK_THAT(help, Contains("like 1, 2, and 3"));
 }
 
 TEST_CASE("THelp: Footer", "[help]") {
@@ -849,7 +850,7 @@ TEST_CASE_METHOD(CapturedHelp, "CallForAllHelpOutput", "[help]") {
                        "  One description\n\n"
                        "two\n"
                        "  Options:\n"
-                       "    --three                     \n\n\n");
+                       "    --three                     \n\n");
 }
 TEST_CASE_METHOD(CapturedHelp, "NewFormattedHelp", "[help]") {
     app.formatter_fn([](const CLI::App *, std::string, CLI::AppFormatMode) { return "New Help"; });

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -26,6 +26,42 @@ TEST_CASE("THelp: Basic", "[help]") {
     CHECK_THAT(help, Contains("Usage:"));
 }
 
+TEST_CASE("THelp: Usage", "[help]") {
+    CLI::App app{"My prog"};
+    app.usage("use: just use it");
+
+    std::string help = app.help();
+
+    CHECK_THAT(help, Contains("My prog"));
+    CHECK_THAT(help, Contains("-h,--help"));
+    CHECK_THAT(help, Contains("Options:"));
+    CHECK_THAT(help, Contains("use: just use it"));
+}
+
+TEST_CASE("THelp: UsageCallback", "[help]") {
+    CLI::App app{"My prog"};
+    app.usage([]() { return "use: just use it"; });
+
+    std::string help = app.help();
+
+    CHECK_THAT(help, Contains("My prog"));
+    CHECK_THAT(help, Contains("-h,--help"));
+    CHECK_THAT(help, Contains("Options:"));
+    CHECK_THAT(help, Contains("use: just use it"));
+}
+
+TEST_CASE("THelp: UsageCallbackBoth", "[help]") {
+    CLI::App app{"My prog"};
+    app.usage([]() { return "use: just use it"; });
+    app.usage(", like 1, 2, and 3");
+    std::string help = app.help();
+
+    CHECK_THAT(help, Contains("My prog"));
+    CHECK_THAT(help, Contains("-h,--help"));
+    CHECK_THAT(help, Contains("Options:"));
+    CHECK_THAT(help, Contains("use: just use it, like 1, 2, and 3"));
+}
+
 TEST_CASE("THelp: Footer", "[help]") {
     CLI::App app{"My prog"};
     app.footer("Report bugs to bugs@example.com");


### PR DESCRIPTION
## Usage message replacement

Now you able to set custom usage message or pass callback function that will generate it for you.  
Example:

```c++
CLI::App app{"app v1"};
app.usage("use: [-h|--help] | --option UINT");
```

Output will be:

```text
app v1
use: [-h|--help] | --option UINT

Options:
  -h,--help                             Show this message
```
To void usage message replacement in subcommand and be able to get generated usage message just set with empty string:

```c++
auto sub = app.add_subcommand("sub");
sub->usage("");
```
Help message for `app -h`:

```text
app v1
use: [-h|--help] | --option UINT

Options:
  -h,--help                             Show this message

Subcommands:
sub

```

Help message for `app sub -h`:

```text
Usage: app sub [OPTIONS]

Options:
  -h,--help                             Show this message
```

## Footer newline behavior

Moved to https://github.com/CLIUtils/CLI11/pull/796
