### PR TITLE
missing function definition

### DIFF
--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -433,6 +433,15 @@ CLI11_NODISCARD CLI11_INLINE CLI::App_p App::get_subcommand_ptr(int index) const
     throw OptionNotFound(std::to_string(index));
 }
 
+CLI11_NODISCARD CLI11_INLINE CLI::App *App::get_option_group(std::string group_name) const {
+for(const App_p &app : subcommands_) {
+    if(app->name_.empty() && app->group_ == group_name) {
+        return app.get();
+    }
+}
+throw OptionNotFound(group_name);
+    }
+
 CLI11_NODISCARD CLI11_INLINE std::size_t App::count_all() const {
     std::size_t cnt{0};
     for(const auto &opt : options_) {

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -434,13 +434,13 @@ CLI11_NODISCARD CLI11_INLINE CLI::App_p App::get_subcommand_ptr(int index) const
 }
 
 CLI11_NODISCARD CLI11_INLINE CLI::App *App::get_option_group(std::string group_name) const {
-for(const App_p &app : subcommands_) {
-    if(app->name_.empty() && app->group_ == group_name) {
-        return app.get();
+    for(const App_p &app : subcommands_) {
+        if(app->name_.empty() && app->group_ == group_name) {
+            return app.get();
+        }
     }
+    throw OptionNotFound(group_name);
 }
-throw OptionNotFound(group_name);
-    }
 
 CLI11_NODISCARD CLI11_INLINE std::size_t App::count_all() const {
     std::size_t cnt{0};

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -450,10 +450,9 @@ TEST_CASE_METHOD(ManyGroups, "SingleGroup", "[optiongroup]") {
 
 TEST_CASE_METHOD(ManyGroups, "getGroup", "[optiongroup]") {
     // only 1 group can be used
-   auto *mn=app.get_option_group("main");
-   CHECK(mn==main);
-   CHECK_THROWS_AS(app.get_option_group("notfound"),CLI::OptionNotFound);
-
+    auto *mn = app.get_option_group("main");
+    CHECK(mn == main);
+    CHECK_THROWS_AS(app.get_option_group("notfound"), CLI::OptionNotFound);
 }
 
 TEST_CASE_METHOD(ManyGroups, "ExcludesGroup", "[optiongroup]") {

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -448,6 +448,14 @@ TEST_CASE_METHOD(ManyGroups, "SingleGroup", "[optiongroup]") {
     CHECK_THROWS_AS(run(), CLI::RequiredError);
 }
 
+TEST_CASE_METHOD(ManyGroups, "getGroup", "[optiongroup]") {
+    // only 1 group can be used
+   auto *mn=app.get_option_group("main");
+   CHECK(mn==main);
+   CHECK_THROWS_AS(app.get_option_group("notfound"),CLI::OptionNotFound);
+
+}
+
 TEST_CASE_METHOD(ManyGroups, "ExcludesGroup", "[optiongroup]") {
     // only 1 group can be used
     g1->excludes(g2);

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -449,7 +449,6 @@ TEST_CASE_METHOD(ManyGroups, "SingleGroup", "[optiongroup]") {
 }
 
 TEST_CASE_METHOD(ManyGroups, "getGroup", "[optiongroup]") {
-    // only 1 group can be used
     auto *mn = app.get_option_group("main");
     CHECK(mn == main);
     CHECK_THROWS_AS(app.get_option_group("notfound"), CLI::OptionNotFound);


### PR DESCRIPTION
the get_option_group definition was missing from the splitting of the definitions. 

I tried to compile the single header into our code and discovered a missing function call.