### PR TITLE
fix: fixed footer newline behavior

### DIFF
--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -137,7 +137,7 @@ CLI11_INLINE std::string Formatter::make_footer(const App *app) const {
     if(footer.empty()) {
         return std::string{};
     }
-    return footer + "\n";
+    return "\n" + footer + "\n";
 }
 
 CLI11_INLINE std::string Formatter::make_help(const App *app, std::string name, AppFormatMode mode) const {
@@ -159,7 +159,7 @@ CLI11_INLINE std::string Formatter::make_help(const App *app, std::string name, 
     out << make_positionals(app);
     out << make_groups(app, mode);
     out << make_subcommands(app, mode);
-    out << '\n' << make_footer(app);
+    out << make_footer(app);
 
     return out.str();
 }

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -63,7 +63,7 @@ TEST_CASE("Formatter: OptCustomize", "[formatter]") {
                   "Usage: [OPTIONS]\n\n"
                   "Options:\n"
                   "  -h,--help              Print this help message and exit\n"
-                  "  --opt INT (MUST HAVE)  Something\n\n");
+                  "  --opt INT (MUST HAVE)  Something\n");
 }
 
 TEST_CASE("Formatter: OptCustomizeSimple", "[formatter]") {
@@ -82,7 +82,7 @@ TEST_CASE("Formatter: OptCustomizeSimple", "[formatter]") {
                   "Usage: [OPTIONS]\n\n"
                   "Options:\n"
                   "  -h,--help              Print this help message and exit\n"
-                  "  --opt INT (MUST HAVE)  Something\n\n");
+                  "  --opt INT (MUST HAVE)  Something\n");
 }
 
 TEST_CASE("Formatter: OptCustomizeOptionText", "[formatter]") {
@@ -100,7 +100,7 @@ TEST_CASE("Formatter: OptCustomizeOptionText", "[formatter]") {
                   "Usage: [OPTIONS]\n\n"
                   "Options:\n"
                   "  -h,--help              Print this help message and exit\n"
-                  "  --opt (ARG)            Something\n\n");
+                  "  --opt (ARG)            Something\n");
 }
 
 TEST_CASE("Formatter: FalseFlagExample", "[formatter]") {
@@ -140,7 +140,7 @@ TEST_CASE("Formatter: AppCustomize", "[formatter]") {
                   "  -h,--help         Print this help message and exit\n\n"
                   "Subcommands:\n"
                   "  subcom1           This\n"
-                  "  subcom2           This\n\n");
+                  "  subcom2           This\n");
 }
 
 TEST_CASE("Formatter: AppCustomizeSimple", "[formatter]") {
@@ -159,7 +159,7 @@ TEST_CASE("Formatter: AppCustomizeSimple", "[formatter]") {
                   "  -h,--help         Print this help message and exit\n\n"
                   "Subcommands:\n"
                   "  subcom1           This\n"
-                  "  subcom2           This\n\n");
+                  "  subcom2           This\n");
 }
 
 TEST_CASE("Formatter: AllSub", "[formatter]") {

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -813,7 +813,7 @@ TEST_CASE_METHOD(CapturedHelp, "CallForAllHelpOutput", "[help]") {
                        "  One description\n\n"
                        "two\n"
                        "  Options:\n"
-                       "    --three                     \n\n\n");
+                       "    --three                     \n\n");
 }
 TEST_CASE_METHOD(CapturedHelp, "NewFormattedHelp", "[help]") {
     app.formatter_fn([](const CLI::App *, std::string, CLI::AppFormatMode) { return "New Help"; });


### PR DESCRIPTION
# Footer newline behavior

Without or empty footer now:

```
app v1
use: [-h|--help] | --option UINT

Options:
  -h,--help                             Show this message
<newline>
```

With footer now:

```
app v1
use: [-h|--help] | --option UINT

Options:
  -h,--help                             Show this message
<newline>
footer
```

Without or empty footer with follow changes:

```
app v1
use: [-h|--help] | --option UINT

Options:
  -h,--help                             Show this message
```

With footer (like now):

```
app v1
use: [-h|--help] | --option UINT

Options:
  -h,--help                             Show this message
<newline>
footer
```

If footer is set, then we can expect it to be at least one string.
So somebody can add more newlines directly in footer string if needed.