### PR TITLE
tweak the parsing of files for flags with disable_flag_override

### DIFF
--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1397,25 +1397,19 @@ CLI11_INLINE bool App::_parse_single_config(const ConfigItem &item, std::size_t 
                 // Flag parsing
                 auto res = config_formatter_->to_flag(item);
                 bool converted{false};
-                if (op->get_disable_flag_override())
-                {
-                    
-                    try
-                    {
+                if(op->get_disable_flag_override()) {
+
+                    try {
                         auto val = detail::to_flag_value(res);
-                        if (val == 1)
-                        {
+                        if(val == 1) {
                             res = op->get_flag_value(item.name, "{}");
-                            converted=true;
+                            converted = true;
                         }
-                    }
-                    catch (...)
-                    {
+                    } catch(...) {
                     }
                 }
 
-                if (!converted)
-                {
+                if(!converted) {
                     res = op->get_flag_value(item.name, res);
                 }
 

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1396,7 +1396,28 @@ CLI11_INLINE bool App::_parse_single_config(const ConfigItem &item, std::size_t 
             if(item.inputs.size() <= 1) {
                 // Flag parsing
                 auto res = config_formatter_->to_flag(item);
-                res = op->get_flag_value(item.name, res);
+                bool converted{false};
+                if (op->get_disable_flag_override())
+                {
+                    
+                    try
+                    {
+                        auto val = detail::to_flag_value(res);
+                        if (val == 1)
+                        {
+                            res = op->get_flag_value(item.name, "{}");
+                            converted=true;
+                        }
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+
+                if (!converted)
+                {
+                    res = op->get_flag_value(item.name, res);
+                }
 
                 op->add_result(res);
                 return true;

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -435,7 +435,7 @@ TEST_CASE("StringBased: file_error", "[config]") {
     CHECK_THROWS_AS(CLI::ConfigINI().from_file("nonexist_file"), CLI::FileError);
 }
 
-static const int fclear1=fileClear("TestIniTmp.ini");
+static const int fclear1 = fileClear("TestIniTmp.ini");
 
 TEST_CASE_METHOD(TApp, "IniNotRequired", "[config]") {
 
@@ -597,7 +597,7 @@ TEST_CASE_METHOD(TApp, "IniNotRequiredbadConfigurator", "[config]") {
     REQUIRE_NOTHROW(run());
 }
 
-static const int fclear2=fileClear("TestIniTmp2.ini");
+static const int fclear2 = fileClear("TestIniTmp2.ini");
 
 TEST_CASE_METHOD(TApp, "IniNotRequiredNotDefault", "[config]") {
 
@@ -2024,7 +2024,7 @@ TEST_CASE_METHOD(TApp, "IniFalseFlagsDefDisableOverrideSuccess", "[config]") {
     CHECK(val == 15);
 }
 
-static const int fclear3=fileClear("TestIniTmp3.ini");
+static const int fclear3 = fileClear("TestIniTmp3.ini");
 
 TEST_CASE_METHOD(TApp, "IniDisableFlagOverride", "[config]") {
 
@@ -2052,7 +2052,6 @@ TEST_CASE_METHOD(TApp, "IniDisableFlagOverride", "[config]") {
         out << "three=true" << std::endl;
     }
 
-
     int val{0};
     app.add_flag("--one{1},--two{2},--three{3}", val)->disable_flag_override();
 
@@ -2061,8 +2060,7 @@ TEST_CASE_METHOD(TApp, "IniDisableFlagOverride", "[config]") {
     CHECK(val == 2);
 
     args = {"--config", tmpini2};
-    CHECK_THROWS_AS(run(),CLI::ArgumentMismatch);
-
+    CHECK_THROWS_AS(run(), CLI::ArgumentMismatch);
 
     args = {"--config", tmpini3};
     run();

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -435,6 +435,8 @@ TEST_CASE("StringBased: file_error", "[config]") {
     CHECK_THROWS_AS(CLI::ConfigINI().from_file("nonexist_file"), CLI::FileError);
 }
 
+static const int fclear1=fileClear("TestIniTmp.ini");
+
 TEST_CASE_METHOD(TApp, "IniNotRequired", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};
@@ -594,6 +596,8 @@ TEST_CASE_METHOD(TApp, "IniNotRequiredbadConfigurator", "[config]") {
     app.add_option("--two", two);
     REQUIRE_NOTHROW(run());
 }
+
+static const int fclear2=fileClear("TestIniTmp2.ini");
 
 TEST_CASE_METHOD(TApp, "IniNotRequiredNotDefault", "[config]") {
 
@@ -2018,6 +2022,53 @@ TEST_CASE_METHOD(TApp, "IniFalseFlagsDefDisableOverrideSuccess", "[config]") {
     CHECK(two == 2);
     CHECK(four == 4);
     CHECK(val == 15);
+}
+
+static const int fclear3=fileClear("TestIniTmp3.ini");
+
+TEST_CASE_METHOD(TApp, "IniDisableFlagOverride", "[config]") {
+
+    TempFile tmpini{"TestIniTmp.ini"};
+    TempFile tmpini2{"TestIniTmp2.ini"};
+    TempFile tmpini3{"TestIniTmp3.ini"};
+
+    app.set_config("--config", tmpini);
+
+    {
+        std::ofstream out{tmpini};
+        out << "[default]" << std::endl;
+        out << "two=2" << std::endl;
+    }
+
+    {
+        std::ofstream out{tmpini2};
+        out << "[default]" << std::endl;
+        out << "two=7" << std::endl;
+    }
+
+    {
+        std::ofstream out{tmpini3};
+        out << "[default]" << std::endl;
+        out << "three=true" << std::endl;
+    }
+
+
+    int val{0};
+    app.add_flag("--one{1},--two{2},--three{3}", val)->disable_flag_override();
+
+    run();
+    CHECK(tmpini.c_str() == app["--config"]->as<std::string>());
+    CHECK(val == 2);
+
+    args = {"--config", tmpini2};
+    CHECK_THROWS_AS(run(),CLI::ArgumentMismatch);
+
+
+    args = {"--config", tmpini3};
+    run();
+
+    CHECK(val == 3);
+    CHECK(tmpini3.c_str() == app.get_config_ptr()->as<std::string>());
 }
 
 TEST_CASE_METHOD(TApp, "TomlOutputSimple", "[config]") {

--- a/tests/app_helper.hpp
+++ b/tests/app_helper.hpp
@@ -33,6 +33,10 @@ class TApp {
     }
 };
 
+CLI11_INLINE int fileClear(const std::string& name) {
+    return std::remove(name.c_str());
+}
+
 class TempFile {
     std::string _name{};
 

--- a/tests/app_helper.hpp
+++ b/tests/app_helper.hpp
@@ -33,9 +33,7 @@ class TApp {
     }
 };
 
-CLI11_INLINE int fileClear(const std::string& name) {
-    return std::remove(name.c_str());
-}
+CLI11_INLINE int fileClear(const std::string &name) { return std::remove(name.c_str()); }
 
 class TempFile {
     std::string _name{};


### PR DESCRIPTION
Allow true as a valid value to be interpreted as the default in that case.

Ran into a situation where the user was very confused by an error in a config file.  Basically had a flag with `disable_flag_override` that was using different hidden values.  The user tried to specify it in a config file and expected "flag":true to work and gave a confusing error.  

This PR tweaks things a little so a value equivalent to "true" in a config file will get properly converted to the appropriate default value and remove a confusing error condition.   