### PR TITLE
Update TypeTools.hpp

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 // [CLI11:public_includes:set]
+#include <cmath>
 #include <cstdint>
 #include <exception>
 #include <limits>
@@ -15,7 +16,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-#include <cmath>
 // [CLI11:public_includes:end]
 
 #include "StringTools.hpp"

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -15,6 +15,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <cmath>
 // [CLI11:public_includes:end]
 
 #include "StringTools.hpp"
@@ -1545,8 +1546,7 @@ inline std::string sum_string_vector(const std::vector<std::string> &values) {
     } else {
         if(val <= static_cast<double>((std::numeric_limits<std::int64_t>::min)()) ||
            val >= static_cast<double>((std::numeric_limits<std::int64_t>::max)()) ||
-           // NOLINTNEXTLINE(clang-diagnostic-float-equal,bugprone-narrowing-conversions)
-           val == static_cast<std::int64_t>(val)) {
+           std::ceil(val) == std::floor(val)) {
             output = detail::value_string(static_cast<int64_t>(val));
         } else {
             output = detail::value_string(val);


### PR DESCRIPTION
fix #802 by using checking `std::ceil(val) == std::floor(val)` instead of `val == static_cast<std::int64_t>(val)` to avoid warnings-