### PR TITLE
test for out of bounds long long

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -796,11 +796,16 @@ inline std::string type_name() {
 /// Convert to an unsigned integral
 template <typename T, enable_if_t<std::is_unsigned<T>::value, detail::enabler> = detail::dummy>
 bool integral_conversion(const std::string &input, T &output) noexcept {
-    if(input.empty()) {
+    if(input.empty()||input.front()=='-') {
         return false;
     }
     char *val = nullptr;
+    errno=0;
     std::uint64_t output_ll = std::strtoull(input.c_str(), &val, 0);
+    if (errno == ERANGE)
+    {
+        return false;
+    }
     output = static_cast<T>(output_ll);
     if(val == (input.c_str() + input.size()) && static_cast<std::uint64_t>(output) == output_ll) {
         return true;
@@ -821,7 +826,12 @@ bool integral_conversion(const std::string &input, T &output) noexcept {
         return false;
     }
     char *val = nullptr;
+    errno=0;
     std::int64_t output_ll = std::strtoll(input.c_str(), &val, 0);
+    if (errno == ERANGE)
+    {
+        return false;
+    }
     output = static_cast<T>(output_ll);
     if(val == (input.c_str() + input.size()) && static_cast<std::int64_t>(output) == output_ll) {
         return true;

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -796,14 +796,13 @@ inline std::string type_name() {
 /// Convert to an unsigned integral
 template <typename T, enable_if_t<std::is_unsigned<T>::value, detail::enabler> = detail::dummy>
 bool integral_conversion(const std::string &input, T &output) noexcept {
-    if(input.empty()||input.front()=='-') {
+    if(input.empty() || input.front() == '-') {
         return false;
     }
     char *val = nullptr;
-    errno=0;
+    errno = 0;
     std::uint64_t output_ll = std::strtoull(input.c_str(), &val, 0);
-    if (errno == ERANGE)
-    {
+    if(errno == ERANGE) {
         return false;
     }
     output = static_cast<T>(output_ll);
@@ -826,10 +825,9 @@ bool integral_conversion(const std::string &input, T &output) noexcept {
         return false;
     }
     char *val = nullptr;
-    errno=0;
+    errno = 0;
     std::int64_t output_ll = std::strtoll(input.c_str(), &val, 0);
-    if (errno == ERANGE)
-    {
+    if(errno == ERANGE) {
         return false;
     }
     output = static_cast<T>(output_ll);

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1995,6 +1995,31 @@ TEST_CASE_METHOD(TApp, "typeCheck", "[app]") {
     CHECK_THROWS_AS(run(), CLI::ValidationError);
 }
 
+TEST_CASE_METHOD(TApp, "NeedsTrue", "[app]") {
+    std::string str;
+    app.add_option("-s,--string", str);
+    app.add_flag("--opt1")->check([&](const std::string &) {
+        return (str != "val_with_opt1")?std::string("--opt1 requires --string val_with_opt1"):std::string{};
+        });
+
+    run();
+
+    args = {"--opt1"};
+    CHECK_THROWS_AS(run(), CLI::ValidationError);
+
+    args = {"--string", "val"};
+    run();
+
+    args = {"--string", "val", "--opt1"};
+    CHECK_THROWS_AS(run(), CLI::ValidationError);
+
+    args = {"--string", "val_with_opt1", "--opt1"};
+    run();
+
+    args = {"--opt1", "--string", "val_with_opt1"};  // order is not revelant
+    run();
+}
+
 // Check to make sure programmatic access to left over is available
 TEST_CASE_METHOD(TApp, "AllowExtras", "[app]") {
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1999,8 +1999,8 @@ TEST_CASE_METHOD(TApp, "NeedsTrue", "[app]") {
     std::string str;
     app.add_option("-s,--string", str);
     app.add_flag("--opt1")->check([&](const std::string &) {
-        return (str != "val_with_opt1")?std::string("--opt1 requires --string val_with_opt1"):std::string{};
-        });
+        return (str != "val_with_opt1") ? std::string("--opt1 requires --string val_with_opt1") : std::string{};
+    });
 
     run();
 

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -410,7 +410,7 @@ TEST_CASE_METHOD(TApp, "IntegerOverFlowShort", "[optiontype]") {
     unsigned short B;
 
     app.add_option("-a", A);
-    app.add_option("-b",B);
+    app.add_option("-b", B);
 
     args = {"-a", "2626254242"};
     CHECK_THROWS_AS(run(), CLI::ConversionError);
@@ -430,7 +430,7 @@ TEST_CASE_METHOD(TApp, "IntegerOverFlowInt", "[optiontype]") {
     unsigned int B;
 
     app.add_option("-a", A);
-    app.add_option("-b",B);
+    app.add_option("-b", B);
 
     args = {"-a", "262625424225252"};
     CHECK_THROWS_AS(run(), CLI::ConversionError);
@@ -450,7 +450,7 @@ TEST_CASE_METHOD(TApp, "IntegerOverFlowLong", "[optiontype]") {
     unsigned long B;
 
     app.add_option("-a", A);
-    app.add_option("-b",B);
+    app.add_option("-b", B);
 
     args = {"-a", "1111111111111111111111111111"};
     CHECK_THROWS_AS(run(), CLI::ConversionError);
@@ -470,7 +470,7 @@ TEST_CASE_METHOD(TApp, "IntegerOverFlowLongLong", "[optiontype]") {
     unsigned long long B;
 
     app.add_option("-a", A);
-    app.add_option("-b",B);
+    app.add_option("-b", B);
 
     args = {"-a", "1111111111111111111111111111111111111111111111111111111111"};
     CHECK_THROWS_AS(run(), CLI::ConversionError);

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -406,8 +406,8 @@ TEST_CASE_METHOD(TApp, "VectorIndexedValidator", "[optiontype]") {
 }
 
 TEST_CASE_METHOD(TApp, "IntegerOverFlowShort", "[optiontype]") {
-    short A;
-    unsigned short B;
+    std::int16_t A{0};
+    std::uint16_t B{0};
 
     app.add_option("-a", A);
     app.add_option("-b", B);
@@ -426,8 +426,8 @@ TEST_CASE_METHOD(TApp, "IntegerOverFlowShort", "[optiontype]") {
 }
 
 TEST_CASE_METHOD(TApp, "IntegerOverFlowInt", "[optiontype]") {
-    int A;
-    unsigned int B;
+    int A{0};
+    unsigned int B{0};
 
     app.add_option("-a", A);
     app.add_option("-b", B);
@@ -446,8 +446,8 @@ TEST_CASE_METHOD(TApp, "IntegerOverFlowInt", "[optiontype]") {
 }
 
 TEST_CASE_METHOD(TApp, "IntegerOverFlowLong", "[optiontype]") {
-    long A;
-    unsigned long B;
+    std::int32_t A{0};
+    std::uint32_t B{0};
 
     app.add_option("-a", A);
     app.add_option("-b", B);
@@ -466,8 +466,8 @@ TEST_CASE_METHOD(TApp, "IntegerOverFlowLong", "[optiontype]") {
 }
 
 TEST_CASE_METHOD(TApp, "IntegerOverFlowLongLong", "[optiontype]") {
-    long long A;
-    unsigned long long B;
+    std::int64_t A{ 0 };
+    std::uint64_t B{0};
 
     app.add_option("-a", A);
     app.add_option("-b", B);

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -405,6 +405,86 @@ TEST_CASE_METHOD(TApp, "VectorIndexedValidator", "[optiontype]") {
     CHECK_THROWS_AS(run(), CLI::ValidationError);
 }
 
+TEST_CASE_METHOD(TApp, "IntegerOverFlowShort", "[optiontype]") {
+    short A;
+    unsigned short B;
+
+    app.add_option("-a", A);
+    app.add_option("-b",B);
+
+    args = {"-a", "2626254242"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "2626254242"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "-26262"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "-262624262525"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+}
+
+TEST_CASE_METHOD(TApp, "IntegerOverFlowInt", "[optiontype]") {
+    int A;
+    unsigned int B;
+
+    app.add_option("-a", A);
+    app.add_option("-b",B);
+
+    args = {"-a", "262625424225252"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "262625424225252"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "-2626225252"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "-26262426252525252"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+}
+
+TEST_CASE_METHOD(TApp, "IntegerOverFlowLong", "[optiontype]") {
+    long A;
+    unsigned long B;
+
+    app.add_option("-a", A);
+    app.add_option("-b",B);
+
+    args = {"-a", "1111111111111111111111111111"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "1111111111111111111111111111"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "-2626225252"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "-111111111111111111111111"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+}
+
+TEST_CASE_METHOD(TApp, "IntegerOverFlowLongLong", "[optiontype]") {
+    long long A;
+    unsigned long long B;
+
+    app.add_option("-a", A);
+    app.add_option("-b",B);
+
+    args = {"-a", "1111111111111111111111111111111111111111111111111111111111"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "1111111111111111111111111111111111111111111111111111111111"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "-2626225252"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+
+    args = {"-b", "-111111111111111111111111111111111111111111111111111111111"};
+    CHECK_THROWS_AS(run(), CLI::ConversionError);
+}
+
 TEST_CASE_METHOD(TApp, "VectorUnlimString", "[optiontype]") {
     std::vector<std::string> strvec;
     std::vector<std::string> answer{"mystring", "mystring2", "mystring3"};

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -466,7 +466,7 @@ TEST_CASE_METHOD(TApp, "IntegerOverFlowLong", "[optiontype]") {
 }
 
 TEST_CASE_METHOD(TApp, "IntegerOverFlowLongLong", "[optiontype]") {
-    std::int64_t A{ 0 };
+    std::int64_t A{0};
     std::uint64_t B{0};
 
     app.add_option("-a", A);


### PR DESCRIPTION
Resolve Issue #801  and add a test based on discussion #806 

Added ERANGE clear and check for unsigned and signed integer and added a check for `-` as the first value of the string for unsigned integers(this only mattered for uint64_t for 32 bit or smaller unsigned the existing check worked fine.  