### PR TITLE
fix: make_description min option output

### DIFF
--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -75,7 +75,7 @@ CLI11_INLINE std::string Formatter::make_description(const App *app) const {
         if(min_options == 1) {
             desc += " \n[Exactly 1 of the following options is required]";
         } else {
-            desc += " \n[Exactly " + std::to_string(min_options) + "options from the following list are required]";
+            desc += " \n[Exactly " + std::to_string(min_options) + " options from the following list are required]";
         }
     } else if(max_options > 0) {
         if(min_options > 0) {


### PR DESCRIPTION
Include spacing between the number of minimum options required and the rest of the description.