### PR TITLE
fix(tests): experimental support for external Catch3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ a.out*
 /package.json
 /yarn.lock
 /CLI11.hpp
+
+/subprojects/Catch2-*
+/subprojects/packagecache

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -141,8 +141,6 @@ TEST_CASE_METHOD(TApp, "StrangeFlagNames", "[app]") {
 }
 
 TEST_CASE_METHOD(TApp, "RequireOptionsError", "[app]") {
-    using Catch::Matchers::Contains;
-
     app.add_flag("-c");
     app.add_flag("--q");
     app.add_flag("--this,--that");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,32 +61,39 @@ endif()
 
 set(CLI11_MULTIONLY_TESTS TimerTest)
 
-add_library(catch_main main.cpp catch.hpp)
-target_include_directories(catch_main PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-
 find_package(Catch2 CONFIG)
 
 if(Catch2_FOUND)
   if(NOT TARGET Catch2::Catch2)
     message(FATAL_ERROR "Found Catch2 at ${Catch2_DIR} but targets are missing.")
   endif()
-  message(STATUS "Found Catch2")
-  target_link_libraries(catch_main PUBLIC Catch2::Catch2)
+  message(STATUS "Found Catch2 ${Catch2_VERSION}")
+
+  if(Catch2_VERSION VERSION_LESS 3)
+    add_library(catch_main main.cpp catch.hpp)
+    target_include_directories(catch_main PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+    target_link_libraries(catch_main PUBLIC Catch2::Catch2)
+  else()
+    add_library(catch_main ALIAS Catch2::Catch2WithMain)
+    target_compile_definitions(Catch2::Catch2WithMain INTERFACE -DCLI11_CATCH3)
+  endif()
 else()
   message(STATUS "Downloading Catch2")
 
   # FetchContent would be better, but requires newer CMake.
   file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/catch2")
-  set(url https://github.com/philsquared/Catch/releases/download/v2.13.7/catch.hpp)
+  set(url https://github.com/philsquared/Catch/releases/download/v2.13.10/catch.hpp)
   file(
     DOWNLOAD ${url} "${CMAKE_CURRENT_BINARY_DIR}/catch2/catch.hpp"
     STATUS status
-    EXPECTED_HASH SHA256=ea379c4a3cb5799027b1eb451163dff065a3d641aaba23bf4e24ee6b536bd9bc)
+    EXPECTED_HASH SHA256=3725c0f0a75f376a5005dde31ead0feb8f7da7507644c201b814443de8355170)
   list(GET status 0 error)
   if(error)
     message(FATAL_ERROR "Could not download ${url}, and Catch2 not found on your system.")
   endif()
-  target_include_directories(catch_main PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
+  add_library(catch_main main.cpp catch.hpp)
+  target_include_directories(catch_main PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}"
+                                               "${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
 # Target must already exist

--- a/tests/ComplexTypeTest.cpp
+++ b/tests/ComplexTypeTest.cpp
@@ -9,8 +9,6 @@
 #include <complex>
 #include <cstdint>
 
-using Catch::Matchers::Contains;
-
 using cx = std::complex<double>;
 
 CLI::Option *

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -9,8 +9,6 @@
 #include <cstdio>
 #include <sstream>
 
-using Catch::Matchers::Contains;
-
 TEST_CASE("StringBased: convert_arg_for_ini", "[config]") {
 
     CHECK("\"\"" == CLI::detail::convert_arg_for_ini(std::string{}));

--- a/tests/DeprecatedTest.cpp
+++ b/tests/DeprecatedTest.cpp
@@ -6,8 +6,6 @@
 
 #include "app_helper.hpp"
 
-using Catch::Matchers::Contains;
-
 TEST_CASE("Deprecated: Empty", "[deprecated]") {
     // No deprecated features at this time.
     CHECK(true);

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -13,8 +13,6 @@
 #include "catch.hpp"
 #include <fstream>
 
-using Catch::Matchers::Contains;
-
 class SimpleFormatter : public CLI::FormatterBase {
   public:
     SimpleFormatter() : FormatterBase() {}

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -13,8 +13,6 @@
 #include "catch.hpp"
 #include <fstream>
 
-using Catch::Matchers::Contains;
-
 TEST_CASE("THelp: Basic", "[help]") {
     CLI::App app{"My prog"};
 
@@ -1313,7 +1311,7 @@ TEST_CASE("TVersion: parse_throw", "[help]") {
     try {
         app.parse("--Version");
     } catch(const CLI::CallForVersion &v) {
-        CHECK_THAT(CLI11_VERSION, Catch::Equals(v.what()));
+        CHECK_THAT(CLI11_VERSION, Equals(v.what()));
         CHECK(0 == v.get_exit_code());
         const auto &appc = app;
         const auto *cptr = appc.get_version_ptr();

--- a/tests/NewParseTest.cpp
+++ b/tests/NewParseTest.cpp
@@ -10,8 +10,6 @@
 #include <cstdint>
 #include <utility>
 
-using Catch::Matchers::Contains;
-
 using cx = std::complex<double>;
 
 TEST_CASE_METHOD(TApp, "ComplexOption", "[newparse]") {

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -6,8 +6,6 @@
 
 #include "app_helper.hpp"
 
-using Catch::Matchers::Contains;
-
 using vs_t = std::vector<std::string>;
 
 TEST_CASE_METHOD(TApp, "BasicOptionGroup", "[optiongroup]") {

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -6,8 +6,6 @@
 
 #include "app_helper.hpp"
 
-using Catch::Matchers::Contains;
-
 using vs_t = std::vector<std::string>;
 
 TEST_CASE_METHOD(TApp, "BasicSubcommands", "[subcom]") {

--- a/tests/TimerTest.cpp
+++ b/tests/TimerTest.cpp
@@ -12,8 +12,6 @@
 #include <string>
 #include <thread>
 
-using Catch::Matchers::Contains;
-
 TEST_CASE("Timer: MSTimes", "[timer]") {
     CLI::Timer timer{"My Timer"};
     std::this_thread::sleep_for(std::chrono::milliseconds(123));

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -6,4 +6,26 @@
 
 #pragma once
 
+#include <string>
+
+#ifdef CLI11_CATCH3
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+using Catch::Approx;  // NOLINT(google-global-names-in-headers)
+using Catch::Matchers::Equals;  // NOLINT(google-global-names-in-headers)
+
+inline auto Contains(const std::string &x) { return Catch::Matchers::ContainsSubstring(x); }
+
+#else
+
 #include <catch2/catch.hpp>
+
+using Catch::Equals;  // NOLINT(google-global-names-in-headers)
+using Catch::Matchers::Contains;  // NOLINT(google-global-names-in-headers)
+
+#endif

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -16,7 +16,7 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
-using Catch::Approx;  // NOLINT(google-global-names-in-headers)
+using Catch::Approx;            // NOLINT(google-global-names-in-headers)
 using Catch::Matchers::Equals;  // NOLINT(google-global-names-in-headers)
 
 inline auto Contains(const std::string &x) { return Catch::Matchers::ContainsSubstring(x); }
@@ -25,7 +25,7 @@ inline auto Contains(const std::string &x) { return Catch::Matchers::ContainsSub
 
 #include <catch2/catch.hpp>
 
-using Catch::Equals;  // NOLINT(google-global-names-in-headers)
+using Catch::Equals;              // NOLINT(google-global-names-in-headers)
 using Catch::Matchers::Contains;  // NOLINT(google-global-names-in-headers)
 
 #endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,14 +1,21 @@
 catch2 = dependency('catch2')
 
-testmain = static_library(
-    'catch_main',
-    'main.cpp', 'catch.hpp',
-    dependencies: catch2,
-)
-testdep = declare_dependency(
-    link_with: testmain,
-    dependencies: [catch2, CLI11_dep]
-)
+if catch2.version().version_compare('<3')
+    testmain = static_library(
+        'catch_main',
+        'main.cpp', 'catch.hpp',
+        dependencies: catch2,
+    )
+    testdep = declare_dependency(
+        link_with: testmain,
+        dependencies: [catch2, CLI11_dep]
+    )
+else
+    testdep = declare_dependency(
+        dependencies: [CLI11_dep, dependency('catch2-with-main')],
+        compile_args: '-DCLI11_CATCH3'
+    )
+endif
 
 link_test_lib = library(
     'link_test_1',


### PR DESCRIPTION
Tested locally. Ideally we should add a CI test. Closes #826.
