### PR TITLE
fix: parse config file `remaining`

### DIFF
--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -87,6 +87,8 @@ app.allow_config_extras(CLI::config_extras_mode::ignore_all);
 will completely ignore any mismatches, extras, or other issues with the config
 file
 
+Config file extras are stored in the remaining output as two components. The first is the name of the field including subcommands using dot notation the second (or more) are the argument fields.
+
 ### Getting the used configuration file name
 
 If it is needed to get the configuration file name used this can be obtained via

--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -87,7 +87,9 @@ app.allow_config_extras(CLI::config_extras_mode::ignore_all);
 will completely ignore any mismatches, extras, or other issues with the config
 file
 
-Config file extras are stored in the remaining output as two components. The first is the name of the field including subcommands using dot notation the second (or more) are the argument fields.
+Config file extras are stored in the remaining output as two components. The
+first is the name of the field including subcommands using dot notation the
+second (or more) are the argument fields.
 
 ### Getting the used configuration file name
 

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1414,10 +1414,9 @@ CLI11_INLINE bool App::_parse_single_config(const ConfigItem &item, std::size_t 
         if(get_allow_config_extras() == config_extras_mode::capture)
             // Should we worry about classifying the extras properly?
             missing_.emplace_back(detail::Classifier::NONE, item.fullname());
-            for (const auto& input : item.inputs)
-            {
-                missing_.emplace_back(detail::Classifier::NONE,input);
-            }
+        for(const auto &input : item.inputs) {
+            missing_.emplace_back(detail::Classifier::NONE, input);
+        }
         return false;
     }
 

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1414,6 +1414,10 @@ CLI11_INLINE bool App::_parse_single_config(const ConfigItem &item, std::size_t 
         if(get_allow_config_extras() == config_extras_mode::capture)
             // Should we worry about classifying the extras properly?
             missing_.emplace_back(detail::Classifier::NONE, item.fullname());
+            for (const auto& input : item.inputs)
+            {
+                missing_.emplace_back(detail::Classifier::NONE,input);
+            }
         return false;
     }
 

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -509,8 +509,46 @@ TEST_CASE_METHOD(TApp, "IniGetRemainingOption", "[config]") {
     int two{0};
     app.add_option("--two", two);
     REQUIRE_NOTHROW(run());
-    std::vector<std::string> ExpectedRemaining = {ExtraOption};
+    std::vector<std::string> ExpectedRemaining = {ExtraOption,"3"};
     CHECK(ExpectedRemaining == app.remaining());
+}
+
+TEST_CASE_METHOD(TApp, "IniRemainingSub", "[config]") {
+    TempFile tmpini{"TestIniTmp.ini"};
+
+    app.set_config("--config", tmpini);
+    auto *map=app.add_subcommand("map");
+    map->allow_config_extras();
+
+    {
+        std::ofstream out{tmpini};
+        out << "[map]\n";
+        out << "a = 1\n";
+        out << "b=[1,2,3]\n";
+        out << "c = 3"<<std::endl;
+    }
+
+    REQUIRE_NOTHROW(run());
+    std::vector<std::string> rem=map->remaining();
+    REQUIRE(rem.size()==8U);
+    CHECK(rem[0]=="map.a");
+    CHECK(rem[2]=="map.b");
+    CHECK(rem[6]=="map.c");
+    CHECK(rem[5]=="3");
+
+    int a{ 0 };
+    int c{ 0 };
+    std::vector<int> b;
+    map->add_option("-a",a);
+    map->add_option("-b",b);
+    map->add_option("-c",c);
+
+    CHECK_NOTHROW(app.parse(app.remaining_for_passthrough()));
+    CHECK(a==1);
+    CHECK(c==3);
+    REQUIRE(b.size()==3U);
+    CHECK(b[1]==2);
+
 }
 
 TEST_CASE_METHOD(TApp, "IniGetNoRemaining", "[config]") {

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -509,7 +509,7 @@ TEST_CASE_METHOD(TApp, "IniGetRemainingOption", "[config]") {
     int two{0};
     app.add_option("--two", two);
     REQUIRE_NOTHROW(run());
-    std::vector<std::string> ExpectedRemaining = {ExtraOption,"3"};
+    std::vector<std::string> ExpectedRemaining = {ExtraOption, "3"};
     CHECK(ExpectedRemaining == app.remaining());
 }
 
@@ -517,7 +517,7 @@ TEST_CASE_METHOD(TApp, "IniRemainingSub", "[config]") {
     TempFile tmpini{"TestIniTmp.ini"};
 
     app.set_config("--config", tmpini);
-    auto *map=app.add_subcommand("map");
+    auto *map = app.add_subcommand("map");
     map->allow_config_extras();
 
     {
@@ -525,30 +525,29 @@ TEST_CASE_METHOD(TApp, "IniRemainingSub", "[config]") {
         out << "[map]\n";
         out << "a = 1\n";
         out << "b=[1,2,3]\n";
-        out << "c = 3"<<std::endl;
+        out << "c = 3" << std::endl;
     }
 
     REQUIRE_NOTHROW(run());
-    std::vector<std::string> rem=map->remaining();
-    REQUIRE(rem.size()==8U);
-    CHECK(rem[0]=="map.a");
-    CHECK(rem[2]=="map.b");
-    CHECK(rem[6]=="map.c");
-    CHECK(rem[5]=="3");
+    std::vector<std::string> rem = map->remaining();
+    REQUIRE(rem.size() == 8U);
+    CHECK(rem[0] == "map.a");
+    CHECK(rem[2] == "map.b");
+    CHECK(rem[6] == "map.c");
+    CHECK(rem[5] == "3");
 
-    int a{ 0 };
-    int c{ 0 };
+    int a{0};
+    int c{0};
     std::vector<int> b;
-    map->add_option("-a",a);
-    map->add_option("-b",b);
-    map->add_option("-c",c);
+    map->add_option("-a", a);
+    map->add_option("-b", b);
+    map->add_option("-c", c);
 
     CHECK_NOTHROW(app.parse(app.remaining_for_passthrough()));
-    CHECK(a==1);
-    CHECK(c==3);
-    REQUIRE(b.size()==3U);
-    CHECK(b[1]==2);
-
+    CHECK(a == 1);
+    CHECK(c == 3);
+    REQUIRE(b.size() == 3U);
+    CHECK(b[1] == 2);
 }
 
 TEST_CASE_METHOD(TApp, "IniGetNoRemaining", "[config]") {


### PR DESCRIPTION
Adds the output values from a config file to the remaining stream.  
This fixes issue #821 and allows the remaining in the case subcommands to be reparsed if the options are added or in a second CLI11 app.  
