### PR TITLE
chore: Mark include files as SYSTEM

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,9 +53,17 @@ endif()
 # Allow IDE's to group targets into folders
 add_library(CLI11::CLI11 ALIAS CLI11) # for add_subdirectory calls
 
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  set(SYSTEM_INCL "")
+else()
+  # If this project is included from somewhere else, we mark our headers as system headers to avoid
+  # the compiler emitting any warnings about them
+  set(SYSTEM_INCL "SYSTEM")
+endif()
+
 # Duplicated because CMake adds the current source dir if you don't.
 target_include_directories(
-  CLI11 ${PUBLIC_OR_INTERFACE} $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  CLI11 ${SYSTEM_INCL} ${PUBLIC_OR_INTERFACE} $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
 if(CMAKE_VERSION VERSION_LESS 3.8)


### PR DESCRIPTION
When including CLI11 in a separate project (e.g. via FetchContent) cmake will now mark the CLI11 include files as system includes, which prevents compilers from issuing any warnings for stuff it found inside these headers. This makes sure that downstream users are not confronted with potential warning messages from CLI11, regardless of what kind of obscure warnings they might have enabled for their projects.

Fixes #833