### PR TITLE
isolate the definition of NOMINMAX 

### DIFF
--- a/include/CLI/impl/Argv_inl.hpp
+++ b/include/CLI/impl/Argv_inl.hpp
@@ -31,16 +31,23 @@
 #define _ARM_
 #endif
 #endif
-#define NOMINMAX
+
 // first
+#ifndef NOMINMAX
+// if NOMINMAX is already defined we don't want to mess with that either way
+#define NOMINMAX
 #include <windef.h>
+#undef NOMINMAX
+#else
+#include <windef.h>
+#endif
+
 // second
 #include <winbase.h>
 // third
 #include <processthreadsapi.h>
 #include <shellapi.h>
 
-#undef NOMINMAX
 #elif defined(__APPLE__)
 #include <crt_externs.h>
 #endif


### PR DESCRIPTION
isolate the definition of NOMINMAX further and skip undef if previously defined to not cause issue with other code that uses the definition.

This became an issue when using CLI11 in code that also included windows.h and made use of the NOMINMAX definition.  There was a potential issue when CLI11 undefined it.    This fix checks for the definition of NOMINMAX and leave it in place instead of undefining it.  