### PR TITLE
NVCC warning supression pragma fix for CUDA >= 11.5

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -159,11 +159,19 @@ template <typename T, typename C> class is_direct_constructible {
     static auto test(int, std::true_type) -> decltype(
 // NVCC warns about narrowing conversions here
 #ifdef __CUDACC__
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_suppress 2361
+#else
 #pragma diag_suppress 2361
+#endif
 #endif
         TT{std::declval<CC>()}
 #ifdef __CUDACC__
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diag_default 2361
+#else
 #pragma diag_default 2361
+#endif
 #endif
         ,
         std::is_move_assignable<TT>());


### PR DESCRIPTION
CUDA 11.5 deprecated (and CUDA 12.0 removed) diagnostic pragmas such as `diag_suppress` and `diag_default`.

Replacement pragmas were prefixed with `nv_`, i.e. `nv_diag_suppress`

`__NVCC_DIAG_PRAGMA_SUPPORT__` is defined if the prefixed versions are available.

Closes https://github.com/CLIUtils/CLI11/issues/757

---

This is not currently covered by any CI, as `tests.yml`'s `cuda-build` uses CUDA `10.2`. To cover all 3 variants of warnigns would require `CUDA < 11.5`, `CUDA >= 11.5 && CUDA <= 11.8` and `CUDA >= 12.0`.

When building with `-DCLI11_CUDA_TESTS=ON`, using CUDA 11.5 to 11.8 inclusive this patch prevents the repeated emission of: 

```
CLI11/include/CLI/TypeTools.hpp(162): warning #20236-D: pragma "diag_suppress" is deprecated, use "nv_diag_suppress" instead

CLI11/include/CLI/TypeTools.hpp(166): warning #20236-D: pragma "diag_default" is deprecated, use "nv_diag_default" instead
```

When using CUDA 12.0+, it prevents the repeated emission of:

```
CLI11/include/CLI/TypeTools.hpp(164): warning #2361-D: invalid narrowing conversion from "int" to "unsigned long"
          TT{std::declval<CC>()}
             ^
          detected during:
            instantiation of "CLI::detail::is_direct_constructible<T, C>::test [with T=std::vector<std::string, std::allocator<std::string>>, C=int]" based on template arguments <std::vector<std::string, std::allocator<std::string>>, int> at line 176
            instantiation of class "CLI::detail::is_direct_constructible<T, C> [with T=std::vector<std::string, std::allocator<std::string>>, C=int]" at line 674 of CLI11/include/CLI/Option.hpp
            instantiation of "void CLI::Option::results(T &) const [with T=std::vector<std::string, std::allocator<std::string>>]" at line 703 of CLI11/include/CLI/Option.hpp
            instantiation of "T CLI::Option::as<T>() const [with T=std::vector<std::string, std::allocator<std::string>>]" at line 1017 of CLI11/include/CLI/impl/App_inl.hpp

```
