### PR TITLE
[DEPRECATED] Better Help-Text formatting - Align single and double dash flags and options

### DIFF
--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -10,10 +10,10 @@
 #include <CLI/StringTools.hpp>
 
 // [CLI11:public_includes:set]
-#include <string>
-#include <vector>
 #include <algorithm>
 #include <cmath>
+#include <string>
+#include <vector>
 // [CLI11:public_includes:end]
 
 namespace CLI {
@@ -122,7 +122,7 @@ format_help(std::ostream &out, std::string name, const std::string &description,
         // Calculate setw sizes
         const int leftSideWidth = static_cast<int>(wid) / 4;  // 25% left for short names
         const int rightSideWidth = static_cast<int>(
-                                                    std::ceil(static_cast<float>(wid) / 4.0f * 3.0f));  // 75% right for long names and options, ceil result
+            std::ceil(static_cast<float>(wid) / 4.0f * 3.0f));  // 75% right for long names and options, ceil result
 
         //*****************************************************************************
         // Assemble short (single dash) names if any and print them on left side

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -88,100 +88,91 @@ format_help(std::ostream &out, std::string name, const std::string &description,
     // Split name and opts into two parts, but only at first space (cannot use provided split(...) function for that)
     std::vector<std::string> name_opts;
     const std::size_t firstSpace = name.find(" ");
-    
+
     name_opts.push_back(name.substr(0, firstSpace));
     if(firstSpace != std::string::npos)
         name_opts.push_back(name.substr(firstSpace + 1, std::string::npos));
-    
-    // Check for any single or dual dash. If none present, this is a subcommand or positional. Subcommand/positional doesn't need special formatting
-    if(name_opts[0].find("-", 0) == std::string::npos && name_opts[0].find("--", 0) == std::string::npos)
-    {
+
+    // Check for any single or dual dash. If none present, this is a subcommand or positional. Subcommand/positional
+    // doesn't need special formatting
+    if(name_opts[0].find("-", 0) == std::string::npos && name_opts[0].find("--", 0) == std::string::npos) {
         // Use default formatting
         name = "  " + name;
         out << std::setw(static_cast<int>(wid)) << std::left << name;
-    }
-    else
-    {
+    } else {
         // Split names at comma
         const auto names = split(name_opts[0], ',');
-        
+
         // Search short and long names
         int posFirstDoubleDashName = -1;
         std::size_t numOfSingleDashName = 0;
-        
+
         // Search first double dash (long) name
-        for(std::size_t i = 0; i < names.size(); i++)
-        {
+        for(std::size_t i = 0; i < names.size(); i++) {
             if(posFirstDoubleDashName == -1 && (names[i].find("--", 0) != std::string::npos))
                 posFirstDoubleDashName = i;
         }
-        
+
         // Calculate num of single dash (short) names
         if(posFirstDoubleDashName == -1)
-            numOfSingleDashName = names.size(); // Only single dash name
+            numOfSingleDashName = names.size();  // Only single dash name
         else
             numOfSingleDashName = static_cast<std::size_t>(posFirstDoubleDashName);
-        
+
         // Calculate setw sizes
-        const int leftSideWidth = static_cast<int>(wid) / 4; // 25% left for short names
-        const int rightSideWidth = static_cast<int>(std::ceil(static_cast<float>(wid) / 4.0f * 3.0f)); // 75% right for long names and options, ceil result
-        
+        const int leftSideWidth = static_cast<int>(wid) / 4;  // 25% left for short names
+        const int rightSideWidth = static_cast<int>(
+                                                    std::ceil(static_cast<float>(wid) / 4.0f * 3.0f));  // 75% right for long names and options, ceil result
+
         //*****************************************************************************
         // Assemble short (single dash) names if any and print them on left side
-        if(numOfSingleDashName > 0)
-        {
+        if(numOfSingleDashName > 0) {
             // Join all single dash (short) names, seperated by ", "
             std::string singleDashNames = "  ";
-            for(std::size_t i = 0; i < numOfSingleDashName; i++)
-            {
+            for(std::size_t i = 0; i < numOfSingleDashName; i++) {
                 singleDashNames += names[i];
-                
+
                 // Add seperator (command + space) only if we're not at the last element
                 if(i < numOfSingleDashName - 1)
                     singleDashNames += ", ";
             }
-            
+
             // Print joined single dash (short) names on the left side
             out << std::setw(leftSideWidth) << std::left << singleDashNames;
-        }
-        else
-        {
+        } else {
             // No single dash (short) names. Print spaces for left side
             out << std::setw(leftSideWidth) << std::left << " ";
         }
-        
+
         //*****************************************************************************
-        // Assemble long (double dash) names if any and print them on right side. Also add name options to the right side
-        if(posFirstDoubleDashName > -1)
-        {
+        // Assemble long (double dash) names if any and print them on right side. Also add name options to the right
+        // side
+        if(posFirstDoubleDashName > -1) {
             // Join all double dash (long) names, seperated by ", "
             std::string doubleDashNames = "";
-            for(std::size_t i = static_cast<std::size_t>(posFirstDoubleDashName); i < names.size(); i++)
-            {
+            for(std::size_t i = static_cast<std::size_t>(posFirstDoubleDashName); i < names.size(); i++) {
                 doubleDashNames += names[i];
-                
+
                 // Add seperator (command + space) only if we're not at the last element
                 if(i < names.size() - 1)
                     doubleDashNames += ", ";
             }
-            
+
             // Add options (if any)
             if(name_opts.size() > 1)
                 doubleDashNames += " " + name_opts[1];
-            
+
             // Print joined double dash (long) names and options on the right side
             out << std::setw(rightSideWidth) << std::left << doubleDashNames;
-        }
-        else
-        {
+        } else {
             // No double dash (long) options. Print options (if any) or spaces for right side
             if(name_opts.size() > 1)
-                out << std::setw(rightSideWidth) << std::left << name_opts[1]; // We have options
+                out << std::setw(rightSideWidth) << std::left << name_opts[1];  // We have options
             else
                 out << std::setw(rightSideWidth) << std::left << " ";
         }
     }
-    
+
     if(!description.empty()) {
         if(name.length() >= wid)
             out << "\n" << std::setw(static_cast<int>(wid)) << "";

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -12,6 +12,8 @@
 // [CLI11:public_includes:set]
 #include <string>
 #include <vector>
+#include <algorithm>
+#include <cmath>
 // [CLI11:public_includes:end]
 
 namespace CLI {
@@ -83,8 +85,103 @@ CLI11_INLINE std::string fix_newlines(const std::string &leader, std::string inp
 
 CLI11_INLINE std::ostream &
 format_help(std::ostream &out, std::string name, const std::string &description, std::size_t wid) {
-    name = "  " + name;
-    out << std::setw(static_cast<int>(wid)) << std::left << name;
+    // Split name and opts into two parts, but only at first space (cannot use provided split(...) function for that)
+    std::vector<std::string> name_opts;
+    const std::size_t firstSpace = name.find(" ");
+    
+    name_opts.push_back(name.substr(0, firstSpace));
+    if(firstSpace != std::string::npos)
+        name_opts.push_back(name.substr(firstSpace + 1, std::string::npos));
+    
+    // Check for any single or dual dash. If none present, this is a subcommand or positional. Subcommand/positional doesn't need special formatting
+    if(name_opts[0].find("-", 0) == std::string::npos && name_opts[0].find("--", 0) == std::string::npos)
+    {
+        // Use default formatting
+        name = "  " + name;
+        out << std::setw(static_cast<int>(wid)) << std::left << name;
+    }
+    else
+    {
+        // Split names at comma
+        const auto names = split(name_opts[0], ',');
+        
+        // Search short and long names
+        int posFirstDoubleDashName = -1;
+        std::size_t numOfSingleDashName = 0;
+        
+        // Search first double dash (long) name
+        for(std::size_t i = 0; i < names.size(); i++)
+        {
+            if(posFirstDoubleDashName == -1 && (names[i].find("--", 0) != std::string::npos))
+                posFirstDoubleDashName = i;
+        }
+        
+        // Calculate num of single dash (short) names
+        if(posFirstDoubleDashName == -1)
+            numOfSingleDashName = names.size(); // Only single dash name
+        else
+            numOfSingleDashName = static_cast<std::size_t>(posFirstDoubleDashName);
+        
+        // Calculate setw sizes
+        const int leftSideWidth = static_cast<int>(wid) / 4; // 25% left for short names
+        const int rightSideWidth = static_cast<int>(std::ceil(static_cast<float>(wid) / 4.0f * 3.0f)); // 75% right for long names and options, ceil result
+        
+        //*****************************************************************************
+        // Assemble short (single dash) names if any and print them on left side
+        if(numOfSingleDashName > 0)
+        {
+            // Join all single dash (short) names, seperated by ", "
+            std::string singleDashNames = "  ";
+            for(std::size_t i = 0; i < numOfSingleDashName; i++)
+            {
+                singleDashNames += names[i];
+                
+                // Add seperator (command + space) only if we're not at the last element
+                if(i < numOfSingleDashName - 1)
+                    singleDashNames += ", ";
+            }
+            
+            // Print joined single dash (short) names on the left side
+            out << std::setw(leftSideWidth) << std::left << singleDashNames;
+        }
+        else
+        {
+            // No single dash (short) names. Print spaces for left side
+            out << std::setw(leftSideWidth) << std::left << " ";
+        }
+        
+        //*****************************************************************************
+        // Assemble long (double dash) names if any and print them on right side. Also add name options to the right side
+        if(posFirstDoubleDashName > -1)
+        {
+            // Join all double dash (long) names, seperated by ", "
+            std::string doubleDashNames = "";
+            for(std::size_t i = static_cast<std::size_t>(posFirstDoubleDashName); i < names.size(); i++)
+            {
+                doubleDashNames += names[i];
+                
+                // Add seperator (command + space) only if we're not at the last element
+                if(i < names.size() - 1)
+                    doubleDashNames += ", ";
+            }
+            
+            // Add options (if any)
+            if(name_opts.size() > 1)
+                doubleDashNames += " " + name_opts[1];
+            
+            // Print joined double dash (long) names and options on the right side
+            out << std::setw(rightSideWidth) << std::left << doubleDashNames;
+        }
+        else
+        {
+            // No double dash (long) options. Print options (if any) or spaces for right side
+            if(name_opts.size() > 1)
+                out << std::setw(rightSideWidth) << std::left << name_opts[1]; // We have options
+            else
+                out << std::setw(rightSideWidth) << std::left << " ";
+        }
+    }
+    
     if(!description.empty()) {
         if(name.length() >= wid)
             out << "\n" << std::setw(static_cast<int>(wid)) << "";

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -87,7 +87,7 @@ CLI11_INLINE std::ostream &
 format_help(std::ostream &out, std::string name, const std::string &description, std::size_t wid) {
     // Split name and opts into two parts, but only at first space (cannot use provided split(...) function for that)
     std::vector<std::string> name_opts;
-    const std::size_t firstSpace = name.find(" ");
+    const std::size_t firstSpace = name.find(' ');
 
     name_opts.push_back(name.substr(0, firstSpace));
     if(firstSpace != std::string::npos)
@@ -95,7 +95,7 @@ format_help(std::ostream &out, std::string name, const std::string &description,
 
     // Check for any single or dual dash. If none present, this is a subcommand or positional. Subcommand/positional
     // doesn't need special formatting
-    if(name_opts[0].find("-", 0) == std::string::npos && name_opts[0].find("--", 0) == std::string::npos) {
+    if(name_opts[0].find('-', 0) == std::string::npos && name_opts[0].find("--", 0) == std::string::npos) {
         // Use default formatting
         name = "  " + name;
         out << std::setw(static_cast<int>(wid)) << std::left << name;
@@ -110,7 +110,7 @@ format_help(std::ostream &out, std::string name, const std::string &description,
         // Search first double dash (long) name
         for(std::size_t i = 0; i < names.size(); i++) {
             if(posFirstDoubleDashName == -1 && (names[i].find("--", 0) != std::string::npos))
-                posFirstDoubleDashName = i;
+                posFirstDoubleDashName = static_cast<int>(i);
         }
 
         // Calculate num of single dash (short) names
@@ -150,7 +150,7 @@ format_help(std::ostream &out, std::string name, const std::string &description,
         if(posFirstDoubleDashName > -1) {
             // Join all double dash (long) names, seperated by ", "
             std::string doubleDashNames = "";
-            for(std::size_t i = static_cast<std::size_t>(posFirstDoubleDashName); i < names.size(); i++) {
+            for(auto i = static_cast<std::size_t>(posFirstDoubleDashName); i < names.size(); i++) {
                 doubleDashNames += names[i];
 
                 // Add seperator (command + space) only if we're not at the last element


### PR DESCRIPTION
# Deprecated
### A new PR has been made, see #866.
### ⚠️ Please ignore everything below. Only the new PR is relevant now.

----------------------------------------------------------------------------------------------------------------------
**EDIT: I found a way to implement this PR nicely into the default `Formatter`, instead of the ugly way like it is now. I'm currently working on that and some additional features for better help formatting, like paragraphs with correct line wrapping for long descriptions.
Please ignore the text below, do not merge this PR, and please leave it open for now until I sorted things out. I'll take care of everything.**

**EDIT 2: Still on it, almost done. Should be completed this weekend.**

This PR is mainly based on #353 and indirectly on #856. It adds a new and better help text formatting by aligning single and double dash flags and options nicely.

A bit about the background: ~~As far as I understood the source code (and wrote in #856) there is no good way to reliable format all combinations for flags and options using a custom formatter (or by modifying the default formatter). This PR therefore changes the `std::ostream& format_help(...)` function directly.~~ **_EDIT: This is wrong. I'm working on a PR which changes the default formatter and leaves the `format_help` function in it's original state._**
A goal was not needing to modify any function signatures or otherwise spread-out changes to the codebase. Because of that, the code for this PR seems a bit more verbose since, for example, we need to split up the parameter `std::string name` inside `format_help` after it got assembled while actually calling `format_help`. But as I said, I wanted to avoid changing function signatures or spread the changes across more files than necessary. I added a lot of comments to explain what is going on. The code also supports setting a custom column size. Single dash flags occupy 25% of the column width, double dash flags and options (like REQUIRED) 75%.

I thoroughly testes this code and so far it worked without a problem with all examples and custom tests made by me. ~~I'm currently testing with CLI11 tests.~~ **_EDIT: The failed tests are failing because they expect the old help text format. So all Tests seem to "pass"._** However there is no guarantee (yet) that it is fully bug free. The code is only manipulating singe and double dash flags and options (-f or --file). Subcommands and positionals are formatted like before, no changes are made to them.

Here's an example of the new help text formatting:
```
Description
Usage: myApp [OPTIONS]

Options:
  -h      --help                        Print this help message and exit
  -v      --version                     Display program version information and exit
  -p      --path STRING REQUIRED        Path to start in
  -a, -b  --multiple                    Multiple
          --only-long                   Long
          --hidden, --hide              Show or hide hidden files
  -r      REQUIRED                      Short req.
  -s                                    Short

This is a footer!
```

The alignment is like suggested in #353 and also looks more UNIX standard.

I think I'll make some improvements tomorrow or simplify some code, fix some spelling and code style issues. But there shouldn't be any major changes. I'll appreciate some feedback and am looking forward to possibly see the new formatting in CLI11. If this is completely the wrong way and such changes are only allowed using custom formatters, let me know.

