### PR TITLE
Add a method to trigger reading of all config files

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -288,6 +288,10 @@ class App {
     /// This is the formatter for help printing. Default provided. INHERITABLE (same pointer)
     std::shared_ptr<Config> config_formatter_{new ConfigTOML()};
 
+    /// Take all options from all config files into account. Results are in the order config files are parsed
+    /// Last parsed config file takes precedence
+    bool all_config_files_{false};
+
     ///@}
 
     /// Special private constructor for subcommand
@@ -475,6 +479,12 @@ class App {
     /// Set the config formatter
     App *config_formatter(std::shared_ptr<Config> fmt) {
         config_formatter_ = fmt;
+        return this;
+    }
+
+    /// Specify that all options from all config files are considered
+    App *all_config_files(bool all = true) {
+        all_config_files_ = all;
         return this;
     }
 
@@ -1222,6 +1232,9 @@ class App {
 
     /// Read and process a configuration file (main app only)
     void _process_config_file();
+
+    /// Read and process a particular configuration file
+    void _process_config_file(const std::string &config_file, bool config_required, bool file_given);
 
     /// Get envname options if not yet passed. Runs on *all* subcommands.
     void _process_env();


### PR DESCRIPTION
This pull request did not change the behavior of application code if the newly introduced method
`App *all_config_files(bool all = true)` is not used.

- Add a method `App *all_config_files(bool all = true)` to trigger reading of all config files in reverse order so that the last read config file takes precedence.
- This is at least interesting when subcommand aliases are used and the same option names exist in different configuration files for these different subcommand names. This allows a combined option set to be constructed from different subcommand names and configuration files.

