### PR TITLE
Test update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,45 +75,41 @@ jobs:
         run: cmake --build build -j4 -- --keep-going
 
   cuda10-build:
-    name: CUDA build only
+    name: CUDA 10 build only
     runs-on: ubuntu-latest
     container: nvidia/cuda:10.2-devel-ubuntu18.04
     steps:
+      - name: Add build tools
+        run: apt-get update && apt-get install -y wget git cmake
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Add wget
-        run: apt-get update && apt-get install -y wget
-      - name: Get cmake
-        uses: jwlawson/actions-setup-cmake@v1.13
       - name: Configure
         run: cmake -S . -B build -DCLI11_CUDA_TESTS=ON
       - name: Build
         run: cmake --build build -j2
         
   cuda11-build:
-    name: CUDA build only
+    name: CUDA 11 build only
     runs-on: ubuntu-latest
     container: nvidia/cuda:11.8.0-devel-ubuntu22.04
     steps:
+      - name: Add build tools
+        run: apt-get update && apt-get install -y wget git cmake
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Add wget
-        run: apt-get update && apt-get install -y wget
-      - name: Get cmake
-        uses: jwlawson/actions-setup-cmake@v1.13
       - name: Configure
         run: cmake -S . -B build -DCLI11_CUDA_TESTS=ON
       - name: Build
         run: cmake --build build -j2
 
   cuda12-build:
-    name: CUDA build only
+    name: CUDA 12 build only
     runs-on: ubuntu-latest
     container: nvidia/cuda:12.1.0-devel-ubuntu22.04
     steps:
-      - name: Add wget
+      - name: Add build tools
         run: apt-get update && apt-get install -y wget git cmake
       - uses: actions/checkout@v3
         with:
@@ -128,13 +124,11 @@ jobs:
     runs-on: ubuntu-latest
     container: zouzias/boost:1.78.0
     steps:
+      - name: Add deps
+        run: apt-get update && apt-get install make cmake
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Add deps
-        run: apt-get update && apt-get install make
-      - name: Get CMake
-        uses: jwlawson/actions-setup-cmake@v1.13
       - name: Configure
         run: cmake -S . -B build -DCLI11_BOOST=ON
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,19 +106,13 @@ jobs:
 
   boost-build:
     name: Boost build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Install boost
-        uses: MarkusJx/install-boost@v2.4.1
-        id: install-boost
-        with:
-            # REQUIRED: Specify the required boost version
-            # A list of supported versions can be found here:
-            # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
-            boost_version: 1.78.0
+      - name: Add boost
+        run: sudo apt-get update && sudo apt-get install -y libboost-dev
       # NOTE: If a boost version matching all requirements cannot be found,
       # this build step will fail
       - name: Configure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,13 +113,11 @@ jobs:
     runs-on: ubuntu-latest
     container: nvidia/cuda:12.1.0-devel-ubuntu22.04
     steps:
+      - name: Add wget
+        run: apt-get update && apt-get install -y wget git cmake
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Add wget
-        run: apt-get update && apt-get install -y wget
-      - name: Get cmake
-        uses: jwlawson/actions-setup-cmake@v1.13
       - name: Configure
         run: cmake -S . -B build -DCLI11_CUDA_TESTS=ON
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,12 +74,46 @@ jobs:
       - name: Build
         run: cmake --build build -j4 -- --keep-going
 
-  cuda-build:
+  cuda10-build:
     name: CUDA build only
     runs-on: ubuntu-latest
     container: nvidia/cuda:10.2-devel-ubuntu18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Add wget
+        run: apt-get update && apt-get install -y wget
+      - name: Get cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+      - name: Configure
+        run: cmake -S . -B build -DCLI11_CUDA_TESTS=ON
+      - name: Build
+        run: cmake --build build -j2
+        
+  cuda11-build:
+    name: CUDA build only
+    runs-on: ubuntu-latest
+    container: nvidia/cuda:11.8-devel-ubuntu22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Add wget
+        run: apt-get update && apt-get install -y wget
+      - name: Get cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+      - name: Configure
+        run: cmake -S . -B build -DCLI11_CUDA_TESTS=ON
+      - name: Build
+        run: cmake --build build -j2
+
+  cuda12-build:
+    name: CUDA build only
+    runs-on: ubuntu-latest
+    container: nvidia/cuda:12.1-devel-ubuntu22.04
+    steps:
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Add wget
@@ -96,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     container: zouzias/boost:1.76.0
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Add deps
@@ -260,16 +294,22 @@ jobs:
           cmake-version: "3.22"
         if: success() || failure()
 
-      - name: Check CMake 3.23 (full)
+      - name: Check CMake 3.23 
         uses: ./.github/actions/quick_cmake
         with:
           cmake-version: "3.23"
-          args: -DCLI11_SANITIZERS=ON -DCLI11_BUILD_EXAMPLES_JSON=ON
         if: success() || failure()
 
       - name: Check CMake 3.24 (full)
         uses: ./.github/actions/quick_cmake
         with:
           cmake-version: "3.24"
+          args: -DCLI11_SANITIZERS=ON -DCLI11_BUILD_EXAMPLES_JSON=ON
+        if: success() || failure()
+
+      - name: Check CMake 3.25 (full)
+        uses: ./.github/actions/quick_cmake
+        with:
+          cmake-version: "3.25"
           args: -DCLI11_SANITIZERS=ON -DCLI11_BUILD_EXAMPLES_JSON=ON
         if: success() || failure()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,21 +74,6 @@ jobs:
       - name: Build
         run: cmake --build build -j4 -- --keep-going
 
-  cuda10-build:
-    name: CUDA 10 build only
-    runs-on: ubuntu-latest
-    container: nvidia/cuda:10.2-devel-ubuntu18.04
-    steps:
-      - name: Add build tools
-        run: apt-get update && apt-get install -y wget git cmake
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Configure
-        run: cmake -S . -B build -DCLI11_CUDA_TESTS=ON
-      - name: Build
-        run: cmake --build build -j2
-        
   cuda11-build:
     name: CUDA 11 build only
     runs-on: ubuntu-latest
@@ -122,13 +107,20 @@ jobs:
   boost-build:
     name: Boost build
     runs-on: ubuntu-latest
-    container: zouzias/boost:1.78.0
     steps:
-      - name: Add deps
-        run: apt-get update && apt-get install make cmake
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2.4.1
+        id: install-boost
+        with:
+            # REQUIRED: Specify the required boost version
+            # A list of supported versions can be found here:
+            # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
+            boost_version: 1.78.0
+      # NOTE: If a boost version matching all requirements cannot be found,
+      # this build step will fail
       - name: Configure
         run: cmake -S . -B build -DCLI11_BOOST=ON
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
   cuda11-build:
     name: CUDA build only
     runs-on: ubuntu-latest
-    container: nvidia/cuda:11.8-devel-ubuntu22.04
+    container: nvidia/cuda:11.8.0-devel-ubuntu22.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -111,7 +111,7 @@ jobs:
   cuda12-build:
     name: CUDA build only
     runs-on: ubuntu-latest
-    container: nvidia/cuda:12.1-devel-ubuntu22.04
+    container: nvidia/cuda:12.1.0-devel-ubuntu22.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -128,7 +128,7 @@ jobs:
   boost-build:
     name: Boost build
     runs-on: ubuntu-latest
-    container: zouzias/boost:1.76.0
+    container: zouzias/boost:1.78.0
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,10 @@ cmake_minimum_required(VERSION 3.4)
 # of CMake. For most of the policies, the new version is better (hence the change).
 # We don't use the 3.4...3.24 syntax because of a bug in an older MSVC's
 # built-in and modified CMake 3.11
-if(${CMAKE_VERSION} VERSION_LESS 3.24)
+if(${CMAKE_VERSION} VERSION_LESS 3.25)
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 else()
-  cmake_policy(VERSION 3.24)
+  cmake_policy(VERSION 3.25)
 endif()
 
 set(VERSION_REGEX "#define CLI11_VERSION[ \t]+\"(.+)\"")


### PR DESCRIPTION
update checkout to v3, update cmake tested version to 3.25, and add some additional CUDA tests

Update the CUDA 10 test, to CUDA 11 and added a CUDA 12 test.
Update the boost test to use the runner directly and install boost on ubuntu.  
upgrade all checkout actions to v3
add CMAKE 3.25 test and allow use in CLI11

