### PR TITLE
prioritize wide strings over strings on MSVC

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -608,6 +608,7 @@ template <typename T> struct classify_object<T, typename std::enable_if<std::is_
     static constexpr object_category value{object_category::floating_point};
 };
 
+#if defined _MSC_VER
 /// String and similar direct assignment
 template <typename T>
 struct classify_object<T,
@@ -646,6 +647,46 @@ struct classify_object<
                             std::is_constructible<T, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_constructible};
 };
+#else
+/// String and similar direct assignment
+template <typename T>
+struct classify_object<T,
+    typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
+    std::is_assignable<T &, std::string>::value>::type> {
+    static constexpr object_category value{object_category::string_assignable};
+};
+
+/// String and similar constructible and copy assignment
+template <typename T>
+struct classify_object<
+    T,
+    typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
+    !std::is_assignable<T &, std::string>::value && (type_count<T>::value == 1) &&
+    std::is_constructible<T, std::string>::value>::type> {
+    static constexpr object_category value{object_category::string_constructible};
+};
+
+/// Wide strings
+template <typename T>
+struct classify_object<T,
+    typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
+    !std::is_assignable<T &, std::string>::value &&
+    !std::is_constructible<T, std::string>::value &&
+    std::is_assignable<T &, std::wstring>::value>::type> {
+    static constexpr object_category value{object_category::wstring_assignable};
+};
+
+template <typename T>
+struct classify_object<
+    T,
+    typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
+    !std::is_assignable<T &, std::wstring>::value && (type_count<T>::value == 1) &&
+    !std::is_assignable<T &, std::string>::value &&
+    !std::is_constructible<T, std::string>::value &&
+    std::is_constructible<T, std::wstring>::value>::type> {
+    static constexpr object_category value{object_category::wstring_constructible};
+};
+#endif
 
 /// Enumerations
 template <typename T> struct classify_object<T, typename std::enable_if<std::is_enum<T>::value>::type> {

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -620,9 +620,10 @@ template <typename T> struct classify_object<T, typename std::enable_if<std::is_
 
 /// String and similar direct assignment
 template <typename T>
-struct classify_object<T,
-                       typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-                                               WIDE_STRING_CHECK && std::is_assignable<T &, std::string>::value>::type> {
+struct classify_object<
+    T,
+    typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value && WIDE_STRING_CHECK &&
+                            std::is_assignable<T &, std::string>::value>::type> {
     static constexpr object_category value{object_category::string_assignable};
 };
 

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -611,18 +611,18 @@ template <typename T> struct classify_object<T, typename std::enable_if<std::is_
 // in MSVC wstring should take precedence if available this isn't as useful on other compilers due to the broader use of
 // utf-8 encoding
 #define WIDE_STRING_CHECK                                                                                              \
-    !std::is_assignable<T &, std::wstring>::value && !std::is_constructible<T, std::wstring>::value &&
-#define STRING_CHECK
+    !std::is_assignable<T &, std::wstring>::value && !std::is_constructible<T, std::wstring>::value
+#define STRING_CHECK true
 #else
-#define WIDE_STRING_CHECK
-#define STRING_CHECK !std::is_assignable<T &, std::string>::value && !std::is_constructible<T, std::string>::value &&
+#define WIDE_STRING_CHECK true
+#define STRING_CHECK !std::is_assignable<T &, std::string>::value && !std::is_constructible<T, std::string>::value
 #endif
 
 /// String and similar direct assignment
 template <typename T>
 struct classify_object<T,
                        typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-                                               WIDE_STRING_CHECK std::is_assignable<T &, std::string>::value>::type> {
+                                               WIDE_STRING_CHECK && std::is_assignable<T &, std::string>::value>::type> {
     static constexpr object_category value{object_category::string_assignable};
 };
 
@@ -632,7 +632,7 @@ struct classify_object<
     T,
     typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
                             !std::is_assignable<T &, std::string>::value && (type_count<T>::value == 1) &&
-                            WIDE_STRING_CHECK std::is_constructible<T, std::string>::value>::type> {
+                            WIDE_STRING_CHECK && std::is_constructible<T, std::string>::value>::type> {
     static constexpr object_category value{object_category::string_constructible};
 };
 
@@ -640,7 +640,7 @@ struct classify_object<
 template <typename T>
 struct classify_object<T,
                        typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-                                               STRING_CHECK std::is_assignable<T &, std::wstring>::value>::type> {
+                                               STRING_CHECK && std::is_assignable<T &, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_assignable};
 };
 
@@ -649,7 +649,7 @@ struct classify_object<
     T,
     typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
                             !std::is_assignable<T &, std::wstring>::value && (type_count<T>::value == 1) &&
-                            STRING_CHECK std::is_constructible<T, std::wstring>::value>::type> {
+                            STRING_CHECK && std::is_constructible<T, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_constructible};
 };
 

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -651,8 +651,8 @@ struct classify_object<
 /// String and similar direct assignment
 template <typename T>
 struct classify_object<T,
-    typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-    std::is_assignable<T &, std::string>::value>::type> {
+                       typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
+                                               std::is_assignable<T &, std::string>::value>::type> {
     static constexpr object_category value{object_category::string_assignable};
 };
 
@@ -661,18 +661,18 @@ template <typename T>
 struct classify_object<
     T,
     typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-    !std::is_assignable<T &, std::string>::value && (type_count<T>::value == 1) &&
-    std::is_constructible<T, std::string>::value>::type> {
+                            !std::is_assignable<T &, std::string>::value && (type_count<T>::value == 1) &&
+                            std::is_constructible<T, std::string>::value>::type> {
     static constexpr object_category value{object_category::string_constructible};
 };
 
 /// Wide strings
 template <typename T>
 struct classify_object<T,
-    typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-    !std::is_assignable<T &, std::string>::value &&
-    !std::is_constructible<T, std::string>::value &&
-    std::is_assignable<T &, std::wstring>::value>::type> {
+                       typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
+                                               !std::is_assignable<T &, std::string>::value &&
+                                               !std::is_constructible<T, std::string>::value &&
+                                               std::is_assignable<T &, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_assignable};
 };
 
@@ -680,10 +680,10 @@ template <typename T>
 struct classify_object<
     T,
     typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-    !std::is_assignable<T &, std::wstring>::value && (type_count<T>::value == 1) &&
-    !std::is_assignable<T &, std::string>::value &&
-    !std::is_constructible<T, std::string>::value &&
-    std::is_constructible<T, std::wstring>::value>::type> {
+                            !std::is_assignable<T &, std::wstring>::value && (type_count<T>::value == 1) &&
+                            !std::is_assignable<T &, std::string>::value &&
+                            !std::is_constructible<T, std::string>::value &&
+                            std::is_constructible<T, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_constructible};
 };
 #endif

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -612,6 +612,8 @@ template <typename T> struct classify_object<T, typename std::enable_if<std::is_
 template <typename T>
 struct classify_object<T,
                        typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
+                                               !std::is_assignable<T &, std::wstring>::value &&
+                                               !std::is_constructible<T, std::wstring>::value &&
                                                std::is_assignable<T &, std::string>::value>::type> {
     static constexpr object_category value{object_category::string_assignable};
 };
@@ -622,6 +624,8 @@ struct classify_object<
     T,
     typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
                             !std::is_assignable<T &, std::string>::value && (type_count<T>::value == 1) &&
+                            !std::is_assignable<T &, std::wstring>::value &&
+                            !std::is_constructible<T, std::wstring>::value &&
                             std::is_constructible<T, std::string>::value>::type> {
     static constexpr object_category value{object_category::string_constructible};
 };
@@ -630,8 +634,6 @@ struct classify_object<
 template <typename T>
 struct classify_object<T,
                        typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-                                               !std::is_assignable<T &, std::string>::value &&
-                                               !std::is_constructible<T, std::string>::value &&
                                                std::is_assignable<T &, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_assignable};
 };
@@ -640,8 +642,6 @@ template <typename T>
 struct classify_object<
     T,
     typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-                            !std::is_assignable<T &, std::string>::value &&
-                            !std::is_constructible<T, std::string>::value &&
                             !std::is_assignable<T &, std::wstring>::value && (type_count<T>::value == 1) &&
                             std::is_constructible<T, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_constructible};

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -608,11 +608,13 @@ template <typename T> struct classify_object<T, typename std::enable_if<std::is_
     static constexpr object_category value{object_category::floating_point};
 };
 #if defined _MSC_VER
-// in MSVC wstring should take precedence if available this isn't as useful on other compilers due to the broader use of utf-8 encoding
-#define WIDE_STRING_CHECK !std::is_assignable<T &, std::wstring>::value && !std::is_constructible<T, std::wstring>::value &&
+// in MSVC wstring should take precedence if available this isn't as useful on other compilers due to the broader use of
+// utf-8 encoding
+#define WIDE_STRING_CHECK                                                                                              \
+    !std::is_assignable<T &, std::wstring>::value && !std::is_constructible<T, std::wstring>::value &&
 #define STRING_CHECK
 #else
-#define WIDE_STRING_CHECK 
+#define WIDE_STRING_CHECK
 #define STRING_CHECK !std::is_assignable<T &, std::string>::value && !std::is_constructible<T, std::string>::value &&
 #endif
 
@@ -620,8 +622,7 @@ template <typename T> struct classify_object<T, typename std::enable_if<std::is_
 template <typename T>
 struct classify_object<T,
                        typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-                                               WIDE_STRING_CHECK
-                                               std::is_assignable<T &, std::string>::value>::type> {
+                                               WIDE_STRING_CHECK std::is_assignable<T &, std::string>::value>::type> {
     static constexpr object_category value{object_category::string_assignable};
 };
 
@@ -631,8 +632,7 @@ struct classify_object<
     T,
     typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
                             !std::is_assignable<T &, std::string>::value && (type_count<T>::value == 1) &&
-                            WIDE_STRING_CHECK
-                            std::is_constructible<T, std::string>::value>::type> {
+                            WIDE_STRING_CHECK std::is_constructible<T, std::string>::value>::type> {
     static constexpr object_category value{object_category::string_constructible};
 };
 
@@ -640,8 +640,7 @@ struct classify_object<
 template <typename T>
 struct classify_object<T,
                        typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-                                               STRING_CHECK
-                                               std::is_assignable<T &, std::wstring>::value>::type> {
+                                               STRING_CHECK std::is_assignable<T &, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_assignable};
 };
 
@@ -650,11 +649,9 @@ struct classify_object<
     T,
     typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
                             !std::is_assignable<T &, std::wstring>::value && (type_count<T>::value == 1) &&
-                            STRING_CHECK
-                            std::is_constructible<T, std::wstring>::value>::type> {
+                            STRING_CHECK std::is_constructible<T, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_constructible};
 };
-
 
 /// Enumerations
 template <typename T> struct classify_object<T, typename std::enable_if<std::is_enum<T>::value>::type> {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1724,7 +1724,7 @@ TEST_CASE_METHOD(TApp, "filesystemWideName", "[app]") {
 
     CHECK_THROWS_AS(app.parse(L"--file voil\u20ac.txt"), CLI::ValidationError);
 
-    bool ok = static_cast<bool>(std::ofstream(L"voil\u20ac.txt").put('a'));  // create file
+    bool ok = static_cast<bool>(std::ofstream(myfile).put('a'));  // create file
     CHECK(ok);
 
     // deactivate the check, so it should run now

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1715,7 +1715,7 @@ TEST_CASE_METHOD(TApp, "FileExists", "[app]") {
     CHECK(!CLI::ExistingFile(myfile).empty());
 }
 
-#if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
+#if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0 && defined(_MSC_VER)
 TEST_CASE_METHOD(TApp, "filesystemWideName", "[app]") {
     std::filesystem::path myfile{L"voil\u20ac.txt"};
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1724,12 +1724,11 @@ TEST_CASE_METHOD(TApp, "filesystemWideName", "[app]") {
 
     CHECK_THROWS_AS(app.parse(L"--file voilà.txt"), CLI::ValidationError);
 
-
     bool ok = static_cast<bool>(std::ofstream("voilà.txt").put('a'));  // create file
     CHECK(ok);
- 
+
     // deactivate the check, so it should run now
-    
+
     CHECK_NOTHROW(app.parse(L"--file voilà.txt"));
 
     CHECK(fpath == myfile);

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1717,19 +1717,19 @@ TEST_CASE_METHOD(TApp, "FileExists", "[app]") {
 
 #if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
 TEST_CASE_METHOD(TApp, "filesystemWideName", "[app]") {
-    std::filesystem::path myfile{"voilà.txt"};
+    std::filesystem::path myfile{L"voil\u20ac.txt"};
 
     std::filesystem::path fpath;
     app.add_option("--file", fpath)->check(CLI::ExistingFile, "existing file");
 
-    CHECK_THROWS_AS(app.parse(L"--file voilà.txt"), CLI::ValidationError);
+    CHECK_THROWS_AS(app.parse(L"--file voil\u20ac.txt"), CLI::ValidationError);
 
-    bool ok = static_cast<bool>(std::ofstream("voilà.txt").put('a'));  // create file
+    bool ok = static_cast<bool>(std::ofstream(L"voil\u20ac.txt").put('a'));  // create file
     CHECK(ok);
 
     // deactivate the check, so it should run now
 
-    CHECK_NOTHROW(app.parse(L"--file voilà.txt"));
+    CHECK_NOTHROW(app.parse(L"--file voil\u20ac.txt"));
 
     CHECK(fpath == myfile);
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -1715,6 +1715,31 @@ TEST_CASE_METHOD(TApp, "FileExists", "[app]") {
     CHECK(!CLI::ExistingFile(myfile).empty());
 }
 
+#if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
+TEST_CASE_METHOD(TApp, "filesystemWideName", "[app]") {
+    std::filesystem::path myfile{"voilà.txt"};
+
+    std::filesystem::path fpath;
+    app.add_option("--file", fpath)->check(CLI::ExistingFile, "existing file");
+
+    CHECK_THROWS_AS(app.parse(L"--file voilà.txt"), CLI::ValidationError);
+
+
+    bool ok = static_cast<bool>(std::ofstream("voilà.txt").put('a'));  // create file
+    CHECK(ok);
+ 
+    // deactivate the check, so it should run now
+    
+    CHECK_NOTHROW(app.parse(L"--file voilà.txt"));
+
+    CHECK(fpath == myfile);
+
+    CHECK(std::filesystem::exists(fpath));
+    std::filesystem::remove(myfile);
+    CHECK(!std::filesystem::exists(fpath));
+}
+#endif
+
 TEST_CASE_METHOD(TApp, "NotFileExists", "[app]") {
     std::string myfile{"TestNonFileNotUsed.txt"};
     CHECK(!CLI::ExistingFile(myfile).empty());

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1040,7 +1040,7 @@ TEST_CASE("Types: TypeNameStrings", "[helpers]") {
     auto wsclass = CLI::detail::classify_object<std::wstring>::value;
     CHECK(CLI::detail::object_category::wstring_assignable == wsclass);
 
-#if defined CLI11_HAS_FILEYSTEM && CLI11_HAS_FILESYSTEM>0
+#if defined CLI11_HAS_FILEYSTEM && CLI11_HAS_FILESYSTEM > 0
     auto fspclass = CLI::detail::classify_object<std::filesystem::path>::value;
     CHECK(CLI::detail::object_category::wstring_assignable == fspclass);
 #endif

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1033,6 +1033,14 @@ TEST_CASE("Types: TypeName", "[helpers]") {
     CHECK((atomic_name == "INT" || atomic_name == "TEXT"));
 }
 
+TEST_CASE("Types: TypeNameStrings", "[helpers]") {
+    auto sclass = CLI::detail::classify_object<std::string>::value;
+    CHECK(CLI::detail::object_category::string_assignable == sclass);
+
+    auto wsclass = CLI::detail::classify_object<std::wstring>::value;
+    CHECK(CLI::detail::object_category::wstring_assignable == wsclass);
+}
+
 TEST_CASE("Types: OverflowSmall", "[helpers]") {
     signed char x = 0;
     auto strmax = std::to_string((std::numeric_limits<signed char>::max)() + 1);

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1039,6 +1039,11 @@ TEST_CASE("Types: TypeNameStrings", "[helpers]") {
 
     auto wsclass = CLI::detail::classify_object<std::wstring>::value;
     CHECK(CLI::detail::object_category::wstring_assignable == wsclass);
+
+#if defined CLI11_HAS_FILEYSTEM && CLI11_HAS_FILESYSTEM>0
+    auto fspclass = CLI::detail::classify_object<std::filesystem::path>::value;
+    CHECK(CLI::detail::object_category::wstring_assignable == fspclass);
+#endif
 }
 
 TEST_CASE("Types: OverflowSmall", "[helpers]") {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1040,7 +1040,7 @@ TEST_CASE("Types: TypeNameStrings", "[helpers]") {
     auto wsclass = CLI::detail::classify_object<std::wstring>::value;
     CHECK(CLI::detail::object_category::wstring_assignable == wsclass);
 
-#if defined CLI11_HAS_FILEYSTEM && CLI11_HAS_FILESYSTEM > 0
+#if defined CLI11_HAS_FILEYSTEM && CLI11_HAS_FILESYSTEM > 0 && defined(_MSC_VER)
     auto fspclass = CLI::detail::classify_object<std::filesystem::path>::value;
     CHECK(CLI::detail::object_category::wstring_assignable == fspclass);
 #endif


### PR DESCRIPTION
to handle `std::filesystem::path` better widestring operations should be preferred over regular strings.  

Fix Issue #875 