### PR TITLE
Fix #875 - Unicode support: automatically widen on windows when option is assigned a std::filesystem::path

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -661,8 +661,8 @@ template <typename T>
 struct classify_object<
     T,
     typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-                            (!std::is_assignable<T &, std::string>::value || force_widen<T>::value) &&
-                            !std::is_constructible<T, std::string>::value &&
+                            (force_widen<T>::value || (!std::is_assignable<T &, std::string>::value &&
+                                                       !std::is_constructible<T, std::string>::value)) &&
                             std::is_assignable<T &, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_assignable};
 };
@@ -671,8 +671,8 @@ template <typename T>
 struct classify_object<
     T,
     typename std::enable_if<!std::is_floating_point<T>::value && !std::is_integral<T>::value &&
-                            (!std::is_assignable<T &, std::string>::value || force_widen<T>::value) &&
-                            !std::is_constructible<T, std::string>::value &&
+                            (force_widen<T>::value || (!std::is_assignable<T &, std::string>::value &&
+                                                       !std::is_constructible<T, std::string>::value)) &&
                             !std::is_assignable<T &, std::wstring>::value && (type_count<T>::value == 1) &&
                             std::is_constructible<T, std::wstring>::value>::type> {
     static constexpr object_category value{object_category::wstring_constructible};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ set(CLI11_MULTIONLY_TESTS TimerTest)
 find_package(Catch2 CONFIG)
 
 if(Catch2_FOUND)
-  if(NOT TARGET Catch2::Catch2)
+  if(NOT (TARGET Catch2::Catch2 OR TARGET Catch2::Catch2WithMain))
     message(FATAL_ERROR "Found Catch2 at ${Catch2_DIR} but targets are missing.")
   endif()
   message(STATUS "Found Catch2 ${Catch2_VERSION}")

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1320,6 +1320,27 @@ TEST_CASE("Types: LexicalConversionPath", "[helpers]") {
     CHECK(res);
     CHECK(CLI::to_path("TéstFileNotUsed.txt").native() == x.native());
 }
+
+static_assert(!CLI::is_path<float>::value, "float shouldn't be a path");
+static_assert(!CLI::is_path<std::string>::value, "string shouldn't be a path");
+
+static_assert(CLI::is_path<std::filesystem::path>::value, "path should be a path");
+static_assert(CLI::is_path<const std::filesystem::path>::value, "const path should be a path");
+static_assert(CLI::is_path<std::filesystem::path &>::value, "path& should be a path");
+static_assert(CLI::is_path<const std::filesystem::path &>::value, "const path& should be a path");
+
+#if _WIN32
+static_assert(CLI::force_widen<std::filesystem::path>::value, "path should be widen on WIN32");
+static_assert(CLI::force_widen<const std::filesystem::path>::value, "const path should be widen on WIN32");
+static_assert(CLI::force_widen<std::filesystem::path &>::value, "path& should be widen on WIN32");
+static_assert(CLI::force_widen<const std::filesystem::path &>::value, "const path& should be widen on WIN32");
+#else
+static_assert(!CLI::force_widen<std::filesystem::path>::value, "path should not be widen on WIN32");
+static_assert(!CLI::force_widen<const std::filesystem::path>::value, "const path should not be widen on WIN32");
+static_assert(!CLI::force_widen<std::filesystem::path &>::value, "path& should not be widen on WIN32");
+static_assert(!CLI::force_widen<const std::filesystem::path &>::value, "const path& should not be widen on WIN32");
+#endif
+
 #endif  // CLI11_HAS_FILESYSTEM
 
 static_assert(CLI::detail::is_wrapper<std::vector<double>>::value, "vector double should be a wrapper");

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1313,14 +1313,6 @@ TEST_CASE("Types: LexicalConversionComplex", "[helpers]") {
 }
 
 #if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
-TEST_CASE("Types: LexicalConversionPath", "[helpers]") {
-    CLI::results_t input = {"TéstFileNotUsed.txt"};
-    std::filesystem::path x;
-    bool res = CLI::detail::lexical_conversion<decltype(x), decltype(x)>(input, x);
-    CHECK(res);
-    CHECK(CLI::to_path("TéstFileNotUsed.txt").native() == x.native());
-}
-
 static_assert(!CLI::is_path<float>::value, "float shouldn't be a path");
 static_assert(!CLI::is_path<std::string>::value, "string shouldn't be a path");
 
@@ -1330,16 +1322,31 @@ static_assert(CLI::is_path<std::filesystem::path &>::value, "path& should be a p
 static_assert(CLI::is_path<const std::filesystem::path &>::value, "const path& should be a path");
 
 #if _WIN32
-static_assert(CLI::force_widen<std::filesystem::path>::value, "path should be widen on WIN32");
-static_assert(CLI::force_widen<const std::filesystem::path>::value, "const path should be widen on WIN32");
-static_assert(CLI::force_widen<std::filesystem::path &>::value, "path& should be widen on WIN32");
-static_assert(CLI::force_widen<const std::filesystem::path &>::value, "const path& should be widen on WIN32");
+static_assert(CLI::detail::classify_object<std::filesystem::path>::value ==
+                  CLI::detail::object_category::wstring_assignable,
+              "path is not classified as wstring_assignable on WIN32");
+static_assert(CLI::force_widen<std::filesystem::path>::value, "path should be force_widen on WIN32");
+static_assert(CLI::force_widen<const std::filesystem::path>::value, "const path should be force_widen on WIN32");
+static_assert(CLI::force_widen<std::filesystem::path &>::value, "path& should be force_widen on WIN32");
+static_assert(CLI::force_widen<const std::filesystem::path &>::value, "const path& should be force_widen on WIN32");
 #else
-static_assert(!CLI::force_widen<std::filesystem::path>::value, "path should not be widen on WIN32");
-static_assert(!CLI::force_widen<const std::filesystem::path>::value, "const path should not be widen on WIN32");
-static_assert(!CLI::force_widen<std::filesystem::path &>::value, "path& should not be widen on WIN32");
-static_assert(!CLI::force_widen<const std::filesystem::path &>::value, "const path& should not be widen on WIN32");
+static_assert(CLI::detail::classify_object<std::filesystem::path>::value ==
+                  CLI::detail::object_category::string_assignable,
+              "path is not classified as string_assignable");
+
+static_assert(!CLI::force_widen<std::filesystem::path>::value, "path should not be force_widen");
+static_assert(!CLI::force_widen<const std::filesystem::path>::value, "const path should not be force_widen");
+static_assert(!CLI::force_widen<std::filesystem::path &>::value, "path& should not be force_widen");
+static_assert(!CLI::force_widen<const std::filesystem::path &>::value, "const path& should not be force_widen");
 #endif
+
+TEST_CASE("Types: LexicalConversionPath", "[helpers]") {
+    CLI::results_t input = {"TéstFileNotUsed.txt"};
+    std::filesystem::path x;
+    bool res = CLI::detail::lexical_conversion<decltype(x), decltype(x)>(input, x);
+    CHECK(res);
+    CHECK(CLI::to_path("TéstFileNotUsed.txt").native() == x.native());
+}
 
 #endif  // CLI11_HAS_FILESYSTEM
 

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -21,6 +21,10 @@
 #include <unordered_map>
 #include <utility>
 
+#if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
+#include <filesystem>
+#endif  // CLI11_HAS_FILESYSTEM
+
 class NotStreamable {};
 
 class Streamable {};
@@ -1307,6 +1311,16 @@ TEST_CASE("Types: LexicalConversionComplex", "[helpers]") {
     CHECK(5.1 == x.real());
     CHECK(3.5 == x.imag());
 }
+
+#if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
+TEST_CASE("Types: LexicalConversionPath", "[helpers]") {
+    CLI::results_t input = {"TéstFileNotUsed.txt"};
+    std::filesystem::path x;
+    bool res = CLI::detail::lexical_conversion<decltype(x), decltype(x)>(input, x);
+    CHECK(res);
+    CHECK(CLI::to_path("TéstFileNotUsed.txt").native() == x.native());
+}
+#endif  // CLI11_HAS_FILESYSTEM
 
 static_assert(CLI::detail::is_wrapper<std::vector<double>>::value, "vector double should be a wrapper");
 static_assert(CLI::detail::is_wrapper<std::vector<std::string>>::value, "vector string should be a wrapper");


### PR DESCRIPTION
- Fix #875

Tested locally on Ubuntu 20.04 and Windows 10.