### PR TITLE
Add environment variable processing to the configuration pointer.

### DIFF
--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -223,6 +223,8 @@ CLI11_INLINE std::size_t escape_detect(std::string &str, std::size_t offset);
 /// Add quotes if the string contains spaces
 CLI11_INLINE std::string &add_quotes_if_needed(std::string &str);
 
+/// get the value of an environmental variable or empty string if empty
+CLI11_INLINE std::string get_environment_value(const std::string &env_name);
 }  // namespace detail
 
 // [CLI11:string_tools_hpp:end]

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -1333,8 +1333,7 @@ template <class AssignTo,
                       detail::enabler> = detail::dummy>
 bool lexical_conversion(const std::vector<std ::string> &strings, AssignTo &output) {
     output.erase(output.begin(), output.end());
-    if (strings.empty())
-    {
+    if(strings.empty()) {
         return true;
     }
     if(strings.size() == 1 && strings[0] == "{}") {

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -1333,6 +1333,10 @@ template <class AssignTo,
                       detail::enabler> = detail::dummy>
 bool lexical_conversion(const std::vector<std ::string> &strings, AssignTo &output) {
     output.erase(output.begin(), output.end());
+    if (strings.empty())
+    {
+        return true;
+    }
     if(strings.size() == 1 && strings[0] == "{}") {
         return true;
     }

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -315,7 +315,7 @@ CLI11_INLINE Option *App::set_config(std::string option_name,
         }
         if(!default_filename.empty()) {
             config_ptr_->default_str(std::move(default_filename));
-            config_ptr_->force_callback_=true;
+            config_ptr_->force_callback_ = true;
         }
         config_ptr_->configurable(false);
         // set the option to take the last value given by default
@@ -1017,16 +1017,14 @@ CLI11_INLINE void App::_process_config_file() {
     if(config_ptr_ != nullptr) {
         bool config_required = config_ptr_->get_required();
         auto file_given = config_ptr_->count() > 0;
-        if (!(file_given || config_ptr_->envname_.empty()))
-        {
-                std::string ename_string = detail::get_environment_value(config_ptr_->envname_);
-                if (!ename_string.empty())
-                {
-                    config_ptr_->add_result(ename_string);
-                }
+        if(!(file_given || config_ptr_->envname_.empty())) {
+            std::string ename_string = detail::get_environment_value(config_ptr_->envname_);
+            if(!ename_string.empty()) {
+                config_ptr_->add_result(ename_string);
+            }
         }
         config_ptr_->run_callback();
-        
+
         auto config_files = config_ptr_->as<std::vector<std::string>>();
         if(config_files.empty() || config_files.front().empty()) {
             if(config_required) {
@@ -1055,7 +1053,7 @@ CLI11_INLINE void App::_process_config_file() {
 CLI11_INLINE void App::_process_env() {
     for(const Option_p &opt : options_) {
         if(opt->count() == 0 && !opt->envname_.empty()) {
-            std::string ename_string=detail::get_environment_value(opt->envname_);
+            std::string ename_string = detail::get_environment_value(opt->envname_);
             if(!ename_string.empty()) {
                 opt->add_result(ename_string);
             }

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -255,21 +255,21 @@ CLI11_INLINE std::string &add_quotes_if_needed(std::string &str) {
     return str;
 }
 
-std::string get_environment_value(const std::string& env_name) {
-    char* buffer = nullptr;
+std::string get_environment_value(const std::string &env_name) {
+    char *buffer = nullptr;
     std::string ename_string;
 
 #ifdef _MSC_VER
     // Windows version
     std::size_t sz = 0;
-    if (_dupenv_s(&buffer, &sz, env_name.c_str()) == 0 && buffer != nullptr) {
+    if(_dupenv_s(&buffer, &sz, env_name.c_str()) == 0 && buffer != nullptr) {
         ename_string = std::string(buffer);
         free(buffer);
     }
 #else
     // This also works on Windows, but gives a warning
     buffer = std::getenv(env_name.c_str());
-    if (buffer != nullptr) {
+    if(buffer != nullptr) {
         ename_string = std::string(buffer);
     }
 #endif

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -255,22 +255,23 @@ CLI11_INLINE std::string &add_quotes_if_needed(std::string &str) {
     return str;
 }
 
-std::string get_environment_value(const std::string &env_name) {
-    char *buffer = nullptr;
+std::string get_environment_value(const std::string& env_name) {
+    char* buffer = nullptr;
     std::string ename_string;
 
 #ifdef _MSC_VER
     // Windows version
     std::size_t sz = 0;
-    if(_dupenv_s(&buffer, &sz, env_name.c_str()) == 0 && buffer != nullptr) {
+    if (_dupenv_s(&buffer, &sz, env_name.c_str()) == 0 && buffer != nullptr) {
         ename_string = std::string(buffer);
         free(buffer);
     }
 #else
     // This also works on Windows, but gives a warning
-    buffer = std::getenv(opt->envname_.c_str());
-    if(buffer != nullptr)
+    buffer = std::getenv(env_name.c_str());
+    if (buffer != nullptr) {
         ename_string = std::string(buffer);
+    }
 #endif
     return ename_string;
 }

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -255,6 +255,28 @@ CLI11_INLINE std::string &add_quotes_if_needed(std::string &str) {
     return str;
 }
 
+
+std::string get_environment_value(const std::string& env_name)
+{
+    char *buffer = nullptr;
+    std::string ename_string;
+
+#ifdef _MSC_VER
+    // Windows version
+    std::size_t sz = 0;
+    if(_dupenv_s(&buffer, &sz, env_name.c_str()) == 0 && buffer != nullptr) {
+        ename_string = std::string(buffer);
+        free(buffer);
+    }
+#else
+    // This also works on Windows, but gives a warning
+    buffer = std::getenv(opt->envname_.c_str());
+    if(buffer != nullptr)
+        ename_string = std::string(buffer);
+#endif
+    return ename_string;
+}
+
 }  // namespace detail
 // [CLI11:string_tools_inl_hpp:end]
 }  // namespace CLI

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -255,9 +255,7 @@ CLI11_INLINE std::string &add_quotes_if_needed(std::string &str) {
     return str;
 }
 
-
-std::string get_environment_value(const std::string& env_name)
-{
+std::string get_environment_value(const std::string &env_name) {
     char *buffer = nullptr;
     std::string ename_string;
 

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -677,7 +677,6 @@ TEST_CASE_METHOD(TApp, "IniEnvironmentalFileName", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    
     app.set_config("--config", "")->envname("CONFIG")->required();
 
     {
@@ -692,7 +691,7 @@ TEST_CASE_METHOD(TApp, "IniEnvironmentalFileName", "[config]") {
     app.add_option("--two", two);
     app.add_option("--three", three);
 
-    put_env("CONFIG",tmpini);
+    put_env("CONFIG", tmpini);
 
     CHECK_NOTHROW(run());
 
@@ -701,7 +700,7 @@ TEST_CASE_METHOD(TApp, "IniEnvironmentalFileName", "[config]") {
 
     unset_env("CONFIG");
 
-    CHECK_THROWS_AS(run(),CLI::FileError);
+    CHECK_THROWS_AS(run(), CLI::FileError);
 }
 
 TEST_CASE_METHOD(TApp, "MultiConfig", "[config]") {

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -673,6 +673,37 @@ TEST_CASE_METHOD(TApp, "IniNotRequiredNotDefault", "[config]") {
     CHECK(tmpini2.c_str() == app.get_config_ptr()->as<std::string>());
 }
 
+TEST_CASE_METHOD(TApp, "IniEnvironmentalFileName", "[config]") {
+
+    TempFile tmpini{"TestIniTmp.ini"};
+
+    
+    app.set_config("--config", "")->envname("CONFIG")->required();
+
+    {
+        std::ofstream out{tmpini};
+        out << "[default]" << std::endl;
+        out << "two=99" << std::endl;
+        out << "three=3" << std::endl;
+    }
+
+    int one{0}, two{0}, three{0};
+    app.add_option("--one", one);
+    app.add_option("--two", two);
+    app.add_option("--three", three);
+
+    put_env("CONFIG",tmpini);
+
+    CHECK_NOTHROW(run());
+
+    CHECK(two == 99);
+    CHECK(three == 3);
+
+    unset_env("CONFIG");
+
+    CHECK_THROWS_AS(run(),CLI::FileError);
+}
+
 TEST_CASE_METHOD(TApp, "MultiConfig", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -4,7 +4,6 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "CLI/StringTools.hpp"
 #include "app_helper.hpp"
 
 #include <cmath>

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "app_helper.hpp"
 #include "CLI/StringTools.hpp"
+#include "app_helper.hpp"
 
 #include <cmath>
 
@@ -1356,14 +1356,13 @@ TEST_CASE("FixNewLines: EdgesCheck", "[helpers]") {
     CHECK(output == result);
 }
 
-
 TEST_CASE("String: environment", "[helpers]") {
-    put_env("TEST1","TESTS");
-    
-    auto value=CLI::detail::get_environment_value("TEST1");
-    CHECK(value=="TESTS");
+    put_env("TEST1", "TESTS");
+
+    auto value = CLI::detail::get_environment_value("TEST1");
+    CHECK(value == "TESTS");
     unset_env("TEST1");
 
-    value=CLI::detail::get_environment_value("TEST2");
+    value = CLI::detail::get_environment_value("TEST2");
     CHECK(value.empty());
 }

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "app_helper.hpp"
+#include "CLI/StringTools.hpp"
 
 #include <cmath>
 
@@ -1353,4 +1354,16 @@ TEST_CASE("FixNewLines: EdgesCheck", "[helpers]") {
     std::string output = "\n; one\n; two\n; ";
     std::string result = CLI::detail::fix_newlines("; ", input);
     CHECK(output == result);
+}
+
+
+TEST_CASE("String: environment", "[helpers]") {
+    put_env("TEST1","TESTS");
+    
+    auto value=CLI::detail::get_environment_value("TEST1");
+    CHECK(value=="TESTS");
+    unset_env("TEST1");
+
+    value=CLI::detail::get_environment_value("TEST2");
+    CHECK(value.empty());
 }


### PR DESCRIPTION
Fixes #890 

Add parsing of environmental variables when supplied for the config file option. 