### PR TITLE
Fix possible UB in the sum_string_vector function (TypeTools.hpp)

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -1652,13 +1652,10 @@ inline std::string sum_string_vector(const std::vector<std::string> &values) {
             output.append(arg);
         }
     } else {
-        if(val > static_cast<double>((std::numeric_limits<std::int64_t>::min)()) &&
-           val < static_cast<double>((std::numeric_limits<std::int64_t>::max)()) &&
-           std::ceil(val) - std::floor(val) <= std::numeric_limits<double>::epsilon()) {
-            output = detail::value_string(static_cast<int64_t>(val));
-        } else {
-            output = detail::value_string(val);
-        }
+        std::ostringstream out;
+        out.precision(16);
+        out << val;
+        output = out.str();
     }
     return output;
 }

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -1649,8 +1649,8 @@ inline std::string sum_string_vector(const std::vector<std::string> &values) {
             output.append(arg);
         }
     } else {
-        if(val > static_cast<double>(std::numeric_limits<std::int64_t>::min()) &&
-           val < static_cast<double>(std::numeric_limits<std::int64_t>::max()) &&
+        if(val > static_cast<double>((std::numeric_limits<std::int64_t>::min)()) &&
+           val < static_cast<double>((std::numeric_limits<std::int64_t>::max)()) &&
            std::ceil(val) - std::floor(val) <= std::numeric_limits<double>::epsilon()) {
             output = detail::value_string(static_cast<int64_t>(val));
         } else {

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -1649,9 +1649,9 @@ inline std::string sum_string_vector(const std::vector<std::string> &values) {
             output.append(arg);
         }
     } else {
-        if(val <= static_cast<double>((std::numeric_limits<std::int64_t>::min)()) ||
-           val >= static_cast<double>((std::numeric_limits<std::int64_t>::max)()) ||
-           std::ceil(val) == std::floor(val)) {
+        if(val > static_cast<double>(std::numeric_limits<std::int64_t>::min()) &&
+           val < static_cast<double>(std::numeric_limits<std::int64_t>::max()) &&
+           std::ceil(val) - std::floor(val) <= std::numeric_limits<double>::epsilon()) {
             output = detail::value_string(static_cast<int64_t>(val));
         } else {
             output = detail::value_string(val);

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -11,6 +11,7 @@
 #include <complex>
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 
 TEST_CASE_METHOD(TApp, "OneFlagShort", "[app]") {
     app.add_flag("-c,--count");
@@ -828,7 +829,7 @@ TEST_CASE_METHOD(TApp, "SumOptFloat", "[app]") {
 
     run();
 
-    CHECK(0.6 == val);
+    CHECK(std::fabs(0.6 - val) <= std::numeric_limits<double>::epsilon());
 }
 
 TEST_CASE_METHOD(TApp, "SumOptString", "[app]") {


### PR DESCRIPTION
Fixes #892 
(+ uses safe comparison for double values via epsilon)

https://cpp.godbolt.org/z/Yfje6encG