### PR TITLE
environment variables and subcommands

### DIFF
--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1061,8 +1061,8 @@ CLI11_INLINE void App::_process_env() {
     }
 
     for(App_p &sub : subcommands_) {
-        if (sub->get_name().empty() || !sub->parse_complete_callback_) {
-            if (sub->count_all() > 0) {
+        if(sub->get_name().empty() || !sub->parse_complete_callback_) {
+            if(sub->count_all() > 0) {
                 // only process environment variables if the callback has actually been triggered already
                 sub->_process_env();
             }

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1061,8 +1061,12 @@ CLI11_INLINE void App::_process_env() {
     }
 
     for(App_p &sub : subcommands_) {
-        if(sub->get_name().empty() || !sub->parse_complete_callback_)
-            sub->_process_env();
+        if (sub->get_name().empty() || !sub->parse_complete_callback_) {
+            if (sub->count_all() > 0) {
+                // only process environment variables if the callback has actually been triggered already
+                sub->_process_env();
+            }
+        }
     }
 }
 

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -2119,25 +2119,25 @@ TEST_CASE_METHOD(TApp, "DotNotationSubcommandRecusive2", "[subcom]") {
     CHECK(extras.front() == "sub1.sub2.sub3.bob");
 }
 
-// Reported bug #903 on github 
+// Reported bug #903 on github
 TEST_CASE_METHOD(TApp, "subcommandEnvironmentName", "[subcom]") {
     auto *sub1 = app.add_subcommand("sub1");
     std::string someFile;
     int sub1value{0};
     sub1->add_option("-f,--file", someFile)->envname("SOME_FILE")->required()->check(CLI::ExistingFile);
-    sub1->add_option("-v",sub1value);
-    auto sub2 = app.add_subcommand("sub2");
+    sub1->add_option("-v", sub1value);
+    auto *sub2 = app.add_subcommand("sub2");
     int completelyUnrelatedToSub1 = 0;
     sub2->add_option("-v,--value", completelyUnrelatedToSub1)->required();
 
-    args={"sub2","-v", "111"};
+    args = {"sub2", "-v", "111"};
     CHECK_NOTHROW(run());
 
     put_env("SOME_FILE", "notafile.txt");
 
     CHECK_NOTHROW(run());
-    
-    args={"sub1","-v", "111"};
+
+    args = {"sub1", "-v", "111"};
     CHECK_THROWS_AS(run(), CLI::ValidationError);
     unset_env("SOME_FILE");
 }


### PR DESCRIPTION
Do not check environment variables if a subcommand has not been triggered.

Fixes #903