### PR TITLE
ci: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
       interval: "weekly"
     target-branch: "main"
     open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/348.
