### PR TITLE
Fix: Error in documentation for FetchContent

### DIFF
--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -97,19 +97,17 @@ An example CMake file would include:
 
 ```cmake
 include(FetchContent)
-FetchContent_Populate(
+FetchContent_Declare(
     cli11_proj
     QUIET
     GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
     GIT_TAG v2.3.2
-    SOURCE_DIR     cli11_proj
 )
 
-FetchContent_MakeAvailable(cli11)
+FetchContent_MakeAvailable(cli11_proj)
 
 # And now you can use it
-add_subdirectory(${cli11_proj_SOURCE_DIR} ${cli11_proj_SOURCE_DIR}/build)
-target_link_libraries(<your project> CLI11::CLI11)
+target_link_libraries(<your project> PRIVATE CLI11::CLI11)
 ```
 
 And use


### PR DESCRIPTION
The current installation documentation for FetchContent with CMake, result in the following error Error: 

```
CMake Error at /opt/homebrew/Cellar/cmake/3.28.1/share/cmake/Modules/FetchContent.cmake:1221 (message):
  No content details recorded for cli11
Call Stack (most recent call first):
  /opt/homebrew/Cellar/cmake/3.28.1/share/cmake/Modules/FetchContent.cmake:1740 (__FetchContent_getSavedDetails)
  /opt/homebrew/Cellar/cmake/3.28.1/share/cmake/Modules/FetchContent.cmake:2033 (FetchContent_Populate)
  CMakeLists.txt:17 (FetchContent_MakeAvailable)
```

The important part: `  No content details recorded for cli11`.

I have changed the documentation such that the part which covers FetchContent works out of the box. 