### PR TITLE
tests: fix catch2 3 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CTEST_OUTPUT_ON_FAILURE: "1"
+
 jobs:
   coverage:
     name: Coverage
@@ -65,7 +68,7 @@ jobs:
 
       - name: Get Catch 2
         run: brew install catch2
-      
+
       - name: Configure
         run: |
           cmake -S . -B build \
@@ -162,7 +165,7 @@ jobs:
 
       - name: Build
         run: meson compile -C build-meson
-        
+
   install:
     name: install tests
     runs-on: ubuntu-latest
@@ -179,7 +182,7 @@ jobs:
       - name: Run tests
         run: ctest --output-on-failure -L Packaging
         working-directory: build
-        
+
   install-precompiled:
     name: install tests precompiled
     runs-on: ubuntu-latest
@@ -196,7 +199,7 @@ jobs:
       - name: Run tests
         run: ctest --output-on-failure -L Packaging
         working-directory: build
-        
+
   install-single_file:
     name: install tests single file
     runs-on: ubuntu-latest
@@ -365,7 +368,7 @@ jobs:
         with:
           cmake-version: "3.27"
         if: success() || failure()
-        
+
       - name: Check CMake 3.28 (full)
         uses: ./.github/actions/quick_cmake
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,30 @@ jobs:
           files: build/coverage.info
           functionalities: fixes
 
+  catch2-3:
+    name: Catch 2 3.x
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get Catch 2
+        run: brew install catch2
+      
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_CXX_STANDARD=14 \
+            -DCLI11_SINGLE_FILE_TESTS=OFF \
+            -DCLI11_BUILD_EXAMPLES=OFF \
+            -DCLI11_PRECOMPILED=ON
+
+      - name: Build
+        run: cmake --build build -j4
+
+      - name: Test
+        run: cmake --build build --target test
+
+
   clang-tidy:
     name: Clang-Tidy
     runs-on: ubuntu-latest

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -6,6 +6,8 @@
 
 #include "app_helper.hpp"
 
+#include "catch.hpp"
+
 #include <algorithm>
 #include <atomic>
 #include <cmath>
@@ -243,7 +245,6 @@ static const std::map<std::string, double> testValuesDouble{
 };
 
 TEST_CASE_METHOD(TApp, "floatingConversions", "[optiontype]") {
-
     auto test_data = GENERATE(from_range(testValuesDouble));
 
     double val{0};
@@ -256,7 +257,7 @@ TEST_CASE_METHOD(TApp, "floatingConversions", "[optiontype]") {
         CHECK(std::isnan(val));
     } else {
 
-        CHECK_THAT(val, Catch::WithinRel(test_data.second, 1e-11));
+        CHECK_THAT(val, WithinRel(test_data.second, 1e-11));
     }
 }
 

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -53,6 +53,10 @@
 #endif
 // [CLI11:verbatim]
 
+TEST_CASE("OptionalNoEmpty") {
+    CHECK(1 == 1);
+}
+
 #if CLI11_STD_OPTIONAL
 
 #ifdef _MSC_VER

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -53,9 +53,7 @@
 #endif
 // [CLI11:verbatim]
 
-TEST_CASE("OptionalNoEmpty") {
-    CHECK(1 == 1);
-}
+TEST_CASE("OptionalNoEmpty") { CHECK(1 == 1); }
 
 #if CLI11_STD_OPTIONAL
 

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -15,13 +15,13 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/generators/catch_generators_range.hpp>
-#include <catch2/matchers/catch_matchers_string.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
-using Catch::Approx;                 // NOLINT(google-global-names-in-headers)
-using Catch::Matchers::Equals;       // NOLINT(google-global-names-in-headers)
-using Catch::Matchers::WithinRel;    // NOLINT(google-global-names-in-headers)
-using Catch::Generators::from_range; // NOLINT(google-global-names-in-headers)
+using Catch::Approx;                  // NOLINT(google-global-names-in-headers)
+using Catch::Generators::from_range;  // NOLINT(google-global-names-in-headers)
+using Catch::Matchers::Equals;        // NOLINT(google-global-names-in-headers)
+using Catch::Matchers::WithinRel;     // NOLINT(google-global-names-in-headers)
 
 inline auto Contains(const std::string &x) { return Catch::Matchers::ContainsSubstring(x); }
 
@@ -29,8 +29,8 @@ inline auto Contains(const std::string &x) { return Catch::Matchers::ContainsSub
 
 #include <catch2/catch.hpp>
 
-using Catch::Equals;                 // NOLINT(google-global-names-in-headers)
-using Catch::Matchers::Contains;     // NOLINT(google-global-names-in-headers)
-using Catch::WithinRel;              // NOLINT(google-global-names-in-headers)
+using Catch::Equals;              // NOLINT(google-global-names-in-headers)
+using Catch::WithinRel;           // NOLINT(google-global-names-in-headers)
+using Catch::Matchers::Contains;  // NOLINT(google-global-names-in-headers)
 
 #endif

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -14,10 +14,14 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-using Catch::Approx;            // NOLINT(google-global-names-in-headers)
-using Catch::Matchers::Equals;  // NOLINT(google-global-names-in-headers)
+using Catch::Approx;                 // NOLINT(google-global-names-in-headers)
+using Catch::Matchers::Equals;       // NOLINT(google-global-names-in-headers)
+using Catch::Matchers::WithinRel;    // NOLINT(google-global-names-in-headers)
+using Catch::Generators::from_range; // NOLINT(google-global-names-in-headers)
 
 inline auto Contains(const std::string &x) { return Catch::Matchers::ContainsSubstring(x); }
 
@@ -25,7 +29,8 @@ inline auto Contains(const std::string &x) { return Catch::Matchers::ContainsSub
 
 #include <catch2/catch.hpp>
 
-using Catch::Equals;              // NOLINT(google-global-names-in-headers)
-using Catch::Matchers::Contains;  // NOLINT(google-global-names-in-headers)
+using Catch::Equals;                 // NOLINT(google-global-names-in-headers)
+using Catch::Matchers::Contains;     // NOLINT(google-global-names-in-headers)
+using Catch::WithinRel;              // NOLINT(google-global-names-in-headers)
 
 #endif


### PR DESCRIPTION
Is there an easy way to pre-install this in CI or download it (perhaps in meson)? It's bad that we aren't running in CI with version 3 (but don't want to drop 2, since we can't drop it until we drop C++11).
