### PR TITLE
fix: transiative include issue

### DIFF
--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -10,6 +10,7 @@
 #include <CLI/StringTools.hpp>
 
 // [CLI11:public_includes:set]
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Fix #993. I tried include-what-you-use, but it reports too much stuff to be able to pick out what's missing very effectively.
