### PR TITLE
tests: add atomic flag if needed

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,6 +188,18 @@ if(CMAKE_CXX_STANDARD GREATER 16)
     target_compile_definitions(FuzzFailTest_Single PUBLIC -DTEST_FILE_FOLDER="${TEST_FILE_FOLDER}")
     target_sources(FuzzFailTest_Single PUBLIC ${PROJECT_SOURCE_DIR}/fuzz/fuzzApp.cpp)
   endif()
+
+  # Some platforms need to link to atomic
+  file(WRITE "${CMAKE_BINARY_DIR}/test_atomic.cpp"
+       "#include <atomic>\n" "int main() { std::atomic<int64_t> i(0); i++; return 0; }\n")
+  try_compile(ATOMIC_BUILD_SUCCEEDED "${CMAKE_BINARY_DIR}" "${CMAKE_BINARY_DIR}/test_atomic.cpp")
+  if(NOT ATOMIC_BUILD_SUCCEEDED)
+    target_link_libraries(FuzzFailTest PRIVATE atomic)
+    if(CLI11_SINGLE_FILE AND CLI11_SINGLE_FILE_TESTS)
+      target_link_libraries(FuzzFailTestSingle PRIVATE atomic)
+    endif()
+  endif()
+  file(REMOVE ${CMAKE_BINARY_DIR}/test_atomic.cpp)
 endif()
 
 # Add -Wno-deprecated-declarations to DeprecatedTest


### PR DESCRIPTION
Fix https://github.com/CLIUtils/CLI11/issues/999.

This looks like about what we have to do. This test seems to be missing from Meson, so don't have a workaround there yet.
