### PR TITLE
Config count anomaly

### DIFF
--- a/examples/testEXE.cpp
+++ b/examples/testEXE.cpp
@@ -9,20 +9,26 @@
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>
+#include <filesystem>
 
-int main(int argc, const char *argv[]) {
+int main(int argc, char *argv[])
+{
+    CLI::App app{"MyApp"};
+    std::filesystem::path binpath1 = "../example/myfile.bin";
+        std::filesystem::path binpath2 = "../example/myfile.bin";
+        std::filesystem::path binpath3 = "../example/myfile.bin";
 
-    int value{0};
-    CLI::App app{"Test App"};
-    app.add_option("-v", value, "value");
+        app.add_option("-f,--file1", binpath1, "Path to a .bin file"); // this works but the path "../example/myfile.bin" won't show up in --help. I need it to show somewhere that this is a required argument but it's populated with a default value - running the app.exe without the arg will work and use the default value, but the user can overwrite it.
 
-    auto *subcom = app.add_subcommand("sub", "")->prefix_command();
-    CLI11_PARSE(app, argc, argv);
+    app.add_option("-g,--file2", binpath2, "Path to a .bin file")->capture_default_str(); // this doesn't seem to change anything, and I don't understand the documentation, it's not clear to me what it says.
 
-    std::cout << "value =" << value << '\n';
-    std::cout << "after Args:";
-    for(const auto &aarg : subcom->remaining()) {
-        std::cout << aarg << " ";
+    app.add_option("-i,--file3", binpath3, "Path to a .bin file")->default_str("defFile.bin")->check(CLI::ExistingFile); // this doesn't seem to change anything either, and I also don't understand the documentation, it's not clear to me what it should do or change.
+
+    try
+    {
+        app.parse(argc, argv);
+    } catch (const CLI::ParseError& e)
+    {
+        return app.exit(e);
     }
-    std::cout << '\n';
 }

--- a/examples/testEXE.cpp
+++ b/examples/testEXE.cpp
@@ -7,35 +7,22 @@
 // Code modified from https://github.com/CLIUtils/CLI11/issues/559
 
 #include <CLI/CLI.hpp>
-#include <filesystem>
 #include <iostream>
 #include <string>
 
-int main(int argc, char *argv[]) {
-    CLI::App app{"MyApp"};
-    std::filesystem::path binpath1 = "../example/myfile.bin";
-    std::filesystem::path binpath2 = "../example/myfile.bin";
-    std::filesystem::path binpath3 = "../example/myfile.bin";
+int main(int argc, const char *argv[]) {
 
-    app.add_option("-f,--file1",
-                   binpath1,
-                   "Path to a .bin file");  // this works but the path "../example/myfile.bin" won't show up in --help.
-                                            // I need it to show somewhere that this is a required argument but it's
-                                            // populated with a default value - running the app.exe without the arg will
-                                            // work and use the default value, but the user can overwrite it.
+    int value{0};
+    CLI::App app{"Test App"};
+    app.add_option("-v", value, "value");
 
-    app.add_option("-g,--file2", binpath2, "Path to a .bin file")
-        ->capture_default_str();  // this doesn't seem to change anything, and I don't understand the documentation,
-                                  // it's not clear to me what it says.
+    auto *subcom = app.add_subcommand("sub", "")->prefix_command();
+    CLI11_PARSE(app, argc, argv);
 
-    app.add_option("-i,--file3", binpath3, "Path to a .bin file")
-        ->default_str("defFile.bin")
-        ->check(CLI::ExistingFile);  // this doesn't seem to change anything either, and I also don't understand the
-                                     // documentation, it's not clear to me what it should do or change.
-
-    try {
-        app.parse(argc, argv);
-    } catch(const CLI::ParseError &e) {
-        return app.exit(e);
+    std::cout << "value =" << value << '\n';
+    std::cout << "after Args:";
+    for(const auto &aarg : subcom->remaining()) {
+        std::cout << aarg << " ";
     }
+    std::cout << '\n';
 }

--- a/examples/testEXE.cpp
+++ b/examples/testEXE.cpp
@@ -7,28 +7,35 @@
 // Code modified from https://github.com/CLIUtils/CLI11/issues/559
 
 #include <CLI/CLI.hpp>
+#include <filesystem>
 #include <iostream>
 #include <string>
-#include <filesystem>
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     CLI::App app{"MyApp"};
     std::filesystem::path binpath1 = "../example/myfile.bin";
-        std::filesystem::path binpath2 = "../example/myfile.bin";
-        std::filesystem::path binpath3 = "../example/myfile.bin";
+    std::filesystem::path binpath2 = "../example/myfile.bin";
+    std::filesystem::path binpath3 = "../example/myfile.bin";
 
-        app.add_option("-f,--file1", binpath1, "Path to a .bin file"); // this works but the path "../example/myfile.bin" won't show up in --help. I need it to show somewhere that this is a required argument but it's populated with a default value - running the app.exe without the arg will work and use the default value, but the user can overwrite it.
+    app.add_option("-f,--file1",
+                   binpath1,
+                   "Path to a .bin file");  // this works but the path "../example/myfile.bin" won't show up in --help.
+                                            // I need it to show somewhere that this is a required argument but it's
+                                            // populated with a default value - running the app.exe without the arg will
+                                            // work and use the default value, but the user can overwrite it.
 
-    app.add_option("-g,--file2", binpath2, "Path to a .bin file")->capture_default_str(); // this doesn't seem to change anything, and I don't understand the documentation, it's not clear to me what it says.
+    app.add_option("-g,--file2", binpath2, "Path to a .bin file")
+        ->capture_default_str();  // this doesn't seem to change anything, and I don't understand the documentation,
+                                  // it's not clear to me what it says.
 
-    app.add_option("-i,--file3", binpath3, "Path to a .bin file")->default_str("defFile.bin")->check(CLI::ExistingFile); // this doesn't seem to change anything either, and I also don't understand the documentation, it's not clear to me what it should do or change.
+    app.add_option("-i,--file3", binpath3, "Path to a .bin file")
+        ->default_str("defFile.bin")
+        ->check(CLI::ExistingFile);  // this doesn't seem to change anything either, and I also don't understand the
+                                     // documentation, it's not clear to me what it should do or change.
 
-    try
-    {
+    try {
         app.parse(argc, argv);
-    } catch (const CLI::ParseError& e)
-    {
+    } catch(const CLI::ParseError &e) {
         return app.exit(e);
     }
 }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1231,7 +1231,7 @@ class App {
     void _process_config_file();
 
     /// Read and process a particular configuration file
-    void _process_config_file(const std::string &config_file, bool throw_error);
+    bool _process_config_file(const std::string &config_file, bool throw_error);
 
     /// Get envname options if not yet passed. Runs on *all* subcommands.
     void _process_env();

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1065,18 +1065,25 @@ CLI11_NODISCARD CLI11_INLINE detail::Classifier App::_recognize(const std::strin
     return detail::Classifier::NONE;
 }
 
-CLI11_INLINE void App::_process_config_file(const std::string &config_file, bool throw_error) {
+CLI11_INLINE bool App::_process_config_file(const std::string &config_file, bool throw_error) {
     auto path_result = detail::check_path(config_file.c_str());
     if(path_result == detail::path_type::file) {
         try {
             std::vector<ConfigItem> values = config_formatter_->from_file(config_file);
             _parse_config(values);
+            return true;
         } catch(const FileError &) {
-            if(throw_error)
+            if (throw_error) {
                 throw;
+            }
+            return false;
         }
     } else if(throw_error) {
         throw FileError::Missing(config_file);
+    }
+    else
+    {
+        return false;
     }
 }
 
@@ -1093,6 +1100,7 @@ CLI11_INLINE void App::_process_config_file() {
         config_ptr_->run_callback();
 
         auto config_files = config_ptr_->as<std::vector<std::string>>();
+        std::vector<std::string> used_files;
         if(config_files.empty() || config_files.front().empty()) {
             if(config_required) {
                 throw FileError("config file is required but none was given");
@@ -1100,7 +1108,14 @@ CLI11_INLINE void App::_process_config_file() {
             return;
         }
         for(const auto &config_file : config_files) {
-            _process_config_file(config_file, config_required || file_given);
+            if (_process_config_file(config_file, config_required || file_given))
+            {
+                used_files.push_back(config_file);
+            }
+        }
+        if (!file_given && used_files.empty())
+        {
+            config_ptr_->clear();
         }
     }
 }

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1073,16 +1073,14 @@ CLI11_INLINE bool App::_process_config_file(const std::string &config_file, bool
             _parse_config(values);
             return true;
         } catch(const FileError &) {
-            if (throw_error) {
+            if(throw_error) {
                 throw;
             }
             return false;
         }
     } else if(throw_error) {
         throw FileError::Missing(config_file);
-    }
-    else
-    {
+    } else {
         return false;
     }
 }
@@ -1108,19 +1106,17 @@ CLI11_INLINE void App::_process_config_file() {
             return;
         }
         for(const auto &config_file : config_files) {
-            if (_process_config_file(config_file, config_required || file_given))
-            {
-                files_used=true;
+            if(_process_config_file(config_file, config_required || file_given)) {
+                files_used = true;
             }
         }
-        if (!files_used)
-        {
-            //this is done so the count shows as 0 if no callbacks were processed
+        if(!files_used) {
+            // this is done so the count shows as 0 if no callbacks were processed
             config_ptr_->clear();
-            bool force=config_ptr_->force_callback_;
-            config_ptr_->force_callback_=false;
+            bool force = config_ptr_->force_callback_;
+            config_ptr_->force_callback_ = false;
             config_ptr_->run_callback();
-            config_ptr_->force_callback_=force;
+            config_ptr_->force_callback_ = force;
         }
     }
 }

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1100,7 +1100,7 @@ CLI11_INLINE void App::_process_config_file() {
         config_ptr_->run_callback();
 
         auto config_files = config_ptr_->as<std::vector<std::string>>();
-        std::vector<std::string> used_files;
+        bool files_used{file_given};
         if(config_files.empty() || config_files.front().empty()) {
             if(config_required) {
                 throw FileError("config file is required but none was given");
@@ -1110,12 +1110,17 @@ CLI11_INLINE void App::_process_config_file() {
         for(const auto &config_file : config_files) {
             if (_process_config_file(config_file, config_required || file_given))
             {
-                used_files.push_back(config_file);
+                files_used=true;
             }
         }
-        if (!file_given && used_files.empty())
+        if (!files_used)
         {
+            //this is done so the count shows as 0 if no callbacks were processed
             config_ptr_->clear();
+            bool force=config_ptr_->force_callback_;
+            config_ptr_->force_callback_=false;
+            config_ptr_->run_callback();
+            config_ptr_->force_callback_=force;
         }
     }
 }

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1049,6 +1049,16 @@ TEST_CASE_METHOD(TApp, "IniRequiredNotFound", "[config]") {
     CHECK_THROWS_AS(run(), CLI::FileError);
 }
 
+TEST_CASE_METHOD(TApp, "IniDefaultNotExist", "[config]") {
+
+    std::string noini = "TestIniNotExist.ini";
+    auto *cfg=app.set_config("--config", noini);
+
+    CHECK_NOTHROW(run());
+
+    CHECK(cfg->count()==0);
+}
+
 TEST_CASE_METHOD(TApp, "IniNotRequiredPassedNotFound", "[config]") {
 
     std::string noini = "TestIniNotExist.ini";
@@ -1084,7 +1094,7 @@ TEST_CASE_METHOD(TApp, "IniRequired", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    app.set_config("--config", tmpini, "", true);
+    auto *cfg=app.set_config("--config", tmpini, "", true);
 
     {
         std::ofstream out{tmpini};
@@ -1109,6 +1119,7 @@ TEST_CASE_METHOD(TApp, "IniRequired", "[config]") {
     args = {"--one=1", "--two=2"};
 
     CHECK_NOTHROW(run());
+    CHECK(cfg->count()==1);
     CHECK(1 == one);
     CHECK(2 == two);
     CHECK(3 == three);

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1052,11 +1052,11 @@ TEST_CASE_METHOD(TApp, "IniRequiredNotFound", "[config]") {
 TEST_CASE_METHOD(TApp, "IniDefaultNotExist", "[config]") {
 
     std::string noini = "TestIniNotExist.ini";
-    auto *cfg=app.set_config("--config", noini);
+    auto *cfg = app.set_config("--config", noini);
 
     CHECK_NOTHROW(run());
 
-    CHECK(cfg->count()==0);
+    CHECK(cfg->count() == 0);
 }
 
 TEST_CASE_METHOD(TApp, "IniNotRequiredPassedNotFound", "[config]") {
@@ -1094,7 +1094,7 @@ TEST_CASE_METHOD(TApp, "IniRequired", "[config]") {
 
     TempFile tmpini{"TestIniTmp.ini"};
 
-    auto *cfg=app.set_config("--config", tmpini, "", true);
+    auto *cfg = app.set_config("--config", tmpini, "", true);
 
     {
         std::ofstream out{tmpini};
@@ -1119,7 +1119,7 @@ TEST_CASE_METHOD(TApp, "IniRequired", "[config]") {
     args = {"--one=1", "--two=2"};
 
     CHECK_NOTHROW(run());
-    CHECK(cfg->count()==1);
+    CHECK(cfg->count() == 1);
     CHECK(1 == one);
     CHECK(2 == two);
     CHECK(3 == three);


### PR DESCRIPTION
Correct an anomaly when using config file processing with a default.   In this case the count always shows 1 even if the default file were not actually used.   This caused some issues in some applications and was a change from previous versions.   