### PR TITLE
Add IWYU pragmas

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1439,5 +1439,5 @@ struct AppFriend {
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/App_inl.hpp" // IWYU pragma: export
+#include "impl/App_inl.hpp"  // IWYU pragma: export
 #endif

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <algorithm>
 #include <cstdint>
@@ -1437,5 +1439,5 @@ struct AppFriend {
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/App_inl.hpp"
+#include "impl/App_inl.hpp" // IWYU pragma: export
 #endif

--- a/include/CLI/Argv.hpp
+++ b/include/CLI/Argv.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <string>
 #include <vector>
@@ -25,5 +27,5 @@ CLI11_INLINE std::vector<std::string> compute_win32_argv();
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Argv_inl.hpp"
+#include "impl/Argv_inl.hpp" // IWYU pragma: export
 #endif

--- a/include/CLI/Argv.hpp
+++ b/include/CLI/Argv.hpp
@@ -27,5 +27,5 @@ CLI11_INLINE std::vector<std::string> compute_win32_argv();
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Argv_inl.hpp" // IWYU pragma: export
+#include "impl/Argv_inl.hpp"  // IWYU pragma: export
 #endif

--- a/include/CLI/CLI.hpp
+++ b/include/CLI/CLI.hpp
@@ -9,6 +9,8 @@
 // CLI Library includes
 // Order is important for combiner script
 
+// IWYU pragma: begin_exports
+
 #include "Version.hpp"
 
 #include "Macros.hpp"
@@ -38,3 +40,5 @@
 #include "Config.hpp"
 
 #include "Formatter.hpp"
+
+// IWYU pragma: end_exports

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <algorithm>
 #include <cctype>
@@ -49,5 +51,5 @@ void checkParentSegments(std::vector<ConfigItem> &output, const std::string &cur
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Config_inl.hpp"
+#include "impl/Config_inl.hpp" // IWYU pragma: export
 #endif

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -51,5 +51,5 @@ void checkParentSegments(std::vector<ConfigItem> &output, const std::string &cur
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Config_inl.hpp" // IWYU pragma: export
+#include "impl/Config_inl.hpp"  // IWYU pragma: export
 #endif

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <algorithm>
 #include <fstream>

--- a/include/CLI/Encoding.hpp
+++ b/include/CLI/Encoding.hpp
@@ -52,5 +52,5 @@ CLI11_INLINE std::filesystem::path to_path(std::string_view str);
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Encoding_inl.hpp" // IWYU pragma: export
+#include "impl/Encoding_inl.hpp"  // IWYU pragma: export
 #endif

--- a/include/CLI/Encoding.hpp
+++ b/include/CLI/Encoding.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 #include <CLI/Macros.hpp>
 
 // [CLI11:public_includes:set]
@@ -50,5 +52,5 @@ CLI11_INLINE std::filesystem::path to_path(std::string_view str);
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Encoding_inl.hpp"
+#include "impl/Encoding_inl.hpp" // IWYU pragma: export
 #endif

--- a/include/CLI/Encoding.hpp
+++ b/include/CLI/Encoding.hpp
@@ -9,7 +9,6 @@
 // IWYU pragma: private, include "CLI/CLI.hpp"
 #include "Macros.hpp"
 
-
 // [CLI11:public_includes:set]
 #include <string>
 // [CLI11:public_includes:end]

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <exception>
 #include <stdexcept>

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <algorithm>
 #include <string>
@@ -21,5 +23,5 @@ namespace CLI {
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Formatter_inl.hpp"
+#include "impl/Formatter_inl.hpp" // IWYU pragma: export
 #endif

--- a/include/CLI/Formatter.hpp
+++ b/include/CLI/Formatter.hpp
@@ -23,5 +23,5 @@ namespace CLI {
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Formatter_inl.hpp" // IWYU pragma: export
+#include "impl/Formatter_inl.hpp"  // IWYU pragma: export
 #endif

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <functional>
 #include <map>

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:macros_hpp:verbatim]
 
 // The following version macro is very similar to the one in pybind11

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -806,5 +806,5 @@ class Option : public OptionBase<Option> {
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Option_inl.hpp" // IWYU pragma: export
+#include "impl/Option_inl.hpp"  // IWYU pragma: export
 #endif

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <algorithm>
 #include <functional>
@@ -804,5 +806,5 @@ class Option : public OptionBase<Option> {
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Option_inl.hpp"
+#include "impl/Option_inl.hpp" // IWYU pragma: export
 #endif

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <string>
 #include <tuple>
@@ -44,5 +46,5 @@ get_names(const std::vector<std::string> &input);
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Split_inl.hpp"
+#include "impl/Split_inl.hpp" // IWYU pragma: export
 #endif

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -46,5 +46,5 @@ get_names(const std::vector<std::string> &input);
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Split_inl.hpp" // IWYU pragma: export
+#include "impl/Split_inl.hpp"  // IWYU pragma: export
 #endif

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <algorithm>
 #include <iomanip>
@@ -263,5 +265,5 @@ CLI11_INLINE bool process_quoted_string(std::string &str, char string_char = '\"
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/StringTools_inl.hpp"
+#include "impl/StringTools_inl.hpp" // IWYU pragma: export
 #endif

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -265,5 +265,5 @@ CLI11_INLINE bool process_quoted_string(std::string &str, char string_char = '\"
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/StringTools_inl.hpp" // IWYU pragma: export
+#include "impl/StringTools_inl.hpp"  // IWYU pragma: export
 #endif

--- a/include/CLI/Timer.hpp
+++ b/include/CLI/Timer.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // On GCC < 4.8, the following define is often missing. Due to the
 // fact that this library only uses sleep_for, this should be safe
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5 && __GNUC_MINOR__ < 8

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:public_includes:set]
 #include <algorithm>
 #include <cmath>

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 #include "Error.hpp"
 #include "Macros.hpp"
 #include "StringTools.hpp"
@@ -892,5 +894,5 @@ CLI11_INLINE std::pair<std::string, std::string> split_program_name(std::string 
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Validators_inl.hpp"
+#include "impl/Validators_inl.hpp" // IWYU pragma: export
 #endif

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -894,5 +894,5 @@ CLI11_INLINE std::pair<std::string, std::string> split_program_name(std::string 
 }  // namespace CLI
 
 #ifndef CLI11_COMPILE
-#include "impl/Validators_inl.hpp" // IWYU pragma: export
+#include "impl/Validators_inl.hpp"  // IWYU pragma: export
 #endif

--- a/include/CLI/Version.hpp
+++ b/include/CLI/Version.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // [CLI11:version_hpp:verbatim]
 
 #define CLI11_VERSION_MAJOR 2

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // This include is only needed for IDEs to discover symbols
 #include <CLI/App.hpp>
 

--- a/include/CLI/impl/Argv_inl.hpp
+++ b/include/CLI/impl/Argv_inl.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // This include is only needed for IDEs to discover symbols
 #include <CLI/Argv.hpp>
 

--- a/include/CLI/impl/Config_inl.hpp
+++ b/include/CLI/impl/Config_inl.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // This include is only needed for IDEs to discover symbols
 #include <CLI/Config.hpp>
 

--- a/include/CLI/impl/Encoding_inl.hpp
+++ b/include/CLI/impl/Encoding_inl.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // This include is only needed for IDEs to discover symbols
 #include <CLI/Encoding.hpp>
 #include <CLI/Macros.hpp>

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // This include is only needed for IDEs to discover symbols
 #include <CLI/Formatter.hpp>
 

--- a/include/CLI/impl/Option_inl.hpp
+++ b/include/CLI/impl/Option_inl.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // This include is only needed for IDEs to discover symbols
 #include <CLI/Option.hpp>
 

--- a/include/CLI/impl/Split_inl.hpp
+++ b/include/CLI/impl/Split_inl.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // This include is only needed for IDEs to discover symbols
 #include <CLI/Split.hpp>
 

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 // This include is only needed for IDEs to discover symbols
 #include <CLI/StringTools.hpp>
 

--- a/include/CLI/impl/Validators_inl.hpp
+++ b/include/CLI/impl/Validators_inl.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
 #include <CLI/Validators.hpp>
 
 #include <CLI/Encoding.hpp>

--- a/src/Precompile.cpp
+++ b/src/Precompile.cpp
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+// IWYU pragma: begin_keep
+
 #include <CLI/impl/App_inl.hpp>
 #include <CLI/impl/Argv_inl.hpp>
 #include <CLI/impl/Config_inl.hpp>
@@ -13,3 +15,5 @@
 #include <CLI/impl/Split_inl.hpp>
 #include <CLI/impl/StringTools_inl.hpp>
 #include <CLI/impl/Validators_inl.hpp>
+
+// IWYU pragma: end_keep


### PR DESCRIPTION
Added include-what-you-use pragmas to:
* let IWYU point users to the main include file CLI/CLI.hpp
* tell IWYU that CLI/CLI.hpp is the main exporting header.

This should fix #816 