### PR TITLE
Fix internal header include paths.

### DIFF
--- a/include/CLI/Argv.hpp
+++ b/include/CLI/Argv.hpp
@@ -11,7 +11,7 @@
 #include <vector>
 // [CLI11:public_includes:end]
 
-#include <CLI/Macros.hpp>
+#include "Macros.hpp"
 
 namespace CLI {
 // [CLI11:argv_hpp:verbatim]

--- a/include/CLI/Encoding.hpp
+++ b/include/CLI/Encoding.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <CLI/Macros.hpp>
+#include "Macros.hpp"
 
 // [CLI11:public_includes:set]
 #include <string>

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -7,10 +7,10 @@
 #pragma once
 
 // This include is only needed for IDEs to discover symbols
-#include <CLI/App.hpp>
+#include "../App.hpp"
 
-#include <CLI/Argv.hpp>
-#include <CLI/Encoding.hpp>
+#include "../Argv.hpp"
+#include "../Encoding.hpp"
 
 // [CLI11:public_includes:set]
 #include <algorithm>

--- a/include/CLI/impl/Argv_inl.hpp
+++ b/include/CLI/impl/Argv_inl.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 // This include is only needed for IDEs to discover symbols
-#include <CLI/Argv.hpp>
+#include "../Argv.hpp"
 
-#include <CLI/Encoding.hpp>
+#include "../Encoding.hpp"
 
 // [CLI11:public_includes:set]
 #include <algorithm>

--- a/include/CLI/impl/Config_inl.hpp
+++ b/include/CLI/impl/Config_inl.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 // This include is only needed for IDEs to discover symbols
-#include <CLI/Config.hpp>
+#include "../Config.hpp"
 
 // [CLI11:public_includes:set]
 #include <algorithm>

--- a/include/CLI/impl/Encoding_inl.hpp
+++ b/include/CLI/impl/Encoding_inl.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 // This include is only needed for IDEs to discover symbols
-#include <CLI/Encoding.hpp>
-#include <CLI/Macros.hpp>
+#include "../Encoding.hpp"
+#include "../Macros.hpp"
 
 // [CLI11:public_includes:set]
 #include <array>

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 // This include is only needed for IDEs to discover symbols
-#include <CLI/Formatter.hpp>
+#include "../Formatter.hpp"
 
 // [CLI11:public_includes:set]
 #include <algorithm>

--- a/include/CLI/impl/Option_inl.hpp
+++ b/include/CLI/impl/Option_inl.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 // This include is only needed for IDEs to discover symbols
-#include <CLI/Option.hpp>
+#include "../Option.hpp"
 
 // [CLI11:public_includes:set]
 #include <algorithm>

--- a/include/CLI/impl/Split_inl.hpp
+++ b/include/CLI/impl/Split_inl.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 // This include is only needed for IDEs to discover symbols
-#include <CLI/Split.hpp>
+#include "../Split.hpp"
 
 // [CLI11:public_includes:set]
 #include <string>
@@ -16,8 +16,8 @@
 #include <vector>
 // [CLI11:public_includes:end]
 
-#include <CLI/Error.hpp>
-#include <CLI/StringTools.hpp>
+#include "../Error.hpp"
+#include "../StringTools.hpp"
 
 namespace CLI {
 // [CLI11:split_inl_hpp:verbatim]

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 // This include is only needed for IDEs to discover symbols
-#include <CLI/StringTools.hpp>
+#include "../StringTools.hpp"
 
 // [CLI11:public_includes:set]
 #include <cstdint>

--- a/include/CLI/impl/Validators_inl.hpp
+++ b/include/CLI/impl/Validators_inl.hpp
@@ -6,12 +6,12 @@
 
 #pragma once
 
-#include <CLI/Validators.hpp>
+#include "../Validators.hpp"
 
-#include <CLI/Encoding.hpp>
-#include <CLI/Macros.hpp>
-#include <CLI/StringTools.hpp>
-#include <CLI/TypeTools.hpp>
+#include "../Encoding.hpp"
+#include "../Macros.hpp"
+#include "../StringTools.hpp"
+#include "../TypeTools.hpp"
 
 // [CLI11:public_includes:set]
 #include <map>


### PR DESCRIPTION
The extra leading `"CLI/"` part of include directives prevents the inclusion of `CLI.hpp` from a relative directory without an extra `-I` or `/I` compiler directive, and makes it harder to make CLI11 part of a larger codebase.

This is a regression of #475.