### PR TITLE
Meson: fixes, cleanups, and modernizations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,6 +166,9 @@ jobs:
       - name: Build
         run: meson compile -C build-meson
 
+      - name: Test
+        run: meson test -C build-meson
+
   install:
     name: install tests
     runs-on: ubuntu-latest

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('CLI11', ['cpp'],
   version         : run_command(find_program('scripts/ExtractVersion.py'), check: true).stdout().strip(),
   license         : 'BSD-3-clause',
+  meson_version   : '>= 0.60',
   default_options : ['cpp_std=c++11', 'warning_level=3']
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('CLI11', ['cpp'],
   version         : run_command(find_program('scripts/ExtractVersion.py'), check: true).stdout().strip(),
+  license         : 'BSD-3-clause',
   default_options : ['cpp_std=c++11', 'warning_level=3']
 )
 

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,8 @@ CLI11_dep = declare_dependency(
   version             : meson.project_version(),
 )
 
+meson.override_dependency('CLI11', CLI11_dep)
+
 if get_option('tests')
     warnings = ['-Wshadow', '-Wsign-conversion', '-Wswitch-enum']
     if cxx.get_id() == 'gcc' and cxx.version().version_compare('>=4.9')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -69,14 +69,16 @@ dependent_applications = [
     'ensure_utf8_twice',
 ]
 dependent_applications_definitions = []
-#dependent_applications_targets = []
+dependent_applications_targets = []
 foreach app: dependent_applications
-    app_target = executable(app, 'applications'/app + '.cpp',
-        build_by_default: false
+    app_target = executable(
+        app, 'applications'/app + '.cpp',
+        dependencies: CLI11_dep,
     )
 
-    #dependent_applications_targets += dependency(app_target)
-    dependent_applications_definitions += '-DCLI11_@0@_EXE="@1@"'.format(app.to_upper(), app_target)
+    dependent_applications_targets += app_target
+    dependent_applications_definitions += '-DCLI11_@0@_EXE="@1@/@2@"'.format(
+        app.to_upper(), meson.current_build_dir(), app_target)
 endforeach
 
 if host_machine.system() == 'windows'
@@ -96,5 +98,5 @@ foreach n: testnames
         dependencies: [testdep] + kwargs.get('dependencies', []),
         link_with: kwargs.get('link_with', [])
     )
-    test(name, t)
+    test(name, t, depends: dependent_applications_targets)
 endforeach


### PR DESCRIPTION
This series cleans up and modernizes the Meson code a bit:

 - It adds the license SPDX name to the proper field
 - Sets a minimum version, the version is fairly old, but without setting a version then Meson will never warn about issues, including potentially important ones like "this happens to work in some cases but wasn't intended and doesn't work in all cases"
 - uses more modern Meson features to make things easier for consumers
 - Fixes the tests using the ensure_utf8 helpers by ensuring that they're actually built, and placing them in the correct path.
 - Adds the Meson test to the CI