### PR TITLE
Improved clarity in RequiredError

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -99,7 +99,7 @@ add_test(NAME option_groups_missing COMMAND option_groups)
 set_property(TEST option_groups_missing PROPERTY PASS_REGULAR_EXPRESSION "Exactly 1 option from"
                                                  "is required")
 add_test(NAME option_groups_extra COMMAND option_groups --csv --binary)
-set_property(TEST option_groups_extra PROPERTY PASS_REGULAR_EXPRESSION "and 2 were given")
+set_property(TEST option_groups_extra PROPERTY PASS_REGULAR_EXPRESSION "but 2 were given")
 add_test(NAME option_groups_extra2 COMMAND option_groups --csv --address "192.168.1.1" -o
                                            "test.out")
 set_property(TEST option_groups_extra2 PROPERTY PASS_REGULAR_EXPRESSION "at most 1")

--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -239,22 +239,22 @@ class RequiredError : public ParseError {
         if((min_option == 1) && (max_option == 1) && (used == 0))
             return RequiredError("Exactly 1 option from [" + option_list + "]");
         if((min_option == 1) && (max_option == 1) && (used > 1)) {
-            return {"Exactly 1 option from [" + option_list + "] is required and " + std::to_string(used) +
+            return {"Exactly 1 option from [" + option_list + "] is required but " + std::to_string(used) +
                         " were given",
                     ExitCodes::RequiredError};
         }
         if((min_option == 1) && (used == 0))
             return RequiredError("At least 1 option from [" + option_list + "]");
         if(used < min_option) {
-            return {"Requires at least " + std::to_string(min_option) + " options used and only " +
-                        std::to_string(used) + "were given from [" + option_list + "]",
+            return {"Requires at least " + std::to_string(min_option) + " options used but only " +
+                        std::to_string(used) + " were given from [" + option_list + "]",
                     ExitCodes::RequiredError};
         }
         if(max_option == 1)
             return {"Requires at most 1 options be given from [" + option_list + "]", ExitCodes::RequiredError};
 
-        return {"Requires at most " + std::to_string(max_option) + " options be used and " + std::to_string(used) +
-                    "were given from [" + option_list + "]",
+        return {"Requires at most " + std::to_string(max_option) + " options be used but " + std::to_string(used) +
+                    " were given from [" + option_list + "]",
                 ExitCodes::RequiredError};
     }
 };


### PR DESCRIPTION
Hello. Thank you for this tool.

I found a few small typos in the RequiredError class.

This is an error message I received:

```
Requires at most 2 options be used and 3were given from [filename,--get-size,--get-size2]
```
This PR changes the error message to
```
Requires at most 2 options be used but 3 were given from [filename,--get-size,--get-size2]
```

Happy to make changes as needed!

## Source

```cpp
    std::string filename;
    bool get_size = false;

    CLI::App app{"Program to read a file specified as command-line argument"};

    app.add_option("filename", filename, "File to read")->required();
    app.add_flag("--get-size", get_size, "Print the size of the file");
    app.add_flag("--get-size2", get_size, "Print the size of the file2");

    app.require_option(1, 2); // Enforce only one flag can be input

    CLI11_PARSE(app, argc, argv);
```

## Further Idea

Also, another idea I had was to remove required options from this error message. In this example, "filename" is required, so a better error message would be
```
Requires at most 1 options be used but 2 were given from [--get-size,--get-size2]
```
I'm happy to look into this if you feel it would be valuable