### PR TITLE
Group merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- add mechanism to allow option groups to be hidden and all options be considered part of the parent for help display
+
 ## Version 2.4: Unicode and TOML support
 
 This version adds Unicode support, support for TOML standard including multiline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- add mechanism to allow option groups to be hidden and all options be considered part of the parent for help display
+- add mechanism to allow option groups to be hidden and all options be
+  considered part of the parent for help display
 
 ## Version 2.4: Unicode and TOML support
 

--- a/README.md
+++ b/README.md
@@ -1205,7 +1205,13 @@ auto hidden_group=app.add_option_group("");
 ```
 
 will create a group such that no options in that group are displayed in the help
-string.
+string.  For the purposes of help display,  if the option group name starts with a '+' it is treated as if it were not in a group for help and get_options.   For example:
+
+```cpp
+auto added_group=app.add_option_group("+sub");
+```
+
+In this case the help output will not reference the option group and options inside of it will be treated for most purposes as if they were part of the parent.
 
 ### Configuration file
 

--- a/README.md
+++ b/README.md
@@ -1205,13 +1205,17 @@ auto hidden_group=app.add_option_group("");
 ```
 
 will create a group such that no options in that group are displayed in the help
-string.  For the purposes of help display,  if the option group name starts with a '+' it is treated as if it were not in a group for help and get_options.   For example:
+string. For the purposes of help display, if the option group name starts with a
+'+' it is treated as if it were not in a group for help and get_options. For
+example:
 
 ```cpp
 auto added_group=app.add_option_group("+sub");
 ```
 
-In this case the help output will not reference the option group and options inside of it will be treated for most purposes as if they were part of the parent.
+In this case the help output will not reference the option group and options
+inside of it will be treated for most purposes as if they were part of the
+parent.
 
 ### Configuration file
 

--- a/examples/testEXE.cpp
+++ b/examples/testEXE.cpp
@@ -8,21 +8,26 @@
 
 #include <CLI/CLI.hpp>
 #include <iostream>
-#include <string>
+#include <optional>
 
 int main(int argc, const char *argv[]) {
 
-    int value{0};
-    CLI::App app{"Test App"};
-    app.add_option("-v", value, "value");
+    CLI::App app;
 
-    auto *subcom = app.add_subcommand("sub", "")->prefix_command();
-    CLI11_PARSE(app, argc, argv);
+    bool flag = false;
+    std::optional<bool> optional_flag = std::nullopt;
 
-    std::cout << "value =" << value << '\n';
-    std::cout << "after Args:";
-    for(const auto &aarg : subcom->remaining()) {
-        std::cout << aarg << " ";
+    app.add_option("--tester");
+    auto *m1=app.add_option_group("+tester");
+
+    m1->add_option("--flag", flag, "description");
+    m1->add_option("--optional_flag", optional_flag, "description");
+
+    CLI11_PARSE(app,argc, argv);
+
+    std::cout << "flag: " << flag << std::endl;
+
+    if(optional_flag){
+        std::cout << "optional flag: " << optional_flag.value() << std::endl;
     }
-    std::cout << '\n';
 }

--- a/examples/testEXE.cpp
+++ b/examples/testEXE.cpp
@@ -18,16 +18,16 @@ int main(int argc, const char *argv[]) {
     std::optional<bool> optional_flag = std::nullopt;
 
     app.add_option("--tester");
-    auto *m1=app.add_option_group("+tester");
+    auto *m1 = app.add_option_group("+tester");
 
     m1->add_option("--flag", flag, "description");
     m1->add_option("--optional_flag", optional_flag, "description");
 
-    CLI11_PARSE(app,argc, argv);
+    CLI11_PARSE(app, argc, argv);
 
     std::cout << "flag: " << flag << std::endl;
 
-    if(optional_flag){
+    if(optional_flag) {
         std::cout << "optional flag: " << optional_flag.value() << std::endl;
     }
 }

--- a/examples/testEXE.cpp
+++ b/examples/testEXE.cpp
@@ -8,26 +8,21 @@
 
 #include <CLI/CLI.hpp>
 #include <iostream>
-#include <optional>
+#include <string>
 
 int main(int argc, const char *argv[]) {
 
-    CLI::App app;
+    int value{0};
+    CLI::App app{"Test App"};
+    app.add_option("-v", value, "value");
 
-    bool flag = false;
-    std::optional<bool> optional_flag = std::nullopt;
-
-    app.add_option("--tester");
-    auto *m1 = app.add_option_group("+tester");
-
-    m1->add_option("--flag", flag, "description");
-    m1->add_option("--optional_flag", optional_flag, "description");
-
+    auto *subcom = app.add_subcommand("sub", "")->prefix_command();
     CLI11_PARSE(app, argc, argv);
 
-    std::cout << "flag: " << flag << std::endl;
-
-    if(optional_flag) {
-        std::cout << "optional flag: " << optional_flag.value() << std::endl;
+    std::cout << "value =" << value << '\n';
+    std::cout << "after Args:";
+    for(const auto &aarg : subcom->remaining()) {
+        std::cout << aarg << " ";
     }
+    std::cout << '\n';
 }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1340,9 +1340,8 @@ class Option_group : public App {
         : App(std::move(group_description), "", parent) {
         group(group_name);
         // option groups should have automatic fallthrough
-        if (group_name.empty() || group_name.front() == '+')
-        {
-            //help will not be used by default in these contexts
+        if(group_name.empty() || group_name.front() == '+') {
+            // help will not be used by default in these contexts
             set_help_flag("");
             set_help_all_flag("");
         }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1340,6 +1340,12 @@ class Option_group : public App {
         : App(std::move(group_description), "", parent) {
         group(group_name);
         // option groups should have automatic fallthrough
+        if (group_name.empty() || group_name.front() == '+')
+        {
+            //help will not be used by default in these contexts
+            set_help_flag("");
+            set_help_all_flag("");
+        }
     }
     using App::add_option;
     /// Add an existing option to the Option_group

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -786,9 +786,9 @@ CLI11_INLINE std::vector<const Option *> App::get_options(const std::function<bo
     }
     for(const auto &subcp : subcommands_) {
         // also check down into nameless subcommands
-        const App *subc=subcp.get();
-        if(subc->get_name().empty() && !subc->get_group().empty() && subc->get_group().front()=='+') {
-            std::vector<const Option *> subcopts=subc->get_options(filter);
+        const App *subc = subcp.get();
+        if(subc->get_name().empty() && !subc->get_group().empty() && subc->get_group().front() == '+') {
+            std::vector<const Option *> subcopts = subc->get_options(filter);
             options.insert(options.end(), subcopts.begin(), subcopts.end());
         }
     }
@@ -807,8 +807,8 @@ CLI11_INLINE std::vector<Option *> App::get_options(const std::function<bool(Opt
     }
     for(auto &subc : subcommands_) {
         // also check down into nameless subcommands
-        if(subc->get_name().empty() && !subc->get_group().empty() && subc->get_group().front()=='+') {
-            auto subcopts=subc->get_options(filter);
+        if(subc->get_name().empty() && !subc->get_group().empty() && subc->get_group().front() == '+') {
+            auto subcopts = subc->get_options(filter);
             options.insert(options.end(), subcopts.begin(), subcopts.end());
         }
     }

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -807,7 +807,7 @@ CLI11_INLINE std::vector<Option *> App::get_options(const std::function<bool(Opt
     }
     for(auto &subc : subcommands_) {
         // also check down into nameless subcommands
-        if(subc->get_name().empty() && !subc-get_group().empty() && subc->get_group().front()=='+') {
+        if(subc->get_name().empty() && !subc->get_group().empty() && subc->get_group().front()=='+') {
             auto subcopts=subc->get_options(filter);
             options.insert(options.end(), subcopts.begin(), subcopts.end());
         }

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -784,7 +784,14 @@ CLI11_INLINE std::vector<const Option *> App::get_options(const std::function<bo
                                      [&filter](const Option *opt) { return !filter(opt); }),
                       std::end(options));
     }
-
+    for(const auto &subcp : subcommands_) {
+        // also check down into nameless subcommands
+        const App *subc=subcp.get();
+        if(subc->get_name().empty() && !subc->get_group().empty() && subc->get_group().front()=='+') {
+            std::vector<const Option *> subcopts=subc->get_options(filter);
+            options.insert(options.end(), subcopts.begin(), subcopts.end());
+        }
+    }
     return options;
 }
 
@@ -798,7 +805,13 @@ CLI11_INLINE std::vector<Option *> App::get_options(const std::function<bool(Opt
             std::remove_if(std::begin(options), std::end(options), [&filter](Option *opt) { return !filter(opt); }),
             std::end(options));
     }
-
+    for(auto &subc : subcommands_) {
+        // also check down into nameless subcommands
+        if(subc->get_name().empty() && !subc-get_group().empty() && subc->get_group().front()=='+') {
+            auto subcopts=subc->get_options(filter);
+            options.insert(options.end(), subcopts.begin(), subcopts.end());
+        }
+    }
     return options;
 }
 

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -180,7 +180,7 @@ CLI11_INLINE std::string Formatter::make_subcommands(const App *app, AppFormatMo
     std::vector<std::string> subcmd_groups_seen;
     for(const App *com : subcommands) {
         if(com->get_name().empty()) {
-            if(com->get_group().empty()||com->get_group().front() == '+') {
+            if(com->get_group().empty() || com->get_group().front() == '+') {
                 continue;
             }
             out << make_expanded(com);

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -180,10 +180,10 @@ CLI11_INLINE std::string Formatter::make_subcommands(const App *app, AppFormatMo
     std::vector<std::string> subcmd_groups_seen;
     for(const App *com : subcommands) {
         if(com->get_name().empty()) {
-            if(!com->get_group().empty()) {
-                out << make_expanded(com);
+            if(com->get_group().empty()||com->get_group().front() == '+') {
+                continue;
             }
-            continue;
+            out << make_expanded(com);
         }
         std::string group_key = com->get_group();
         if(!group_key.empty() &&

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -221,6 +221,32 @@ TEST_CASE_METHOD(TApp, "BasicOptionGroupMin", "[optiongroup]") {
     CHECK(std::string::npos != exactloc);
 }
 
+TEST_CASE_METHOD(TApp, "integratedOptionGroup", "[optiongroup]") {
+    auto *ogroup = app.add_option_group("+clusters");
+    int res{0};
+    ogroup->add_option("--test1", res);
+    ogroup->add_option("--test2", res);
+    ogroup->add_option("--test3", res);
+    int val2{0};
+    app.add_option("--option", val2);
+    ogroup->require_option();
+
+    args = {"--option", "9"};
+    CHECK_THROWS_AS(run(), CLI::RequiredError);
+
+    args = {"--test1", "5", "--test2", "4", "--test3=5"};
+    CHECK_NOTHROW(run());
+
+    auto options=app.get_options();
+    CHECK(options.size()==5);
+    const CLI::App *capp=&app;
+    auto coptions=capp->get_options();
+    CHECK(coptions.size()==5);
+    std::string help = app.help();
+    auto exactloc = help.find("clusters");
+    CHECK(std::string::npos == exactloc);
+}
+
 TEST_CASE_METHOD(TApp, "BasicOptionGroupExact2", "[optiongroup]") {
     auto *ogroup = app.add_option_group("clusters");
     int res{0};

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -237,11 +237,11 @@ TEST_CASE_METHOD(TApp, "integratedOptionGroup", "[optiongroup]") {
     args = {"--test1", "5", "--test2", "4", "--test3=5"};
     CHECK_NOTHROW(run());
 
-    auto options=app.get_options();
-    CHECK(options.size()==5);
-    const CLI::App *capp=&app;
-    auto coptions=capp->get_options();
-    CHECK(coptions.size()==5);
+    auto options = app.get_options();
+    CHECK(options.size() == 5);
+    const CLI::App *capp = &app;
+    auto coptions = capp->get_options();
+    CHECK(coptions.size() == 5);
     std::string help = app.help();
     auto exactloc = help.find("clusters");
     CHECK(std::string::npos == exactloc);


### PR DESCRIPTION
This PR adds a mechanism to hide groups but have their options visible as part of the parent.
This works for option group names starting with a '+'

for example 
```
 CLI::App app;

    bool flag = false;
    std::optional<bool> optional_flag = std::nullopt;

    app.add_option("--tester");
    auto *m1=app.add_option_group("+tester");

    m1->add_option("--flag", flag, "description");
    m1->add_option("--optional_flag", optional_flag, "description");

    CLI11_PARSE(app,argc, argv);
```
will produce help as 
```txt
Options:
  -h,--help                   Print this help message and exit
  --tester
  --flag BOOLEAN              description
  --optional_flag BOOLEAN     description
```

instead of 
```
Options:
  -h,--help                   Print this help message and exit
  --tester
[Option Group: tester]
  Options:
    --flag BOOLEAN              description
    --optional_flag BOOLEAN     description

```

Fixes issue #1034 and a few other past issues or questions
