### PR TITLE
Fix Windows encoding issue

### DIFF
--- a/include/CLI/impl/Encoding_inl.hpp
+++ b/include/CLI/impl/Encoding_inl.hpp
@@ -61,13 +61,7 @@ CLI11_DIAGNOSTIC_IGNORE_DEPRECATED
 
 CLI11_INLINE std::string narrow_impl(const wchar_t *str, std::size_t str_size) {
 #if CLI11_HAS_CODECVT
-#ifdef _WIN32
-    return std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>().to_bytes(str, str + str_size);
-
-#else
-    return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(str, str + str_size);
-
-#endif  // _WIN32
+    return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(str, str + str_size); // UCS-2 on Windows, UTF-32 otherwise
 #else   // CLI11_HAS_CODECVT
     (void)str_size;
     std::mbstate_t state = std::mbstate_t();
@@ -92,13 +86,7 @@ CLI11_INLINE std::string narrow_impl(const wchar_t *str, std::size_t str_size) {
 
 CLI11_INLINE std::wstring widen_impl(const char *str, std::size_t str_size) {
 #if CLI11_HAS_CODECVT
-#ifdef _WIN32
-    return std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>().from_bytes(str, str + str_size);
-
-#else
-    return std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(str, str + str_size);
-
-#endif  // _WIN32
+    return std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(str, str + str_size); // UCS-2 on Windows, UTF-32 otherwise
 #else   // CLI11_HAS_CODECVT
     (void)str_size;
     std::mbstate_t state = std::mbstate_t();


### PR DESCRIPTION
We uses CLI11 internally to build some of our tools. We are building with MSVC from VS2022, have enabled UNICODE on Windows, as suggested in the [UTF-8 Everywhere manifesto](http://utf8everywhere.org/) and codecvt is available (`CLI11_HAS_CODECVT` is `1`). With this setup we have been unable to parse non-ANSI parameters properly.

We have tracked the issue back to the `narrow` implementation. Specifically on Windows, `codecvt_utf8_utf16` is used to convert `str`. Even though the type is `wchar_t` it is NOT an UTF-16 string. It's actually an UCS-2 string. https://github.com/CLIUtils/CLI11/blob/3afddf3578ccc157e78f4edaf30635ebb3e3991b/include/CLI/impl/Encoding_inl.hpp#L65

According to the documentation, [codecvt_utf8<wchar_t>](https://en.cppreference.com/w/cpp/locale/codecvt_utf8) convert UTF-8 to/from UCS-2 on Windows and to/from UTF-32 on other platforms.
![image](https://github.com/CLIUtils/CLI11/assets/44769431/2c1d02b0-fded-41ec-ab80-8a26d151ae9f)

This probably fixes #1042