### PR TITLE
docs: Add Conan installation in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ details are available at [installation][]:
 - All-in-one global header: Like above, but copying the file to a shared folder
   location like `/opt/CLI11`. Then, the C++ include path has to be extended to
   point at this folder. With CMake 3.5+, use `include_directories(/opt/CLI11)`
-- For other methods including using CMake or vcpkg and some specific
+- For other methods including using CMake, conan or vcpkg and some specific
   instructions for GCC 8 or WASI see [installation][].
 
 ## Usage

--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -238,6 +238,17 @@ community contributors. If the version is out of date, please
 [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the
 vcpkg repository.
 
+## Installing CLI11 using Conan
+
+You can install pre-built binaries for CLI11 or build it from source using [Conan](https://conan.io/). Use the following command:
+
+```bash
+conan install --requires="cli11/[*]" --build=missing
+```
+
+The CLI11 Conan recipe is kept up to date by Conan maintainers and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/conan-io/conan-center-index) on the ConanCenterIndex repository.
+
 ## Special instructions for GCC 8, Some clang, and WASI
 
 If you are using GCC 8 and using it in C++17 mode with CLI11. CLI11 makes use of

--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -240,14 +240,17 @@ vcpkg repository.
 
 ## Installing CLI11 using Conan
 
-You can install pre-built binaries for CLI11 or build it from source using [Conan](https://conan.io/). Use the following command:
+You can install pre-built binaries for CLI11 or build it from source using
+[Conan](https://conan.io/). Use the following command:
 
 ```bash
 conan install --requires="cli11/[*]" --build=missing
 ```
 
-The CLI11 Conan recipe is kept up to date by Conan maintainers and community contributors.
-If the version is out of date, please [create an issue or pull request](https://github.com/conan-io/conan-center-index) on the ConanCenterIndex repository.
+The CLI11 Conan recipe is kept up to date by Conan maintainers and community
+contributors. If the version is out of date, please
+[create an issue or pull request](https://github.com/conan-io/conan-center-index)
+on the ConanCenterIndex repository.
 
 ## Special instructions for GCC 8, Some clang, and WASI
 


### PR DESCRIPTION
Greetings, fellow CLI11 community!

We have just added the latest version of cli11 to [Conan Center](https://conan.io/center/recipes/cli11?version=2.4.2) and thought it would be a nice addition to include instructions on how to install CLI11 via Conan in the book folder.

Please let me know if this is okay, or if you would prefer it placed elsewhere.

**UPDATE**: Some extra information to be more clear about the used command line and links:

I did not mention how to install/configure Conan, because both links to conan.io and conan-center-index has all Conan documentation updated. For instance: https://conan.io/downloads

The latest version of CLI11 available in Conan Center is 2.4.2:

- https://conan.io/center/recipes/cli11?version=2.4.2

or, can be found by running the conan command:

    conan search "cli11"

The command `conan install --requires="cli11/[*]" --build=missing` means:

* conan install: Install a package from a remote. By default, it points to the official Conan Center
* --requires="cli11/[*]": Install the latest version of CLI11 available in Conan Center
* --build=missing: In case not finding a pre-built package compatible, build it from source then.


Regards!