### PR TITLE
Static linking with MSVC and PRECOMPILED=ON

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,8 @@ if(CLI11_PRECOMPILED)
   add_library(CLI11 STATIC ${CLI11_headers} ${CLI11_library_headers} ${CLI11_impl_headers}
                            ${CLI11_precompile_sources})
   if(MSVC)
-    set_property(TARGET CLI11 PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    set_property(TARGET CLI11 PROPERTY MSVC_RUNTIME_LIBRARY
+                                       "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   endif()
   target_compile_definitions(CLI11 PUBLIC -DCLI11_COMPILE)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,9 @@ if(CLI11_PRECOMPILED)
   file(GLOB CLI11_precompile_sources "${PROJECT_SOURCE_DIR}/src/*.cpp")
   add_library(CLI11 STATIC ${CLI11_headers} ${CLI11_library_headers} ${CLI11_impl_headers}
                            ${CLI11_precompile_sources})
+  if(MSVC)
+    set_property(TARGET CLI11 PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  endif()
   target_compile_definitions(CLI11 PUBLIC -DCLI11_COMPILE)
 
   set(PUBLIC_OR_INTERFACE PUBLIC)


### PR DESCRIPTION
Solves the following issue:

Using CLI11 with the option `CLI11_PRECOMPILED=ON` results in the following linking error (Windows10 + MSVC set up to link statically)

`CLI11.lib(Precompile.cpp.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MT_StaticRelease' in srcfile.cpp.obj`