### PR TITLE
Use pymod.find_installation() to find python in meson.build

### DIFF
--- a/single-include/meson.build
+++ b/single-include/meson.build
@@ -2,7 +2,8 @@
 # meson.build here when generating the single file header so that it is placced
 # in the correct location.
 
-prog_python = find_program('python')
+pymod = import('python')
+prog_python = pymod.find_installation()
 
 single_main_file = files('CLI11.hpp.in')
 


### PR DESCRIPTION
Since Monterey 12.3, macOS removed python2.7 from it's base installation. This means that `python` is not longer a command by default (just `python3`), and the build for CLI11 fails. This PR moves to using `pymod.find_installation()` to handle this in a more general way. See https://mesonbuild.com/Python-module.html