### PR TITLE
Issue 1086

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
           lcov --list coverage.info
         working-directory: build
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           files: build/coverage.info
           functionalities: fixes

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -394,30 +394,19 @@ function(setup_target_for_coverage_lcov)
     COMMAND ${LCOV_BASELINE_COUNT_CMD}
     COMMAND ${LCOV_FILTER_CMD}
     COMMAND ${LCOV_GEN_HTML_CMD} ${GCOVR_XML_CMD_COMMAND}
+    COMMAND ${CMAKE_COMMAND} -E echo "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+    COMMAND ${CMAKE_COMMAND} -E echo "Lcov code coverage info report saved in ${Coverage_NAME}.info."
+    COMMAND ${CMAKE_COMMAND} -E echo  ${GCOVR_XML_CMD_COMMENT}
+    COMMAND ${CMAKE_COMMAND} -E echo "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     # Set output files as GENERATED (will be removed on 'make clean')
     BYPRODUCTS ${Coverage_NAME}.base ${Coverage_NAME}.capture ${Coverage_NAME}.total
                ${Coverage_NAME}.info ${GCOVR_XML_CMD_BYPRODUCTS} ${Coverage_NAME}/index.html
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     DEPENDS ${Coverage_DEPENDENCIES}
     VERBATIM # Protect arguments to commands
-    COMMENT
-      "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+    
+      
   )
-
-  # Show where to find the lcov info report
-  add_custom_command(
-    TARGET ${Coverage_NAME}
-    POST_BUILD
-    COMMAND ;
-    COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
-            ${GCOVR_XML_CMD_COMMENT})
-
-  # Show info where to find the report
-  add_custom_command(
-    TARGET ${Coverage_NAME}
-    POST_BUILD
-    COMMAND ;
-    COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report.")
 
 endfunction() # setup_target_for_coverage_lcov
 

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -140,15 +140,15 @@ include(CMakeParseArguments)
 option(CODE_COVERAGE_VERBOSE "Verbose information" FALSE)
 
 # Check prereqs
-find_program( GCOV_PATH gcov )
-find_program( LCOV_PATH  NAMES lcov lcov.bat lcov.exe lcov.perl)
-find_program( FASTCOV_PATH NAMES fastcov fastcov.py )
-find_program( GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat )
-find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
-find_program( CPPFILT_PATH NAMES c++filt )
+find_program(GCOV_PATH gcov)
+find_program(LCOV_PATH NAMES lcov lcov.bat lcov.exe lcov.perl)
+find_program(FASTCOV_PATH NAMES fastcov fastcov.py)
+find_program(GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat)
+find_program(GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
+find_program(CPPFILT_PATH NAMES c++filt)
 
 if(NOT GCOV_PATH)
-    message(FATAL_ERROR "gcov not found! Aborting...")
+  message(FATAL_ERROR "gcov not found! Aborting...")
 endif() # NOT GCOV_PATH
 
 # Check supported compiler (Clang, GNU and Flang)
@@ -158,64 +158,56 @@ foreach(LANG ${LANGUAGES})
     if("${CMAKE_${LANG}_COMPILER_VERSION}" VERSION_LESS 3)
       message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
     endif()
-  elseif(NOT "${CMAKE_${LANG}_COMPILER_ID}" MATCHES "GNU"
-         AND NOT "${CMAKE_${LANG}_COMPILER_ID}" MATCHES "(LLVM)?[Ff]lang")
+  elseif(NOT "${CMAKE_${LANG}_COMPILER_ID}" MATCHES "GNU" AND NOT "${CMAKE_${LANG}_COMPILER_ID}"
+                                                              MATCHES "(LLVM)?[Ff]lang")
     message(FATAL_ERROR "Compiler is not GNU or Flang! Aborting...")
   endif()
 endforeach()
 
-set(COVERAGE_COMPILER_FLAGS "-g --coverage"
+set(COVERAGE_COMPILER_FLAGS
+    "-g --coverage"
     CACHE INTERNAL "")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-    include(CheckCXXCompilerFlag)
-    check_cxx_compiler_flag(-fprofile-abs-path HAVE_cxx_fprofile_abs_path)
-    if(HAVE_cxx_fprofile_abs_path)
-        set(COVERAGE_CXX_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
-    endif()
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-fprofile-abs-path HAVE_cxx_fprofile_abs_path)
+  if(HAVE_cxx_fprofile_abs_path)
+    set(COVERAGE_CXX_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
+  endif()
 endif()
 if(CMAKE_C_COMPILER_ID MATCHES "(GNU|Clang)")
-    include(CheckCCompilerFlag)
-    check_c_compiler_flag(-fprofile-abs-path HAVE_c_fprofile_abs_path)
-    if(HAVE_c_fprofile_abs_path)
-        set(COVERAGE_C_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
-    endif()
+  include(CheckCCompilerFlag)
+  check_c_compiler_flag(-fprofile-abs-path HAVE_c_fprofile_abs_path)
+  if(HAVE_c_fprofile_abs_path)
+    set(COVERAGE_C_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
+  endif()
 endif()
 
 set(CMAKE_Fortran_FLAGS_COVERAGE
     ${COVERAGE_COMPILER_FLAGS}
-    CACHE STRING "Flags used by the Fortran compiler during coverage builds."
-    FORCE )
+    CACHE STRING "Flags used by the Fortran compiler during coverage builds." FORCE)
 set(CMAKE_CXX_FLAGS_COVERAGE
     ${COVERAGE_COMPILER_FLAGS}
-    CACHE STRING "Flags used by the C++ compiler during coverage builds."
-    FORCE )
+    CACHE STRING "Flags used by the C++ compiler during coverage builds." FORCE)
 set(CMAKE_C_FLAGS_COVERAGE
     ${COVERAGE_COMPILER_FLAGS}
-    CACHE STRING "Flags used by the C compiler during coverage builds."
-    FORCE )
+    CACHE STRING "Flags used by the C compiler during coverage builds." FORCE)
 set(CMAKE_EXE_LINKER_FLAGS_COVERAGE
     ""
-    CACHE STRING "Flags used for linking binaries during coverage builds."
-    FORCE )
+    CACHE STRING "Flags used for linking binaries during coverage builds." FORCE)
 set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
     ""
-    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
-    FORCE )
-mark_as_advanced(
-    CMAKE_Fortran_FLAGS_COVERAGE
-    CMAKE_CXX_FLAGS_COVERAGE
-    CMAKE_C_FLAGS_COVERAGE
-    CMAKE_EXE_LINKER_FLAGS_COVERAGE
-    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+    CACHE STRING "Flags used by the shared libraries linker during coverage builds." FORCE)
+mark_as_advanced(CMAKE_Fortran_FLAGS_COVERAGE CMAKE_CXX_FLAGS_COVERAGE CMAKE_C_FLAGS_COVERAGE
+                 CMAKE_EXE_LINKER_FLAGS_COVERAGE CMAKE_SHARED_LINKER_FLAGS_COVERAGE)
 
 get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG))
-    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
+  message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
 endif() # NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-    link_libraries(gcov)
+  link_libraries(gcov)
 endif()
 
 # Defines a target for running and collection code coverage information
@@ -236,164 +228,196 @@ endif()
 # )
 function(setup_target_for_coverage_lcov)
 
-    set(options NO_DEMANGLE SONARQUBE)
-    set(oneValueArgs BASE_DIRECTORY NAME)
-    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
-    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  set(options NO_DEMANGLE SONARQUBE)
+  set(oneValueArgs BASE_DIRECTORY NAME)
+  set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
+  cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if(NOT LCOV_PATH)
-        message(FATAL_ERROR "lcov not found! Aborting...")
-    endif() # NOT LCOV_PATH
+  if(NOT LCOV_PATH)
+    message(FATAL_ERROR "lcov not found! Aborting...")
+  endif() # NOT LCOV_PATH
 
-    if(NOT GENHTML_PATH)
-        message(FATAL_ERROR "genhtml not found! Aborting...")
-    endif() # NOT GENHTML_PATH
+  if(NOT GENHTML_PATH)
+    message(FATAL_ERROR "genhtml not found! Aborting...")
+  endif() # NOT GENHTML_PATH
 
-    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
-    if(DEFINED Coverage_BASE_DIRECTORY)
-        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
-    else()
-        set(BASEDIR ${PROJECT_SOURCE_DIR})
+  # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+  if(DEFINED Coverage_BASE_DIRECTORY)
+    get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+  else()
+    set(BASEDIR ${PROJECT_SOURCE_DIR})
+  endif()
+
+  # Collect excludes (CMake 3.4+: Also compute absolute paths)
+  set(LCOV_EXCLUDES "")
+  foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_LCOV_EXCLUDES})
+    if(CMAKE_VERSION VERSION_GREATER 3.4)
+      get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
     endif()
+    list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
+  endforeach()
+  list(REMOVE_DUPLICATES LCOV_EXCLUDES)
 
-    # Collect excludes (CMake 3.4+: Also compute absolute paths)
-    set(LCOV_EXCLUDES "")
-    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_LCOV_EXCLUDES})
-        if(CMAKE_VERSION VERSION_GREATER 3.4)
-            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
-        endif()
-        list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
-    endforeach()
-    list(REMOVE_DUPLICATES LCOV_EXCLUDES)
+  # Conditional arguments
+  if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
+    set(GENHTML_EXTRA_ARGS "--demangle-cpp")
+  endif()
 
-    # Conditional arguments
-    if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
-      set(GENHTML_EXTRA_ARGS "--demangle-cpp")
-    endif()
+  # Setting up commands which will be run to generate coverage data.
+  # Cleanup lcov
+  set(LCOV_CLEAN_CMD
+      ${LCOV_PATH}
+      ${Coverage_LCOV_ARGS}
+      --gcov-tool
+      ${GCOV_PATH}
+      -directory
+      .
+      -b
+      ${BASEDIR}
+      --zerocounters)
+  # Create baseline to make sure untouched files show up in the report
+  set(LCOV_BASELINE_CMD
+      ${LCOV_PATH}
+      ${Coverage_LCOV_ARGS}
+      --gcov-tool
+      ${GCOV_PATH}
+      -c
+      -i
+      -d
+      .
+      -b
+      ${BASEDIR}
+      -o
+      ${Coverage_NAME}.base)
+  # Run tests
+  set(LCOV_EXEC_TESTS_CMD ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS})
+  # Capturing lcov counters and generating report
+  set(LCOV_CAPTURE_CMD
+      ${LCOV_PATH}
+      ${Coverage_LCOV_ARGS}
+      --gcov-tool
+      ${GCOV_PATH}
+      --directory
+      .
+      -b
+      ${BASEDIR}
+      --capture
+      --output-file
+      ${Coverage_NAME}.capture)
+  # add baseline counters
+  set(LCOV_BASELINE_COUNT_CMD
+      ${LCOV_PATH}
+      ${Coverage_LCOV_ARGS}
+      --gcov-tool
+      ${GCOV_PATH}
+      -a
+      ${Coverage_NAME}.base
+      -a
+      ${Coverage_NAME}.capture
+      --output-file
+      ${Coverage_NAME}.total)
+  # filter collected data to final coverage report
+  set(LCOV_FILTER_CMD
+      ${LCOV_PATH}
+      ${Coverage_LCOV_ARGS}
+      --gcov-tool
+      ${GCOV_PATH}
+      --remove
+      ${Coverage_NAME}.total
+      ${LCOV_EXCLUDES}
+      --output-file
+      ${Coverage_NAME}.info)
+  # Generate HTML output
+  set(LCOV_GEN_HTML_CMD ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o
+                        ${Coverage_NAME} ${Coverage_NAME}.info)
+  if(${Coverage_SONARQUBE})
+    # Generate SonarQube output
+    set(GCOVR_XML_CMD
+        ${GCOVR_PATH}
+        --sonarqube
+        ${Coverage_NAME}_sonarqube.xml
+        -r
+        ${BASEDIR}
+        ${GCOVR_ADDITIONAL_ARGS}
+        ${GCOVR_EXCLUDE_ARGS}
+        --object-directory=${PROJECT_BINARY_DIR})
+    set(GCOVR_XML_CMD_COMMAND COMMAND ${GCOVR_XML_CMD})
+    set(GCOVR_XML_CMD_BYPRODUCTS ${Coverage_NAME}_sonarqube.xml)
+    set(GCOVR_XML_CMD_COMMENT
+        COMMENT "SonarQube code coverage info report saved in ${Coverage_NAME}_sonarqube.xml.")
+  endif()
 
-    # Setting up commands which will be run to generate coverage data.
-    # Cleanup lcov
-    set(LCOV_CLEAN_CMD
-        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory .
-        -b ${BASEDIR} --zerocounters
-    )
-    # Create baseline to make sure untouched files show up in the report
-    set(LCOV_BASELINE_CMD
-        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b
-        ${BASEDIR} -o ${Coverage_NAME}.base
-    )
-    # Run tests
-    set(LCOV_EXEC_TESTS_CMD
-        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
-    )
-    # Capturing lcov counters and generating report
-    set(LCOV_CAPTURE_CMD
-        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b
-        ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
-    )
-    # add baseline counters
-    set(LCOV_BASELINE_COUNT_CMD
-        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base
-        -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
-    )
-    # filter collected data to final coverage report
-    set(LCOV_FILTER_CMD
-        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove
-        ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
-    )
-    # Generate HTML output
-    set(LCOV_GEN_HTML_CMD
-        ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o
-        ${Coverage_NAME} ${Coverage_NAME}.info
-    )
+  if(CODE_COVERAGE_VERBOSE)
+    message(STATUS "Executed command report")
+    message(STATUS "Command to clean up lcov: ")
+    string(REPLACE ";" " " LCOV_CLEAN_CMD_SPACED "${LCOV_CLEAN_CMD}")
+    message(STATUS "${LCOV_CLEAN_CMD_SPACED}")
+
+    message(STATUS "Command to create baseline: ")
+    string(REPLACE ";" " " LCOV_BASELINE_CMD_SPACED "${LCOV_BASELINE_CMD}")
+    message(STATUS "${LCOV_BASELINE_CMD_SPACED}")
+
+    message(STATUS "Command to run the tests: ")
+    string(REPLACE ";" " " LCOV_EXEC_TESTS_CMD_SPACED "${LCOV_EXEC_TESTS_CMD}")
+    message(STATUS "${LCOV_EXEC_TESTS_CMD_SPACED}")
+
+    message(STATUS "Command to capture counters and generate report: ")
+    string(REPLACE ";" " " LCOV_CAPTURE_CMD_SPACED "${LCOV_CAPTURE_CMD}")
+    message(STATUS "${LCOV_CAPTURE_CMD_SPACED}")
+
+    message(STATUS "Command to add baseline counters: ")
+    string(REPLACE ";" " " LCOV_BASELINE_COUNT_CMD_SPACED "${LCOV_BASELINE_COUNT_CMD}")
+    message(STATUS "${LCOV_BASELINE_COUNT_CMD_SPACED}")
+
+    message(STATUS "Command to filter collected data: ")
+    string(REPLACE ";" " " LCOV_FILTER_CMD_SPACED "${LCOV_FILTER_CMD}")
+    message(STATUS "${LCOV_FILTER_CMD_SPACED}")
+
+    message(STATUS "Command to generate lcov HTML output: ")
+    string(REPLACE ";" " " LCOV_GEN_HTML_CMD_SPACED "${LCOV_GEN_HTML_CMD}")
+    message(STATUS "${LCOV_GEN_HTML_CMD_SPACED}")
+
     if(${Coverage_SONARQUBE})
-        # Generate SonarQube output
-        set(GCOVR_XML_CMD
-            ${GCOVR_PATH} --sonarqube ${Coverage_NAME}_sonarqube.xml -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
-            ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR}
-        )
-        set(GCOVR_XML_CMD_COMMAND
-            COMMAND ${GCOVR_XML_CMD}
-        )
-        set(GCOVR_XML_CMD_BYPRODUCTS ${Coverage_NAME}_sonarqube.xml)
-        set(GCOVR_XML_CMD_COMMENT COMMENT "SonarQube code coverage info report saved in ${Coverage_NAME}_sonarqube.xml.")
+      message(STATUS "Command to generate SonarQube XML output: ")
+      string(REPLACE ";" " " GCOVR_XML_CMD_SPACED "${GCOVR_XML_CMD}")
+      message(STATUS "${GCOVR_XML_CMD_SPACED}")
     endif()
+  endif()
 
+  # Setup target
+  add_custom_target(
+    ${Coverage_NAME}
+    COMMAND ${LCOV_CLEAN_CMD}
+    COMMAND ${LCOV_BASELINE_CMD}
+    COMMAND ${LCOV_EXEC_TESTS_CMD}
+    COMMAND ${LCOV_CAPTURE_CMD}
+    COMMAND ${LCOV_BASELINE_COUNT_CMD}
+    COMMAND ${LCOV_FILTER_CMD}
+    COMMAND ${LCOV_GEN_HTML_CMD} ${GCOVR_XML_CMD_COMMAND}
+    # Set output files as GENERATED (will be removed on 'make clean')
+    BYPRODUCTS ${Coverage_NAME}.base ${Coverage_NAME}.capture ${Coverage_NAME}.total
+               ${Coverage_NAME}.info ${GCOVR_XML_CMD_BYPRODUCTS} ${Coverage_NAME}/index.html
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    DEPENDS ${Coverage_DEPENDENCIES}
+    VERBATIM # Protect arguments to commands
+    COMMENT
+      "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+  )
 
-    if(CODE_COVERAGE_VERBOSE)
-        message(STATUS "Executed command report")
-        message(STATUS "Command to clean up lcov: ")
-        string(REPLACE ";" " " LCOV_CLEAN_CMD_SPACED "${LCOV_CLEAN_CMD}")
-        message(STATUS "${LCOV_CLEAN_CMD_SPACED}")
+  # Show where to find the lcov info report
+  add_custom_command(
+    TARGET ${Coverage_NAME}
+    POST_BUILD
+    COMMAND ;
+    COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
+            ${GCOVR_XML_CMD_COMMENT})
 
-        message(STATUS "Command to create baseline: ")
-        string(REPLACE ";" " " LCOV_BASELINE_CMD_SPACED "${LCOV_BASELINE_CMD}")
-        message(STATUS "${LCOV_BASELINE_CMD_SPACED}")
-
-        message(STATUS "Command to run the tests: ")
-        string(REPLACE ";" " " LCOV_EXEC_TESTS_CMD_SPACED "${LCOV_EXEC_TESTS_CMD}")
-        message(STATUS "${LCOV_EXEC_TESTS_CMD_SPACED}")
-
-        message(STATUS "Command to capture counters and generate report: ")
-        string(REPLACE ";" " " LCOV_CAPTURE_CMD_SPACED "${LCOV_CAPTURE_CMD}")
-        message(STATUS "${LCOV_CAPTURE_CMD_SPACED}")
-
-        message(STATUS "Command to add baseline counters: ")
-        string(REPLACE ";" " " LCOV_BASELINE_COUNT_CMD_SPACED "${LCOV_BASELINE_COUNT_CMD}")
-        message(STATUS "${LCOV_BASELINE_COUNT_CMD_SPACED}")
-
-        message(STATUS "Command to filter collected data: ")
-        string(REPLACE ";" " " LCOV_FILTER_CMD_SPACED "${LCOV_FILTER_CMD}")
-        message(STATUS "${LCOV_FILTER_CMD_SPACED}")
-
-        message(STATUS "Command to generate lcov HTML output: ")
-        string(REPLACE ";" " " LCOV_GEN_HTML_CMD_SPACED "${LCOV_GEN_HTML_CMD}")
-        message(STATUS "${LCOV_GEN_HTML_CMD_SPACED}")
-
-        if(${Coverage_SONARQUBE})
-            message(STATUS "Command to generate SonarQube XML output: ")
-            string(REPLACE ";" " " GCOVR_XML_CMD_SPACED "${GCOVR_XML_CMD}")
-            message(STATUS "${GCOVR_XML_CMD_SPACED}")
-        endif()
-    endif()
-
-    # Setup target
-    add_custom_target(${Coverage_NAME}
-        COMMAND ${LCOV_CLEAN_CMD}
-        COMMAND ${LCOV_BASELINE_CMD}
-        COMMAND ${LCOV_EXEC_TESTS_CMD}
-        COMMAND ${LCOV_CAPTURE_CMD}
-        COMMAND ${LCOV_BASELINE_COUNT_CMD}
-        COMMAND ${LCOV_FILTER_CMD}
-        COMMAND ${LCOV_GEN_HTML_CMD}
-        ${GCOVR_XML_CMD_COMMAND}
-
-        # Set output files as GENERATED (will be removed on 'make clean')
-        BYPRODUCTS
-            ${Coverage_NAME}.base
-            ${Coverage_NAME}.capture
-            ${Coverage_NAME}.total
-            ${Coverage_NAME}.info
-            ${GCOVR_XML_CMD_BYPRODUCTS}
-            ${Coverage_NAME}/index.html
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-        DEPENDS ${Coverage_DEPENDENCIES}
-        VERBATIM # Protect arguments to commands
-        COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
-    )
-
-    # Show where to find the lcov info report
-    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
-        COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
-        ${GCOVR_XML_CMD_COMMENT}
-    )
-
-    # Show info where to find the report
-    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
-        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
-    )
+  # Show info where to find the report
+  add_custom_command(
+    TARGET ${Coverage_NAME}
+    POST_BUILD
+    COMMAND ;
+    COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report.")
 
 endfunction() # setup_target_for_coverage_lcov
 
@@ -415,78 +439,81 @@ endfunction() # setup_target_for_coverage_lcov
 # GCVOR command.
 function(setup_target_for_coverage_gcovr_xml)
 
-    set(options NONE)
-    set(oneValueArgs BASE_DIRECTORY NAME)
-    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
-    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  set(options NONE)
+  set(oneValueArgs BASE_DIRECTORY NAME)
+  set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+  cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if(NOT GCOVR_PATH)
-        message(FATAL_ERROR "gcovr not found! Aborting...")
-    endif() # NOT GCOVR_PATH
+  if(NOT GCOVR_PATH)
+    message(FATAL_ERROR "gcovr not found! Aborting...")
+  endif() # NOT GCOVR_PATH
 
-    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
-    if(DEFINED Coverage_BASE_DIRECTORY)
-        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
-    else()
-        set(BASEDIR ${PROJECT_SOURCE_DIR})
+  # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+  if(DEFINED Coverage_BASE_DIRECTORY)
+    get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+  else()
+    set(BASEDIR ${PROJECT_SOURCE_DIR})
+  endif()
+
+  # Collect excludes (CMake 3.4+: Also compute absolute paths)
+  set(GCOVR_EXCLUDES "")
+  foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+    if(CMAKE_VERSION VERSION_GREATER 3.4)
+      get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
     endif()
+    list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+  endforeach()
+  list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
 
-    # Collect excludes (CMake 3.4+: Also compute absolute paths)
-    set(GCOVR_EXCLUDES "")
-    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
-        if(CMAKE_VERSION VERSION_GREATER 3.4)
-            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
-        endif()
-        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
-    endforeach()
-    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+  # Combine excludes to several -e arguments
+  set(GCOVR_EXCLUDE_ARGS "")
+  foreach(EXCLUDE ${GCOVR_EXCLUDES})
+    list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+    list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
+  endforeach()
 
-    # Combine excludes to several -e arguments
-    set(GCOVR_EXCLUDE_ARGS "")
-    foreach(EXCLUDE ${GCOVR_EXCLUDES})
-        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
-        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
-    endforeach()
+  # Set up commands which will be run to generate coverage data
+  # Run tests
+  set(GCOVR_XML_EXEC_TESTS_CMD ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS})
+  # Running gcovr
+  set(GCOVR_XML_CMD
+      ${GCOVR_PATH}
+      --xml
+      ${Coverage_NAME}.xml
+      -r
+      ${BASEDIR}
+      ${GCOVR_ADDITIONAL_ARGS}
+      ${GCOVR_EXCLUDE_ARGS}
+      --object-directory=${PROJECT_BINARY_DIR})
 
-    # Set up commands which will be run to generate coverage data
-    # Run tests
-    set(GCOVR_XML_EXEC_TESTS_CMD
-        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
-    )
-    # Running gcovr
-    set(GCOVR_XML_CMD
-        ${GCOVR_PATH} --xml ${Coverage_NAME}.xml -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
-        ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR}
-    )
+  if(CODE_COVERAGE_VERBOSE)
+    message(STATUS "Executed command report")
 
-    if(CODE_COVERAGE_VERBOSE)
-        message(STATUS "Executed command report")
+    message(STATUS "Command to run tests: ")
+    string(REPLACE ";" " " GCOVR_XML_EXEC_TESTS_CMD_SPACED "${GCOVR_XML_EXEC_TESTS_CMD}")
+    message(STATUS "${GCOVR_XML_EXEC_TESTS_CMD_SPACED}")
 
-        message(STATUS "Command to run tests: ")
-        string(REPLACE ";" " " GCOVR_XML_EXEC_TESTS_CMD_SPACED "${GCOVR_XML_EXEC_TESTS_CMD}")
-        message(STATUS "${GCOVR_XML_EXEC_TESTS_CMD_SPACED}")
+    message(STATUS "Command to generate gcovr XML coverage data: ")
+    string(REPLACE ";" " " GCOVR_XML_CMD_SPACED "${GCOVR_XML_CMD}")
+    message(STATUS "${GCOVR_XML_CMD_SPACED}")
+  endif()
 
-        message(STATUS "Command to generate gcovr XML coverage data: ")
-        string(REPLACE ";" " " GCOVR_XML_CMD_SPACED "${GCOVR_XML_CMD}")
-        message(STATUS "${GCOVR_XML_CMD_SPACED}")
-    endif()
+  add_custom_target(
+    ${Coverage_NAME}
+    COMMAND ${GCOVR_XML_EXEC_TESTS_CMD}
+    COMMAND ${GCOVR_XML_CMD}
+    BYPRODUCTS ${Coverage_NAME}.xml
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    DEPENDS ${Coverage_DEPENDENCIES}
+    VERBATIM # Protect arguments to commands
+    COMMENT "Running gcovr to produce Cobertura code coverage report.")
 
-    add_custom_target(${Coverage_NAME}
-        COMMAND ${GCOVR_XML_EXEC_TESTS_CMD}
-        COMMAND ${GCOVR_XML_CMD}
-
-        BYPRODUCTS ${Coverage_NAME}.xml
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-        DEPENDS ${Coverage_DEPENDENCIES}
-        VERBATIM # Protect arguments to commands
-        COMMENT "Running gcovr to produce Cobertura code coverage report."
-    )
-
-    # Show info where to find the report
-    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
-        COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
-    )
+  # Show info where to find the report
+  add_custom_command(
+    TARGET ${Coverage_NAME}
+    POST_BUILD
+    COMMAND ;
+    COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml.")
 endfunction() # setup_target_for_coverage_gcovr_xml
 
 # Defines a target for running and collection code coverage information
@@ -507,87 +534,90 @@ endfunction() # setup_target_for_coverage_gcovr_xml
 # GCVOR command.
 function(setup_target_for_coverage_gcovr_html)
 
-    set(options NONE)
-    set(oneValueArgs BASE_DIRECTORY NAME)
-    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
-    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  set(options NONE)
+  set(oneValueArgs BASE_DIRECTORY NAME)
+  set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+  cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if(NOT GCOVR_PATH)
-        message(FATAL_ERROR "gcovr not found! Aborting...")
-    endif() # NOT GCOVR_PATH
+  if(NOT GCOVR_PATH)
+    message(FATAL_ERROR "gcovr not found! Aborting...")
+  endif() # NOT GCOVR_PATH
 
-    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
-    if(DEFINED Coverage_BASE_DIRECTORY)
-        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
-    else()
-        set(BASEDIR ${PROJECT_SOURCE_DIR})
+  # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+  if(DEFINED Coverage_BASE_DIRECTORY)
+    get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+  else()
+    set(BASEDIR ${PROJECT_SOURCE_DIR})
+  endif()
+
+  # Collect excludes (CMake 3.4+: Also compute absolute paths)
+  set(GCOVR_EXCLUDES "")
+  foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+    if(CMAKE_VERSION VERSION_GREATER 3.4)
+      get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
     endif()
+    list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+  endforeach()
+  list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
 
-    # Collect excludes (CMake 3.4+: Also compute absolute paths)
-    set(GCOVR_EXCLUDES "")
-    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
-        if(CMAKE_VERSION VERSION_GREATER 3.4)
-            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
-        endif()
-        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
-    endforeach()
-    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+  # Combine excludes to several -e arguments
+  set(GCOVR_EXCLUDE_ARGS "")
+  foreach(EXCLUDE ${GCOVR_EXCLUDES})
+    list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+    list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
+  endforeach()
 
-    # Combine excludes to several -e arguments
-    set(GCOVR_EXCLUDE_ARGS "")
-    foreach(EXCLUDE ${GCOVR_EXCLUDES})
-        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
-        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
-    endforeach()
+  # Set up commands which will be run to generate coverage data
+  # Run tests
+  set(GCOVR_HTML_EXEC_TESTS_CMD ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS})
+  # Create folder
+  set(GCOVR_HTML_FOLDER_CMD ${CMAKE_COMMAND} -E make_directory
+                            ${PROJECT_BINARY_DIR}/${Coverage_NAME})
+  # Running gcovr
+  set(GCOVR_HTML_CMD
+      ${GCOVR_PATH}
+      --html
+      ${Coverage_NAME}/index.html
+      --html-details
+      -r
+      ${BASEDIR}
+      ${GCOVR_ADDITIONAL_ARGS}
+      ${GCOVR_EXCLUDE_ARGS}
+      --object-directory=${PROJECT_BINARY_DIR})
 
-    # Set up commands which will be run to generate coverage data
-    # Run tests
-    set(GCOVR_HTML_EXEC_TESTS_CMD
-        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
-    )
-    # Create folder
-    set(GCOVR_HTML_FOLDER_CMD
-        ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/${Coverage_NAME}
-    )
-    # Running gcovr
-    set(GCOVR_HTML_CMD
-        ${GCOVR_PATH} --html ${Coverage_NAME}/index.html --html-details -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
-        ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR}
-    )
+  if(CODE_COVERAGE_VERBOSE)
+    message(STATUS "Executed command report")
 
-    if(CODE_COVERAGE_VERBOSE)
-        message(STATUS "Executed command report")
+    message(STATUS "Command to run tests: ")
+    string(REPLACE ";" " " GCOVR_HTML_EXEC_TESTS_CMD_SPACED "${GCOVR_HTML_EXEC_TESTS_CMD}")
+    message(STATUS "${GCOVR_HTML_EXEC_TESTS_CMD_SPACED}")
 
-        message(STATUS "Command to run tests: ")
-        string(REPLACE ";" " " GCOVR_HTML_EXEC_TESTS_CMD_SPACED "${GCOVR_HTML_EXEC_TESTS_CMD}")
-        message(STATUS "${GCOVR_HTML_EXEC_TESTS_CMD_SPACED}")
+    message(STATUS "Command to create a folder: ")
+    string(REPLACE ";" " " GCOVR_HTML_FOLDER_CMD_SPACED "${GCOVR_HTML_FOLDER_CMD}")
+    message(STATUS "${GCOVR_HTML_FOLDER_CMD_SPACED}")
 
-        message(STATUS "Command to create a folder: ")
-        string(REPLACE ";" " " GCOVR_HTML_FOLDER_CMD_SPACED "${GCOVR_HTML_FOLDER_CMD}")
-        message(STATUS "${GCOVR_HTML_FOLDER_CMD_SPACED}")
+    message(STATUS "Command to generate gcovr HTML coverage data: ")
+    string(REPLACE ";" " " GCOVR_HTML_CMD_SPACED "${GCOVR_HTML_CMD}")
+    message(STATUS "${GCOVR_HTML_CMD_SPACED}")
+  endif()
 
-        message(STATUS "Command to generate gcovr HTML coverage data: ")
-        string(REPLACE ";" " " GCOVR_HTML_CMD_SPACED "${GCOVR_HTML_CMD}")
-        message(STATUS "${GCOVR_HTML_CMD_SPACED}")
-    endif()
+  add_custom_target(
+    ${Coverage_NAME}
+    COMMAND ${GCOVR_HTML_EXEC_TESTS_CMD}
+    COMMAND ${GCOVR_HTML_FOLDER_CMD}
+    COMMAND ${GCOVR_HTML_CMD}
+    BYPRODUCTS ${PROJECT_BINARY_DIR}/${Coverage_NAME}/index.html # report directory
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    DEPENDS ${Coverage_DEPENDENCIES}
+    VERBATIM # Protect arguments to commands
+    COMMENT "Running gcovr to produce HTML code coverage report.")
 
-    add_custom_target(${Coverage_NAME}
-        COMMAND ${GCOVR_HTML_EXEC_TESTS_CMD}
-        COMMAND ${GCOVR_HTML_FOLDER_CMD}
-        COMMAND ${GCOVR_HTML_CMD}
-
-        BYPRODUCTS ${PROJECT_BINARY_DIR}/${Coverage_NAME}/index.html  # report directory
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-        DEPENDS ${Coverage_DEPENDENCIES}
-        VERBATIM # Protect arguments to commands
-        COMMENT "Running gcovr to produce HTML code coverage report."
-    )
-
-    # Show info where to find the report
-    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
-        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
-    )
+  # Show info where to find the report
+  add_custom_command(
+    TARGET ${Coverage_NAME}
+    POST_BUILD
+    COMMAND ;
+    COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report.")
 
 endfunction() # setup_target_for_coverage_gcovr_html
 
@@ -610,141 +640,162 @@ endfunction() # setup_target_for_coverage_gcovr_html
 # )
 function(setup_target_for_coverage_fastcov)
 
-    set(options NO_DEMANGLE SKIP_HTML)
-    set(oneValueArgs BASE_DIRECTORY NAME)
-    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES FASTCOV_ARGS GENHTML_ARGS POST_CMD)
-    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  set(options NO_DEMANGLE SKIP_HTML)
+  set(oneValueArgs BASE_DIRECTORY NAME)
+  set(multiValueArgs
+      EXCLUDE
+      EXECUTABLE
+      EXECUTABLE_ARGS
+      DEPENDENCIES
+      FASTCOV_ARGS
+      GENHTML_ARGS
+      POST_CMD)
+  cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if(NOT FASTCOV_PATH)
-        message(FATAL_ERROR "fastcov not found! Aborting...")
-    endif()
+  if(NOT FASTCOV_PATH)
+    message(FATAL_ERROR "fastcov not found! Aborting...")
+  endif()
 
-    if(NOT Coverage_SKIP_HTML AND NOT GENHTML_PATH)
-        message(FATAL_ERROR "genhtml not found! Aborting...")
-    endif()
+  if(NOT Coverage_SKIP_HTML AND NOT GENHTML_PATH)
+    message(FATAL_ERROR "genhtml not found! Aborting...")
+  endif()
 
-    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
-    if(Coverage_BASE_DIRECTORY)
-        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
-    else()
-        set(BASEDIR ${PROJECT_SOURCE_DIR})
-    endif()
+  # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+  if(Coverage_BASE_DIRECTORY)
+    get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+  else()
+    set(BASEDIR ${PROJECT_SOURCE_DIR})
+  endif()
 
-    # Collect excludes (Patterns, not paths, for fastcov)
-    set(FASTCOV_EXCLUDES "")
-    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_FASTCOV_EXCLUDES})
-        list(APPEND FASTCOV_EXCLUDES "${EXCLUDE}")
-    endforeach()
-    list(REMOVE_DUPLICATES FASTCOV_EXCLUDES)
+  # Collect excludes (Patterns, not paths, for fastcov)
+  set(FASTCOV_EXCLUDES "")
+  foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_FASTCOV_EXCLUDES})
+    list(APPEND FASTCOV_EXCLUDES "${EXCLUDE}")
+  endforeach()
+  list(REMOVE_DUPLICATES FASTCOV_EXCLUDES)
 
-    # Conditional arguments
-    if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
-        set(GENHTML_EXTRA_ARGS "--demangle-cpp")
-    endif()
+  # Conditional arguments
+  if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
+    set(GENHTML_EXTRA_ARGS "--demangle-cpp")
+  endif()
 
-    # Set up commands which will be run to generate coverage data
-    set(FASTCOV_EXEC_TESTS_CMD ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS})
+  # Set up commands which will be run to generate coverage data
+  set(FASTCOV_EXEC_TESTS_CMD ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS})
 
-    set(FASTCOV_CAPTURE_CMD ${FASTCOV_PATH} ${Coverage_FASTCOV_ARGS} --gcov ${GCOV_PATH}
-        --search-directory ${BASEDIR}
-        --process-gcno
-        --output ${Coverage_NAME}.json
-        --exclude ${FASTCOV_EXCLUDES}
-    )
+  set(FASTCOV_CAPTURE_CMD
+      ${FASTCOV_PATH}
+      ${Coverage_FASTCOV_ARGS}
+      --gcov
+      ${GCOV_PATH}
+      --search-directory
+      ${BASEDIR}
+      --process-gcno
+      --output
+      ${Coverage_NAME}.json
+      --exclude
+      ${FASTCOV_EXCLUDES})
 
-    set(FASTCOV_CONVERT_CMD ${FASTCOV_PATH}
-        -C ${Coverage_NAME}.json --lcov --output ${Coverage_NAME}.info
-    )
+  set(FASTCOV_CONVERT_CMD ${FASTCOV_PATH} -C ${Coverage_NAME}.json --lcov --output
+                          ${Coverage_NAME}.info)
 
-    if(Coverage_SKIP_HTML)
-        set(FASTCOV_HTML_CMD ";")
-    else()
-        set(FASTCOV_HTML_CMD ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS}
-            -o ${Coverage_NAME} ${Coverage_NAME}.info
-        )
-    endif()
+  if(Coverage_SKIP_HTML)
+    set(FASTCOV_HTML_CMD ";")
+  else()
+    set(FASTCOV_HTML_CMD ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o
+                         ${Coverage_NAME} ${Coverage_NAME}.info)
+  endif()
 
-    set(FASTCOV_POST_CMD ";")
-    if(Coverage_POST_CMD)
-        set(FASTCOV_POST_CMD ${Coverage_POST_CMD})
-    endif()
+  set(FASTCOV_POST_CMD ";")
+  if(Coverage_POST_CMD)
+    set(FASTCOV_POST_CMD ${Coverage_POST_CMD})
+  endif()
 
-    if(CODE_COVERAGE_VERBOSE)
-        message(STATUS "Code coverage commands for target ${Coverage_NAME} (fastcov):")
+  if(CODE_COVERAGE_VERBOSE)
+    message(STATUS "Code coverage commands for target ${Coverage_NAME} (fastcov):")
 
-        message("   Running tests:")
-        string(REPLACE ";" " " FASTCOV_EXEC_TESTS_CMD_SPACED "${FASTCOV_EXEC_TESTS_CMD}")
-        message("     ${FASTCOV_EXEC_TESTS_CMD_SPACED}")
+    message("   Running tests:")
+    string(REPLACE ";" " " FASTCOV_EXEC_TESTS_CMD_SPACED "${FASTCOV_EXEC_TESTS_CMD}")
+    message("     ${FASTCOV_EXEC_TESTS_CMD_SPACED}")
 
-        message("   Capturing fastcov counters and generating report:")
-        string(REPLACE ";" " " FASTCOV_CAPTURE_CMD_SPACED "${FASTCOV_CAPTURE_CMD}")
-        message("     ${FASTCOV_CAPTURE_CMD_SPACED}")
+    message("   Capturing fastcov counters and generating report:")
+    string(REPLACE ";" " " FASTCOV_CAPTURE_CMD_SPACED "${FASTCOV_CAPTURE_CMD}")
+    message("     ${FASTCOV_CAPTURE_CMD_SPACED}")
 
-        message("   Converting fastcov .json to lcov .info:")
-        string(REPLACE ";" " " FASTCOV_CONVERT_CMD_SPACED "${FASTCOV_CONVERT_CMD}")
-        message("     ${FASTCOV_CONVERT_CMD_SPACED}")
+    message("   Converting fastcov .json to lcov .info:")
+    string(REPLACE ";" " " FASTCOV_CONVERT_CMD_SPACED "${FASTCOV_CONVERT_CMD}")
+    message("     ${FASTCOV_CONVERT_CMD_SPACED}")
 
-        if(NOT Coverage_SKIP_HTML)
-            message("   Generating HTML report: ")
-            string(REPLACE ";" " " FASTCOV_HTML_CMD_SPACED "${FASTCOV_HTML_CMD}")
-            message("     ${FASTCOV_HTML_CMD_SPACED}")
-        endif()
-        if(Coverage_POST_CMD)
-            message("   Running post command: ")
-            string(REPLACE ";" " " FASTCOV_POST_CMD_SPACED "${FASTCOV_POST_CMD}")
-            message("     ${FASTCOV_POST_CMD_SPACED}")
-        endif()
-    endif()
-
-    # Setup target
-    add_custom_target(${Coverage_NAME}
-
-        # Cleanup fastcov
-        COMMAND ${FASTCOV_PATH} ${Coverage_FASTCOV_ARGS} --gcov ${GCOV_PATH}
-            --search-directory ${BASEDIR}
-            --zerocounters
-
-        COMMAND ${FASTCOV_EXEC_TESTS_CMD}
-        COMMAND ${FASTCOV_CAPTURE_CMD}
-        COMMAND ${FASTCOV_CONVERT_CMD}
-        COMMAND ${FASTCOV_HTML_CMD}
-        COMMAND ${FASTCOV_POST_CMD}
-
-        # Set output files as GENERATED (will be removed on 'make clean')
-        BYPRODUCTS
-             ${Coverage_NAME}.info
-             ${Coverage_NAME}.json
-             ${Coverage_NAME}/index.html  # report directory
-
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-        DEPENDS ${Coverage_DEPENDENCIES}
-        VERBATIM # Protect arguments to commands
-        COMMENT "Resetting code coverage counters to zero. Processing code coverage counters and generating report."
-    )
-
-    set(INFO_MSG "fastcov code coverage info report saved in ${Coverage_NAME}.info and ${Coverage_NAME}.json.")
     if(NOT Coverage_SKIP_HTML)
-        string(APPEND INFO_MSG " Open ${PROJECT_BINARY_DIR}/${Coverage_NAME}/index.html in your browser to view the coverage report.")
+      message("   Generating HTML report: ")
+      string(REPLACE ";" " " FASTCOV_HTML_CMD_SPACED "${FASTCOV_HTML_CMD}")
+      message("     ${FASTCOV_HTML_CMD_SPACED}")
     endif()
-    # Show where to find the fastcov info report
-    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E echo ${INFO_MSG}
+    if(Coverage_POST_CMD)
+      message("   Running post command: ")
+      string(REPLACE ";" " " FASTCOV_POST_CMD_SPACED "${FASTCOV_POST_CMD}")
+      message("     ${FASTCOV_POST_CMD_SPACED}")
+    endif()
+  endif()
+
+  # Setup target
+  add_custom_target(
+    ${Coverage_NAME}
+    # Cleanup fastcov
+    COMMAND ${FASTCOV_PATH} ${Coverage_FASTCOV_ARGS} --gcov ${GCOV_PATH} --search-directory
+            ${BASEDIR} --zerocounters
+    COMMAND ${FASTCOV_EXEC_TESTS_CMD}
+    COMMAND ${FASTCOV_CAPTURE_CMD}
+    COMMAND ${FASTCOV_CONVERT_CMD}
+    COMMAND ${FASTCOV_HTML_CMD}
+    COMMAND ${FASTCOV_POST_CMD}
+    # Set output files as GENERATED (will be removed on 'make clean')
+    BYPRODUCTS ${Coverage_NAME}.info ${Coverage_NAME}.json
+               ${Coverage_NAME}/index.html # report directory
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    DEPENDS ${Coverage_DEPENDENCIES}
+    VERBATIM # Protect arguments to commands
+    COMMENT
+      "Resetting code coverage counters to zero. Processing code coverage counters and generating report."
+  )
+
+  set(INFO_MSG
+      "fastcov code coverage info report saved in ${Coverage_NAME}.info and ${Coverage_NAME}.json."
+  )
+  if(NOT Coverage_SKIP_HTML)
+    string(
+      APPEND
+      INFO_MSG
+      " Open ${PROJECT_BINARY_DIR}/${Coverage_NAME}/index.html in your browser to view the coverage report."
     )
+  endif()
+  # Show where to find the fastcov info report
+  add_custom_command(
+    TARGET ${Coverage_NAME}
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo ${INFO_MSG})
 
 endfunction() # setup_target_for_coverage_fastcov
 
 function(append_coverage_compiler_flags)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
-    message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
+  set(CMAKE_C_FLAGS
+      "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}"
+      PARENT_SCOPE)
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}"
+      PARENT_SCOPE)
+  set(CMAKE_Fortran_FLAGS
+      "${CMAKE_Fortran_FLAGS} ${COVERAGE_COMPILER_FLAGS}"
+      PARENT_SCOPE)
+  message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
 endfunction() # append_coverage_compiler_flags
 
 # Setup coverage for specific library
 function(append_coverage_compiler_flags_to_target name)
-    separate_arguments(_flag_list NATIVE_COMMAND "${COVERAGE_COMPILER_FLAGS}")
-    target_compile_options(${name} PRIVATE ${_flag_list})
-    if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-        target_link_libraries(${name} PRIVATE gcov)
-    endif()
+  separate_arguments(_flag_list NATIVE_COMMAND "${COVERAGE_COMPILER_FLAGS}")
+  target_compile_options(${name} PRIVATE ${_flag_list})
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU"
+     OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+     OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(${name} PRIVATE gcov)
+  endif()
 endfunction()

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -41,21 +41,90 @@
 # 2017-06-02, Lars Bilke
 # - Merged with modified version from github.com/ufz/ogs
 #
+# 2019-05-06, Anatolii Kurotych
+# - Remove unnecessary --coverage flag
+#
+# 2019-12-13, FeRD (Frank Dana)
+# - Deprecate COVERAGE_LCOVR_EXCLUDES and COVERAGE_GCOVR_EXCLUDES lists in favor
+#   of tool-agnostic COVERAGE_EXCLUDES variable, or EXCLUDE setup arguments.
+# - CMake 3.4+: All excludes can be specified relative to BASE_DIRECTORY
+# - All setup functions: accept BASE_DIRECTORY, EXCLUDE list
+# - Set lcov basedir with -b argument
+# - Add automatic --demangle-cpp in lcovr, if 'c++filt' is available (can be
+#   overridden with NO_DEMANGLE option in setup_target_for_coverage_lcovr().)
+# - Delete output dir, .info file on 'make clean'
+# - Remove Python detection, since version mismatches will break gcovr
+# - Minor cleanup (lowercase function names, update examples...)
+#
+# 2019-12-19, FeRD (Frank Dana)
+# - Rename Lcov outputs, make filtered file canonical, fix cleanup for targets
+#
+# 2020-01-19, Bob Apthorpe
+# - Added gfortran support
+#
+# 2020-02-17, FeRD (Frank Dana)
+# - Make all add_custom_target()s VERBATIM to auto-escape wildcard characters
+#   in EXCLUDEs, and remove manual escaping from gcovr targets
+#
+# 2021-01-19, Robin Mueller
+# - Add CODE_COVERAGE_VERBOSE option which will allow to print out commands which are run
+# - Added the option for users to set the GCOVR_ADDITIONAL_ARGS variable to supply additional
+#   flags to the gcovr command
+#
+# 2020-05-04, Mihchael Davis
+#     - Add -fprofile-abs-path to make gcno files contain absolute paths
+#     - Fix BASE_DIRECTORY not working when defined
+#     - Change BYPRODUCT from folder to index.html to stop ninja from complaining about double defines
+#
+# 2021-05-10, Martin Stump
+#     - Check if the generator is multi-config before warning about non-Debug builds
+#
+# 2022-02-22, Marko Wehle
+#     - Change gcovr output from -o <filename> for --xml <filename> and --html <filename> output respectively.
+#       This will allow for Multiple Output Formats at the same time by making use of GCOVR_ADDITIONAL_ARGS, e.g. GCOVR_ADDITIONAL_ARGS "--txt".
+#
+# 2022-09-28, Sebastian Mueller
+#     - fix append_coverage_compiler_flags_to_target to correctly add flags
+#     - replace "-fprofile-arcs -ftest-coverage" with "--coverage" (equivalent)
 #
 # USAGE:
 #
 # 1. Copy this file into your cmake modules path.
 #
-# 2. Add the following line to your CMakeLists.txt:
+# 2. Add the following line to your CMakeLists.txt (best inside an if-condition
+#    using a CMake option() to enable it just optionally):
 #      include(CodeCoverage)
 #
-# 3. Append necessary compiler flags:
-#      APPEND_COVERAGE_COMPILER_FLAGS()
+# 3. Append necessary compiler flags for all supported source files:
+#      append_coverage_compiler_flags()
+#    Or for specific target:
+#      append_coverage_compiler_flags_to_target(YOUR_TARGET_NAME)
+#
+# 3.a (OPTIONAL) Set appropriate optimization flags, e.g. -O0, -O1 or -Og
 #
 # 4. If you need to exclude additional directories from the report, specify them
-#    using the COVERAGE_EXCLUDES variable before calling SETUP_TARGET_FOR_COVERAGE.
+#    using full paths in the COVERAGE_EXCLUDES variable before calling
+#    setup_target_for_coverage_*().
 #    Example:
-#      set(COVERAGE_EXCLUDES 'dir1/*' 'dir2/*')
+#      set(COVERAGE_EXCLUDES
+#          '${PROJECT_SOURCE_DIR}/src/dir1/*'
+#          '/path/to/my/src/dir2/*')
+#    Or, use the EXCLUDE argument to setup_target_for_coverage_*().
+#    Example:
+#      setup_target_for_coverage_lcov(
+#          NAME coverage
+#          EXECUTABLE testrunner
+#          EXCLUDE "${PROJECT_SOURCE_DIR}/src/dir1/*" "/path/to/my/src/dir2/*")
+#
+# 4.a NOTE: With CMake 3.4+, COVERAGE_EXCLUDES or EXCLUDE can also be set
+#     relative to the BASE_DIRECTORY (default: PROJECT_SOURCE_DIR)
+#     Example:
+#       set(COVERAGE_EXCLUDES "dir1/*")
+#       setup_target_for_coverage_gcovr_html(
+#           NAME coverage
+#           EXECUTABLE testrunner
+#           BASE_DIRECTORY "${PROJECT_SOURCE_DIR}/src"
+#           EXCLUDE "dir2/*")
 #
 # 5. Use the functions described below to create a custom make target which
 #    runs your test executable and produces a code coverage report.
@@ -68,52 +137,85 @@
 
 include(CMakeParseArguments)
 
+option(CODE_COVERAGE_VERBOSE "Verbose information" FALSE)
+
 # Check prereqs
-find_program(GCOV_PATH gcov)
-find_program(LCOV_PATH NAMES lcov lcov.bat lcov.exe lcov.perl)
-find_program(GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat)
-find_program(GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
-find_program(SIMPLE_PYTHON_EXECUTABLE python)
+find_program( GCOV_PATH gcov )
+find_program( LCOV_PATH  NAMES lcov lcov.bat lcov.exe lcov.perl)
+find_program( FASTCOV_PATH NAMES fastcov fastcov.py )
+find_program( GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat )
+find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
+find_program( CPPFILT_PATH NAMES c++filt )
 
 if(NOT GCOV_PATH)
-  message(FATAL_ERROR "gcov not found! Aborting...")
+    message(FATAL_ERROR "gcov not found! Aborting...")
 endif() # NOT GCOV_PATH
 
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
-  if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 3)
-    message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
+# Check supported compiler (Clang, GNU and Flang)
+get_property(LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+foreach(LANG ${LANGUAGES})
+  if("${CMAKE_${LANG}_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+    if("${CMAKE_${LANG}_COMPILER_VERSION}" VERSION_LESS 3)
+      message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
+    endif()
+  elseif(NOT "${CMAKE_${LANG}_COMPILER_ID}" MATCHES "GNU"
+         AND NOT "${CMAKE_${LANG}_COMPILER_ID}" MATCHES "(LLVM)?[Ff]lang")
+    message(FATAL_ERROR "Compiler is not GNU or Flang! Aborting...")
   endif()
-elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
-  message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
-endif()
+endforeach()
 
-set(COVERAGE_COMPILER_FLAGS
-    "-g -O0 --coverage -fprofile-arcs -ftest-coverage -fno-inline -fno-inline-small-functions -fno-default-inline -fno-elide-constructors"
+set(COVERAGE_COMPILER_FLAGS "-g --coverage"
     CACHE INTERNAL "")
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag(-fprofile-abs-path HAVE_cxx_fprofile_abs_path)
+    if(HAVE_cxx_fprofile_abs_path)
+        set(COVERAGE_CXX_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
+    endif()
+endif()
+if(CMAKE_C_COMPILER_ID MATCHES "(GNU|Clang)")
+    include(CheckCCompilerFlag)
+    check_c_compiler_flag(-fprofile-abs-path HAVE_c_fprofile_abs_path)
+    if(HAVE_c_fprofile_abs_path)
+        set(COVERAGE_C_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
+    endif()
+endif()
+
+set(CMAKE_Fortran_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
+    CACHE STRING "Flags used by the Fortran compiler during coverage builds."
+    FORCE )
 set(CMAKE_CXX_FLAGS_COVERAGE
     ${COVERAGE_COMPILER_FLAGS}
-    CACHE STRING "Flags used by the C++ compiler during coverage builds." FORCE)
+    CACHE STRING "Flags used by the C++ compiler during coverage builds."
+    FORCE )
 set(CMAKE_C_FLAGS_COVERAGE
     ${COVERAGE_COMPILER_FLAGS}
-    CACHE STRING "Flags used by the C compiler during coverage builds." FORCE)
+    CACHE STRING "Flags used by the C compiler during coverage builds."
+    FORCE )
 set(CMAKE_EXE_LINKER_FLAGS_COVERAGE
     ""
-    CACHE STRING "Flags used for linking binaries during coverage builds." FORCE)
+    CACHE STRING "Flags used for linking binaries during coverage builds."
+    FORCE )
 set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
     ""
-    CACHE STRING "Flags used by the shared libraries linker during coverage builds." FORCE)
-mark_as_advanced(CMAKE_CXX_FLAGS_COVERAGE CMAKE_C_FLAGS_COVERAGE CMAKE_EXE_LINKER_FLAGS_COVERAGE
-                 CMAKE_SHARED_LINKER_FLAGS_COVERAGE)
+    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
+    FORCE )
+mark_as_advanced(
+    CMAKE_Fortran_FLAGS_COVERAGE
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
 
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
-endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG))
+    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
+endif() # NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
 
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-  link_libraries(gcov)
-else()
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    link_libraries(gcov)
 endif()
 
 # Defines a target for running and collection code coverage information
@@ -121,123 +223,528 @@ endif()
 # NOTE! The executable should always have a ZERO as exit code otherwise
 # the coverage generation will not complete.
 #
-# SETUP_TARGET_FOR_COVERAGE(
+# setup_target_for_coverage_lcov(
 #     NAME testrunner_coverage                    # New target name
 #     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
 #     DEPENDENCIES testrunner                     # Dependencies to build first
+#     BASE_DIRECTORY "../"                        # Base directory for report
+#                                                 #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"           # Patterns to exclude (can be relative
+#                                                 #  to BASE_DIRECTORY, with CMake 3.4+)
+#     NO_DEMANGLE                                 # Don't demangle C++ symbols
+#                                                 #  even if c++filt is found
 # )
-function(SETUP_TARGET_FOR_COVERAGE)
+function(setup_target_for_coverage_lcov)
 
-  set(options NONE)
-  set(oneValueArgs NAME)
-  set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
-  cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    set(options NO_DEMANGLE SONARQUBE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  if(NOT LCOV_PATH)
-    message(FATAL_ERROR "lcov not found! Aborting...")
-  endif() # NOT LCOV_PATH
+    if(NOT LCOV_PATH)
+        message(FATAL_ERROR "lcov not found! Aborting...")
+    endif() # NOT LCOV_PATH
 
-  if(NOT GENHTML_PATH)
-    message(FATAL_ERROR "genhtml not found! Aborting...")
-  endif() # NOT GENHTML_PATH
+    if(NOT GENHTML_PATH)
+        message(FATAL_ERROR "genhtml not found! Aborting...")
+    endif() # NOT GENHTML_PATH
 
-  # Setup target
-  add_custom_target(
-    ${Coverage_NAME}
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(DEFINED Coverage_BASE_DIRECTORY)
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(LCOV_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_LCOV_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES LCOV_EXCLUDES)
+
+    # Conditional arguments
+    if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
+      set(GENHTML_EXTRA_ARGS "--demangle-cpp")
+    endif()
+
+    # Setting up commands which will be run to generate coverage data.
     # Cleanup lcov
-    COMMAND ${LCOV_PATH} --directory . --zerocounters
+    set(LCOV_CLEAN_CMD
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory .
+        -b ${BASEDIR} --zerocounters
+    )
     # Create baseline to make sure untouched files show up in the report
-    COMMAND ${LCOV_PATH} -c -i -d . -o ${Coverage_NAME}.base
+    set(LCOV_BASELINE_CMD
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b
+        ${BASEDIR} -o ${Coverage_NAME}.base
+    )
     # Run tests
-    COMMAND ${Coverage_EXECUTABLE}
+    set(LCOV_EXEC_TESTS_CMD
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+    )
     # Capturing lcov counters and generating report
-    COMMAND ${LCOV_PATH} --directory . --capture --output-file ${Coverage_NAME}.info
+    set(LCOV_CAPTURE_CMD
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b
+        ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
+    )
     # add baseline counters
-    COMMAND ${LCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file
+    set(LCOV_BASELINE_COUNT_CMD
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base
+        -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
+    )
+    # filter collected data to final coverage report
+    set(LCOV_FILTER_CMD
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove
+        ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
+    )
+    # Generate HTML output
+    set(LCOV_GEN_HTML_CMD
+        ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o
+        ${Coverage_NAME} ${Coverage_NAME}.info
+    )
+    if(${Coverage_SONARQUBE})
+        # Generate SonarQube output
+        set(GCOVR_XML_CMD
+            ${GCOVR_PATH} --sonarqube ${Coverage_NAME}_sonarqube.xml -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
+            ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR}
+        )
+        set(GCOVR_XML_CMD_COMMAND
+            COMMAND ${GCOVR_XML_CMD}
+        )
+        set(GCOVR_XML_CMD_BYPRODUCTS ${Coverage_NAME}_sonarqube.xml)
+        set(GCOVR_XML_CMD_COMMENT COMMENT "SonarQube code coverage info report saved in ${Coverage_NAME}_sonarqube.xml.")
+    endif()
+
+
+    if(CODE_COVERAGE_VERBOSE)
+        message(STATUS "Executed command report")
+        message(STATUS "Command to clean up lcov: ")
+        string(REPLACE ";" " " LCOV_CLEAN_CMD_SPACED "${LCOV_CLEAN_CMD}")
+        message(STATUS "${LCOV_CLEAN_CMD_SPACED}")
+
+        message(STATUS "Command to create baseline: ")
+        string(REPLACE ";" " " LCOV_BASELINE_CMD_SPACED "${LCOV_BASELINE_CMD}")
+        message(STATUS "${LCOV_BASELINE_CMD_SPACED}")
+
+        message(STATUS "Command to run the tests: ")
+        string(REPLACE ";" " " LCOV_EXEC_TESTS_CMD_SPACED "${LCOV_EXEC_TESTS_CMD}")
+        message(STATUS "${LCOV_EXEC_TESTS_CMD_SPACED}")
+
+        message(STATUS "Command to capture counters and generate report: ")
+        string(REPLACE ";" " " LCOV_CAPTURE_CMD_SPACED "${LCOV_CAPTURE_CMD}")
+        message(STATUS "${LCOV_CAPTURE_CMD_SPACED}")
+
+        message(STATUS "Command to add baseline counters: ")
+        string(REPLACE ";" " " LCOV_BASELINE_COUNT_CMD_SPACED "${LCOV_BASELINE_COUNT_CMD}")
+        message(STATUS "${LCOV_BASELINE_COUNT_CMD_SPACED}")
+
+        message(STATUS "Command to filter collected data: ")
+        string(REPLACE ";" " " LCOV_FILTER_CMD_SPACED "${LCOV_FILTER_CMD}")
+        message(STATUS "${LCOV_FILTER_CMD_SPACED}")
+
+        message(STATUS "Command to generate lcov HTML output: ")
+        string(REPLACE ";" " " LCOV_GEN_HTML_CMD_SPACED "${LCOV_GEN_HTML_CMD}")
+        message(STATUS "${LCOV_GEN_HTML_CMD_SPACED}")
+
+        if(${Coverage_SONARQUBE})
+            message(STATUS "Command to generate SonarQube XML output: ")
+            string(REPLACE ";" " " GCOVR_XML_CMD_SPACED "${GCOVR_XML_CMD}")
+            message(STATUS "${GCOVR_XML_CMD_SPACED}")
+        endif()
+    endif()
+
+    # Setup target
+    add_custom_target(${Coverage_NAME}
+        COMMAND ${LCOV_CLEAN_CMD}
+        COMMAND ${LCOV_BASELINE_CMD}
+        COMMAND ${LCOV_EXEC_TESTS_CMD}
+        COMMAND ${LCOV_CAPTURE_CMD}
+        COMMAND ${LCOV_BASELINE_COUNT_CMD}
+        COMMAND ${LCOV_FILTER_CMD}
+        COMMAND ${LCOV_GEN_HTML_CMD}
+        ${GCOVR_XML_CMD_COMMAND}
+
+        # Set output files as GENERATED (will be removed on 'make clean')
+        BYPRODUCTS
+            ${Coverage_NAME}.base
+            ${Coverage_NAME}.capture
             ${Coverage_NAME}.total
-    COMMAND ${LCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_EXCLUDES} --output-file
-            ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
-    COMMAND ${GENHTML_PATH} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
-    COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.total
-            ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-    DEPENDS ${Coverage_DEPENDENCIES}
-    COMMENT
-      "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
-  )
+            ${Coverage_NAME}.info
+            ${GCOVR_XML_CMD_BYPRODUCTS}
+            ${Coverage_NAME}/index.html
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+    )
 
-  # Show where to find the lcov info report
-  add_custom_command(
-    TARGET ${Coverage_NAME}
-    POST_BUILD
-    COMMAND ;
-    COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info.")
+    # Show where to find the lcov info report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
+        ${GCOVR_XML_CMD_COMMENT}
+    )
 
-  # Show info where to find the report
-  add_custom_command(
-    TARGET ${Coverage_NAME}
-    POST_BUILD
-    COMMAND ;
-    COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report.")
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+    )
 
-endfunction() # SETUP_TARGET_FOR_COVERAGE
+endfunction() # setup_target_for_coverage_lcov
 
 # Defines a target for running and collection code coverage information
 # Builds dependencies, runs the given executable and outputs reports.
 # NOTE! The executable should always have a ZERO as exit code otherwise
 # the coverage generation will not complete.
 #
-# SETUP_TARGET_FOR_COVERAGE_COBERTURA(
+# setup_target_for_coverage_gcovr_xml(
 #     NAME ctest_coverage                    # New target name
 #     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
 #     DEPENDENCIES executable_target         # Dependencies to build first
+#     BASE_DIRECTORY "../"                   # Base directory for report
+#                                            #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
+#                                            #  to BASE_DIRECTORY, with CMake 3.4+)
 # )
-function(SETUP_TARGET_FOR_COVERAGE_COBERTURA)
+# The user can set the variable GCOVR_ADDITIONAL_ARGS to supply additional flags to the
+# GCVOR command.
+function(setup_target_for_coverage_gcovr_xml)
 
-  set(options NONE)
-  set(oneValueArgs NAME)
-  set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
-  cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    set(options NONE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  if(NOT SIMPLE_PYTHON_EXECUTABLE)
-    message(FATAL_ERROR "python not found! Aborting...")
-  endif() # NOT SIMPLE_PYTHON_EXECUTABLE
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
 
-  if(NOT GCOVR_PATH)
-    message(FATAL_ERROR "gcovr not found! Aborting...")
-  endif() # NOT GCOVR_PATH
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(DEFINED Coverage_BASE_DIRECTORY)
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
 
-  # Combine excludes to several -e arguments
-  set(COBERTURA_EXCLUDES "")
-  foreach(EXCLUDE ${COVERAGE_EXCLUDES})
-    set(COBERTURA_EXCLUDES "-e ${EXCLUDE} ${COBERTURA_EXCLUDES}")
-  endforeach()
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(GCOVR_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
 
-  add_custom_target(
-    ${Coverage_NAME}
+    # Combine excludes to several -e arguments
+    set(GCOVR_EXCLUDE_ARGS "")
+    foreach(EXCLUDE ${GCOVR_EXCLUDES})
+        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
+    endforeach()
+
+    # Set up commands which will be run to generate coverage data
     # Run tests
-    ${Coverage_EXECUTABLE}
+    set(GCOVR_XML_EXEC_TESTS_CMD
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+    )
     # Running gcovr
-    COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} ${COBERTURA_EXCLUDES} -o ${Coverage_NAME}.xml
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-    DEPENDS ${Coverage_DEPENDENCIES}
-    COMMENT "Running gcovr to produce Cobertura code coverage report.")
+    set(GCOVR_XML_CMD
+        ${GCOVR_PATH} --xml ${Coverage_NAME}.xml -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
+        ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR}
+    )
 
-  # Show info where to find the report
-  add_custom_command(
-    TARGET ${Coverage_NAME}
-    POST_BUILD
-    COMMAND ;
-    COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml.")
+    if(CODE_COVERAGE_VERBOSE)
+        message(STATUS "Executed command report")
 
-endfunction() # SETUP_TARGET_FOR_COVERAGE_COBERTURA
+        message(STATUS "Command to run tests: ")
+        string(REPLACE ";" " " GCOVR_XML_EXEC_TESTS_CMD_SPACED "${GCOVR_XML_EXEC_TESTS_CMD}")
+        message(STATUS "${GCOVR_XML_EXEC_TESTS_CMD_SPACED}")
 
-function(APPEND_COVERAGE_COMPILER_FLAGS)
-  set(CMAKE_C_FLAGS
-      "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}"
-      PARENT_SCOPE)
-  set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}"
-      PARENT_SCOPE)
-  message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
-endfunction() # APPEND_COVERAGE_COMPILER_FLAGS
+        message(STATUS "Command to generate gcovr XML coverage data: ")
+        string(REPLACE ";" " " GCOVR_XML_CMD_SPACED "${GCOVR_XML_CMD}")
+        message(STATUS "${GCOVR_XML_CMD_SPACED}")
+    endif()
+
+    add_custom_target(${Coverage_NAME}
+        COMMAND ${GCOVR_XML_EXEC_TESTS_CMD}
+        COMMAND ${GCOVR_XML_CMD}
+
+        BYPRODUCTS ${Coverage_NAME}.xml
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Running gcovr to produce Cobertura code coverage report."
+    )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
+    )
+endfunction() # setup_target_for_coverage_gcovr_xml
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_gcovr_html(
+#     NAME ctest_coverage                    # New target name
+#     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES executable_target         # Dependencies to build first
+#     BASE_DIRECTORY "../"                   # Base directory for report
+#                                            #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
+#                                            #  to BASE_DIRECTORY, with CMake 3.4+)
+# )
+# The user can set the variable GCOVR_ADDITIONAL_ARGS to supply additional flags to the
+# GCVOR command.
+function(setup_target_for_coverage_gcovr_html)
+
+    set(options NONE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(DEFINED Coverage_BASE_DIRECTORY)
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(GCOVR_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+
+    # Combine excludes to several -e arguments
+    set(GCOVR_EXCLUDE_ARGS "")
+    foreach(EXCLUDE ${GCOVR_EXCLUDES})
+        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
+    endforeach()
+
+    # Set up commands which will be run to generate coverage data
+    # Run tests
+    set(GCOVR_HTML_EXEC_TESTS_CMD
+        ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+    )
+    # Create folder
+    set(GCOVR_HTML_FOLDER_CMD
+        ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/${Coverage_NAME}
+    )
+    # Running gcovr
+    set(GCOVR_HTML_CMD
+        ${GCOVR_PATH} --html ${Coverage_NAME}/index.html --html-details -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
+        ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR}
+    )
+
+    if(CODE_COVERAGE_VERBOSE)
+        message(STATUS "Executed command report")
+
+        message(STATUS "Command to run tests: ")
+        string(REPLACE ";" " " GCOVR_HTML_EXEC_TESTS_CMD_SPACED "${GCOVR_HTML_EXEC_TESTS_CMD}")
+        message(STATUS "${GCOVR_HTML_EXEC_TESTS_CMD_SPACED}")
+
+        message(STATUS "Command to create a folder: ")
+        string(REPLACE ";" " " GCOVR_HTML_FOLDER_CMD_SPACED "${GCOVR_HTML_FOLDER_CMD}")
+        message(STATUS "${GCOVR_HTML_FOLDER_CMD_SPACED}")
+
+        message(STATUS "Command to generate gcovr HTML coverage data: ")
+        string(REPLACE ";" " " GCOVR_HTML_CMD_SPACED "${GCOVR_HTML_CMD}")
+        message(STATUS "${GCOVR_HTML_CMD_SPACED}")
+    endif()
+
+    add_custom_target(${Coverage_NAME}
+        COMMAND ${GCOVR_HTML_EXEC_TESTS_CMD}
+        COMMAND ${GCOVR_HTML_FOLDER_CMD}
+        COMMAND ${GCOVR_HTML_CMD}
+
+        BYPRODUCTS ${PROJECT_BINARY_DIR}/${Coverage_NAME}/index.html  # report directory
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Running gcovr to produce HTML code coverage report."
+    )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+    )
+
+endfunction() # setup_target_for_coverage_gcovr_html
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_fastcov(
+#     NAME testrunner_coverage                    # New target name
+#     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES testrunner                     # Dependencies to build first
+#     BASE_DIRECTORY "../"                        # Base directory for report
+#                                                 #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/" "src/dir2/"             # Patterns to exclude.
+#     NO_DEMANGLE                                 # Don't demangle C++ symbols
+#                                                 #  even if c++filt is found
+#     SKIP_HTML                                   # Don't create html report
+#     POST_CMD perl -i -pe s!${PROJECT_SOURCE_DIR}/!!g ctest_coverage.json  # E.g. for stripping source dir from file paths
+# )
+function(setup_target_for_coverage_fastcov)
+
+    set(options NO_DEMANGLE SKIP_HTML)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES FASTCOV_ARGS GENHTML_ARGS POST_CMD)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT FASTCOV_PATH)
+        message(FATAL_ERROR "fastcov not found! Aborting...")
+    endif()
+
+    if(NOT Coverage_SKIP_HTML AND NOT GENHTML_PATH)
+        message(FATAL_ERROR "genhtml not found! Aborting...")
+    endif()
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(Coverage_BASE_DIRECTORY)
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (Patterns, not paths, for fastcov)
+    set(FASTCOV_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_FASTCOV_EXCLUDES})
+        list(APPEND FASTCOV_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES FASTCOV_EXCLUDES)
+
+    # Conditional arguments
+    if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
+        set(GENHTML_EXTRA_ARGS "--demangle-cpp")
+    endif()
+
+    # Set up commands which will be run to generate coverage data
+    set(FASTCOV_EXEC_TESTS_CMD ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS})
+
+    set(FASTCOV_CAPTURE_CMD ${FASTCOV_PATH} ${Coverage_FASTCOV_ARGS} --gcov ${GCOV_PATH}
+        --search-directory ${BASEDIR}
+        --process-gcno
+        --output ${Coverage_NAME}.json
+        --exclude ${FASTCOV_EXCLUDES}
+    )
+
+    set(FASTCOV_CONVERT_CMD ${FASTCOV_PATH}
+        -C ${Coverage_NAME}.json --lcov --output ${Coverage_NAME}.info
+    )
+
+    if(Coverage_SKIP_HTML)
+        set(FASTCOV_HTML_CMD ";")
+    else()
+        set(FASTCOV_HTML_CMD ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS}
+            -o ${Coverage_NAME} ${Coverage_NAME}.info
+        )
+    endif()
+
+    set(FASTCOV_POST_CMD ";")
+    if(Coverage_POST_CMD)
+        set(FASTCOV_POST_CMD ${Coverage_POST_CMD})
+    endif()
+
+    if(CODE_COVERAGE_VERBOSE)
+        message(STATUS "Code coverage commands for target ${Coverage_NAME} (fastcov):")
+
+        message("   Running tests:")
+        string(REPLACE ";" " " FASTCOV_EXEC_TESTS_CMD_SPACED "${FASTCOV_EXEC_TESTS_CMD}")
+        message("     ${FASTCOV_EXEC_TESTS_CMD_SPACED}")
+
+        message("   Capturing fastcov counters and generating report:")
+        string(REPLACE ";" " " FASTCOV_CAPTURE_CMD_SPACED "${FASTCOV_CAPTURE_CMD}")
+        message("     ${FASTCOV_CAPTURE_CMD_SPACED}")
+
+        message("   Converting fastcov .json to lcov .info:")
+        string(REPLACE ";" " " FASTCOV_CONVERT_CMD_SPACED "${FASTCOV_CONVERT_CMD}")
+        message("     ${FASTCOV_CONVERT_CMD_SPACED}")
+
+        if(NOT Coverage_SKIP_HTML)
+            message("   Generating HTML report: ")
+            string(REPLACE ";" " " FASTCOV_HTML_CMD_SPACED "${FASTCOV_HTML_CMD}")
+            message("     ${FASTCOV_HTML_CMD_SPACED}")
+        endif()
+        if(Coverage_POST_CMD)
+            message("   Running post command: ")
+            string(REPLACE ";" " " FASTCOV_POST_CMD_SPACED "${FASTCOV_POST_CMD}")
+            message("     ${FASTCOV_POST_CMD_SPACED}")
+        endif()
+    endif()
+
+    # Setup target
+    add_custom_target(${Coverage_NAME}
+
+        # Cleanup fastcov
+        COMMAND ${FASTCOV_PATH} ${Coverage_FASTCOV_ARGS} --gcov ${GCOV_PATH}
+            --search-directory ${BASEDIR}
+            --zerocounters
+
+        COMMAND ${FASTCOV_EXEC_TESTS_CMD}
+        COMMAND ${FASTCOV_CAPTURE_CMD}
+        COMMAND ${FASTCOV_CONVERT_CMD}
+        COMMAND ${FASTCOV_HTML_CMD}
+        COMMAND ${FASTCOV_POST_CMD}
+
+        # Set output files as GENERATED (will be removed on 'make clean')
+        BYPRODUCTS
+             ${Coverage_NAME}.info
+             ${Coverage_NAME}.json
+             ${Coverage_NAME}/index.html  # report directory
+
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        VERBATIM # Protect arguments to commands
+        COMMENT "Resetting code coverage counters to zero. Processing code coverage counters and generating report."
+    )
+
+    set(INFO_MSG "fastcov code coverage info report saved in ${Coverage_NAME}.info and ${Coverage_NAME}.json.")
+    if(NOT Coverage_SKIP_HTML)
+        string(APPEND INFO_MSG " Open ${PROJECT_BINARY_DIR}/${Coverage_NAME}/index.html in your browser to view the coverage report.")
+    endif()
+    # Show where to find the fastcov info report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo ${INFO_MSG}
+    )
+
+endfunction() # setup_target_for_coverage_fastcov
+
+function(append_coverage_compiler_flags)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
+endfunction() # append_coverage_compiler_flags
+
+# Setup coverage for specific library
+function(append_coverage_compiler_flags_to_target name)
+    separate_arguments(_flag_list NATIVE_COMMAND "${COVERAGE_COMPILER_FLAGS}")
+    target_compile_options(${name} PRIVATE ${_flag_list})
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+        target_link_libraries(${name} PRIVATE gcov)
+    endif()
+endfunction()

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -415,7 +415,7 @@ function(setup_target_for_coverage_lcov)
   add_custom_command(
     TARGET ${Coverage_NAME}
     POST_BUILD
-    COMMAND "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+    COMMAND ${CMAKE_COMMAND} -E echo "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
 )
 
 endfunction() # setup_target_for_coverage_lcov

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -394,19 +394,29 @@ function(setup_target_for_coverage_lcov)
     COMMAND ${LCOV_BASELINE_COUNT_CMD}
     COMMAND ${LCOV_FILTER_CMD}
     COMMAND ${LCOV_GEN_HTML_CMD} ${GCOVR_XML_CMD_COMMAND}
-    COMMAND ${CMAKE_COMMAND} -E echo "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
-    COMMAND ${CMAKE_COMMAND} -E echo "Lcov code coverage info report saved in ${Coverage_NAME}.info."
-    COMMAND ${CMAKE_COMMAND} -E echo  ${GCOVR_XML_CMD_COMMENT}
-    COMMAND ${CMAKE_COMMAND} -E echo "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     # Set output files as GENERATED (will be removed on 'make clean')
     BYPRODUCTS ${Coverage_NAME}.base ${Coverage_NAME}.capture ${Coverage_NAME}.total
                ${Coverage_NAME}.info ${GCOVR_XML_CMD_BYPRODUCTS} ${Coverage_NAME}/index.html
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     DEPENDS ${Coverage_DEPENDENCIES}
     VERBATIM # Protect arguments to commands
-    
-      
+    COMMENT
+      "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
   )
+
+  # Show where to find the lcov info report
+  add_custom_command(
+    TARGET ${Coverage_NAME}
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo "Lcov code coverage info report saved in ${Coverage_NAME}.info."
+    COMMENT ${GCOVR_XML_CMD_COMMENT})
+
+  # Show info where to find the report
+  add_custom_command(
+    TARGET ${Coverage_NAME}
+    POST_BUILD
+    COMMAND "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+)
 
 endfunction() # setup_target_for_coverage_lcov
 

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -165,7 +165,7 @@ foreach(LANG ${LANGUAGES})
 endforeach()
 
 set(COVERAGE_COMPILER_FLAGS
-    "-g --coverage"
+    "-g -O0 --coverage -fprofile-arcs -ftest-coverage -fno-inline -fno-inline-small-functions -fno-default-inline -fno-elide-constructors"
     CACHE INTERNAL "")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -408,15 +408,16 @@ function(setup_target_for_coverage_lcov)
   add_custom_command(
     TARGET ${Coverage_NAME}
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E echo "Lcov code coverage info report saved in ${Coverage_NAME}.info."
+    COMMAND ${CMAKE_COMMAND} -E echo
+            "Lcov code coverage info report saved in ${Coverage_NAME}.info."
     COMMENT ${GCOVR_XML_CMD_COMMENT})
 
   # Show info where to find the report
   add_custom_command(
     TARGET ${Coverage_NAME}
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E echo "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
-)
+    COMMAND ${CMAKE_COMMAND} -E echo
+            "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report.")
 
 endfunction() # setup_target_for_coverage_lcov
 

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -769,14 +769,17 @@ class Option : public OptionBase<Option> {
         try {
             add_result(val_str);
             // if trigger_on_result_ is set the callback already ran
-            if(run_callback_for_default_ && !trigger_on_result_) {
+            if (run_callback_for_default_ && !trigger_on_result_) {
                 run_callback();  // run callback sets the state, we need to reset it again
                 current_option_state_ = option_state::parsing;
-            } else {
+            }
+            else {
                 _validate_results(results_);
                 current_option_state_ = old_option_state;
             }
-        } catch(const CLI::Error &err) {
+        }
+        catch (const ValidationError& err)
+        {
             // this should be done
             results_ = std::move(old_results);
             current_option_state_ = old_option_state;
@@ -787,7 +790,20 @@ class Option : public OptionBase<Option> {
             }
 
             throw ValidationError(get_name(),
-                                  std::string("given default value does not pass validation :") + err.what());
+                std::string("given default value does not pass validation :") + err.what());
+        } catch(const ConversionError &err) {
+            // this should be done
+            results_ = std::move(old_results);
+            current_option_state_ = old_option_state;
+            
+             throw ConversionError(get_name(),
+                                  std::string("given default value(\"")+val_str+"\") produces an error : " + err.what());
+        }
+        catch (const CLI::Error&)
+        {
+            results_ = std::move(old_results);
+            current_option_state_ = old_option_state;
+            throw;
         }
         results_ = std::move(old_results);
         default_str_ = std::move(val_str);

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -769,27 +769,25 @@ class Option : public OptionBase<Option> {
         try {
             add_result(val_str);
             // if trigger_on_result_ is set the callback already ran
-            if (run_callback_for_default_ && !trigger_on_result_) {
+            if(run_callback_for_default_ && !trigger_on_result_) {
                 run_callback();  // run callback sets the state, we need to reset it again
                 current_option_state_ = option_state::parsing;
-            }
-            else {
+            } else {
                 _validate_results(results_);
                 current_option_state_ = old_option_state;
             }
-        }
-        catch(const CLI::Error &err) {
+        } catch(const CLI::Error &err) {
             // this should be done
             results_ = std::move(old_results);
             current_option_state_ = old_option_state;
-            //try an alternate way to convert
-            std::string alternate=detail::value_string(val);
-            if (!alternate.empty() && alternate != val_str)
-            {
+            // try an alternate way to convert
+            std::string alternate = detail::value_string(val);
+            if(!alternate.empty() && alternate != val_str) {
                 return default_val(alternate);
             }
-           
-            throw ValidationError(get_name(),std::string("given default value does not pass validation :")+err.what());
+
+            throw ValidationError(get_name(),
+                                  std::string("given default value does not pass validation :") + err.what());
         }
         results_ = std::move(old_results);
         default_str_ = std::move(val_str);

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -769,17 +769,14 @@ class Option : public OptionBase<Option> {
         try {
             add_result(val_str);
             // if trigger_on_result_ is set the callback already ran
-            if (run_callback_for_default_ && !trigger_on_result_) {
+            if(run_callback_for_default_ && !trigger_on_result_) {
                 run_callback();  // run callback sets the state, we need to reset it again
                 current_option_state_ = option_state::parsing;
-            }
-            else {
+            } else {
                 _validate_results(results_);
                 current_option_state_ = old_option_state;
             }
-        }
-        catch (const ValidationError& err)
-        {
+        } catch(const ValidationError &err) {
             // this should be done
             results_ = std::move(old_results);
             current_option_state_ = old_option_state;
@@ -790,17 +787,15 @@ class Option : public OptionBase<Option> {
             }
 
             throw ValidationError(get_name(),
-                std::string("given default value does not pass validation :") + err.what());
+                                  std::string("given default value does not pass validation :") + err.what());
         } catch(const ConversionError &err) {
             // this should be done
             results_ = std::move(old_results);
             current_option_state_ = old_option_state;
-            
-             throw ConversionError(get_name(),
-                                  std::string("given default value(\"")+val_str+"\") produces an error : " + err.what());
-        }
-        catch (const CLI::Error&)
-        {
+
+            throw ConversionError(
+                get_name(), std::string("given default value(\"") + val_str + "\") produces an error : " + err.what());
+        } catch(const CLI::Error &) {
             results_ = std::move(old_results);
             current_option_state_ = old_option_state;
             throw;

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -769,18 +769,27 @@ class Option : public OptionBase<Option> {
         try {
             add_result(val_str);
             // if trigger_on_result_ is set the callback already ran
-            if(run_callback_for_default_ && !trigger_on_result_) {
+            if (run_callback_for_default_ && !trigger_on_result_) {
                 run_callback();  // run callback sets the state, we need to reset it again
                 current_option_state_ = option_state::parsing;
-            } else {
+            }
+            else {
                 _validate_results(results_);
                 current_option_state_ = old_option_state;
             }
-        } catch(const CLI::Error &) {
+        }
+        catch(const CLI::Error &err) {
             // this should be done
             results_ = std::move(old_results);
             current_option_state_ = old_option_state;
-            throw;
+            //try an alternate way to convert
+            std::string alternate=detail::value_string(val);
+            if (!alternate.empty() && alternate != val_str)
+            {
+                return default_val(alternate);
+            }
+           
+            throw ValidationError(get_name(),std::string("given default value does not pass validation :")+err.what());
         }
         results_ = std::move(old_results);
         default_str_ = std::move(val_str);

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -346,7 +346,7 @@ std::string to_string(T &&value) {
 
 /// Convert an object to a string (streaming must be supported for that type)
 template <typename T,
-          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value &&
+          enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
                           is_ostreamable<T>::value,
                       detail::enabler> = detail::dummy>
 std::string to_string(T &&value) {
@@ -359,14 +359,14 @@ std::string to_string(T &&value) {
 
 /// Print tuple value string for tuples of size ==1
 template <typename T,
-          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value &&
+          enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
                           !is_ostreamable<T>::value && is_tuple_like<T>::value && type_count_base<T>::value == 1,
                       detail::enabler> = detail::dummy>
 inline std::string to_string(T &&value);
 
 /// Print tuple value string for tuples of size > 1
 template <typename T,
-          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value &&
+          enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
                           !is_ostreamable<T>::value && is_tuple_like<T>::value && type_count_base<T>::value >= 2,
                       detail::enabler> = detail::dummy>
 inline std::string to_string(T &&value);
@@ -374,8 +374,9 @@ inline std::string to_string(T &&value);
 /// If conversion is not supported, return an empty string (streaming is not supported for that type)
 template <
     typename T,
-    enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value && !is_ostreamable<T>::value &&
-                    !is_readable_container<typename std::remove_const<T>::type>::value && !is_tuple_like<T>::value,
+    enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
+                    !is_ostreamable<T>::value && !is_readable_container<typename std::remove_const<T>::type>::value &&
+                    !is_tuple_like<T>::value,
                 detail::enabler> = detail::dummy>
 inline std::string to_string(T &&) {
     return {};
@@ -383,8 +384,8 @@ inline std::string to_string(T &&) {
 
 /// convert a readable container to a string
 template <typename T,
-          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value && !is_ostreamable<T>::value &&
-                          is_readable_container<T>::value,
+          enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
+                          !is_ostreamable<T>::value && is_readable_container<T>::value,
                       detail::enabler> = detail::dummy>
 inline std::string to_string(T &&variable) {
     auto cval = variable.begin();
@@ -412,7 +413,7 @@ inline typename std::enable_if<(I < type_count_base<T>::value), std::string>::ty
 
 /// Print tuple value string for tuples of size ==1
 template <typename T,
-          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value &&
+          enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
                           !is_ostreamable<T>::value && is_tuple_like<T>::value && type_count_base<T>::value == 1,
                       detail::enabler>>
 inline std::string to_string(T &&value) {
@@ -421,7 +422,7 @@ inline std::string to_string(T &&value) {
 
 /// Print tuple value string for tuples of size > 1
 template <typename T,
-          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value &&
+          enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
                           !is_ostreamable<T>::value && is_tuple_like<T>::value && type_count_base<T>::value >= 2,
                       detail::enabler>>
 inline std::string to_string(T &&value) {

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -279,9 +279,8 @@ struct is_mutable_container<
 // check to see if an object is a mutable container (fail by default)
 template <typename T, typename _ = void> struct is_readable_container : std::false_type {};
 
-/// type trait to test if a type is a container meaning it has a value_type, it has an iterator, a clear, and an end
-/// methods and an insert function.  And for our purposes we exclude std::string and types that can be constructed from
-/// a std::string
+/// type trait to test if a type is a container meaning it has a value_type, it has an iterator, and an end
+/// method.
 template <typename T>
 struct is_readable_container<
     T,
@@ -323,7 +322,7 @@ struct type_count_base<T,
 /// the base tuple size
 template <typename T>
 struct type_count_base<T, typename std::enable_if<is_tuple_like<T>::value && !is_mutable_container<T>::value>::type> {
-    static constexpr int value{std::tuple_size<typename std::remove_reference<T>::type>::value};
+    static constexpr int value{std::tuple_size<typename std::decay<T>::type>::value};
 };
 
 /// Type count base for containers is the type_count_base of the individual element
@@ -341,13 +340,13 @@ auto to_string(T &&value) -> decltype(std::forward<T>(value)) {
 template <typename T,
           enable_if_t<std::is_constructible<std::string, T>::value && !std::is_convertible<T, std::string>::value,
                       detail::enabler> = detail::dummy>
-std::string to_string(const T &value) {
+std::string to_string(T &&value) {
     return std::string(value);  // NOLINT(google-readability-casting)
 }
 
 /// Convert an object to a string (streaming must be supported for that type)
 template <typename T,
-          enable_if_t<!std::is_convertible<std::string, T>::value && !std::is_constructible<std::string, T>::value &&
+          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value &&
                           is_ostreamable<T>::value,
                       detail::enabler> = detail::dummy>
 std::string to_string(T &&value) {
@@ -360,14 +359,14 @@ std::string to_string(T &&value) {
 
 /// Print tuple value string for tuples of size ==1
 template <typename T,
-          enable_if_t<!std::is_convertible<std::string, T>::value && !std::is_constructible<std::string, T>::value &&
+          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value &&
                           !is_ostreamable<T>::value && is_tuple_like<T>::value && type_count_base<T>::value == 1,
                       detail::enabler> = detail::dummy>
 inline std::string to_string(T &&value);
 
 /// Print tuple value string for tuples of size > 1
 template <typename T,
-          enable_if_t<!std::is_convertible<std::string, T>::value && !std::is_constructible<std::string, T>::value &&
+          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value &&
                           !is_ostreamable<T>::value && is_tuple_like<T>::value && type_count_base<T>::value >= 2,
                       detail::enabler> = detail::dummy>
 inline std::string to_string(T &&value);
@@ -375,7 +374,7 @@ inline std::string to_string(T &&value);
 /// If conversion is not supported, return an empty string (streaming is not supported for that type)
 template <
     typename T,
-    enable_if_t<!std::is_constructible<std::string, T>::value && !is_ostreamable<T>::value &&
+    enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value && !is_ostreamable<T>::value &&
                     !is_readable_container<typename std::remove_const<T>::type>::value && !is_tuple_like<T>::value,
                 detail::enabler> = detail::dummy>
 inline std::string to_string(T &&) {
@@ -384,7 +383,7 @@ inline std::string to_string(T &&) {
 
 /// convert a readable container to a string
 template <typename T,
-          enable_if_t<!std::is_constructible<std::string, T>::value && !is_ostreamable<T>::value &&
+          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value && !is_ostreamable<T>::value &&
                           is_readable_container<T>::value,
                       detail::enabler> = detail::dummy>
 inline std::string to_string(T &&variable) {
@@ -413,7 +412,7 @@ inline typename std::enable_if<(I < type_count_base<T>::value), std::string>::ty
 
 /// Print tuple value string for tuples of size ==1
 template <typename T,
-          enable_if_t<!std::is_convertible<std::string, T>::value && !std::is_constructible<std::string, T>::value &&
+          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value &&
                           !is_ostreamable<T>::value && is_tuple_like<T>::value && type_count_base<T>::value == 1,
                       detail::enabler>>
 inline std::string to_string(T &&value) {
@@ -422,7 +421,7 @@ inline std::string to_string(T &&value) {
 
 /// Print tuple value string for tuples of size > 1
 template <typename T,
-          enable_if_t<!std::is_convertible<std::string, T>::value && !std::is_constructible<std::string, T>::value &&
+          enable_if_t<!std::is_convertible<T,std::string>::value && !std::is_constructible<std::string, T>::value &&
                           !is_ostreamable<T>::value && is_tuple_like<T>::value && type_count_base<T>::value >= 2,
                       detail::enabler>>
 inline std::string to_string(T &&value) {

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -322,7 +322,7 @@ struct type_count_base<T,
 /// the base tuple size
 template <typename T>
 struct type_count_base<T, typename std::enable_if<is_tuple_like<T>::value && !is_mutable_container<T>::value>::type> {
-    static constexpr int value{std::tuple_size<typename std::decay<T>::type>::value};
+    static constexpr int value{std::tuple_size<typename std::decay<T>::type>::value}; // cppcheck-suppress unusedStructMember
 };
 
 /// Type count base for containers is the type_count_base of the individual element

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -322,8 +322,8 @@ struct type_count_base<T,
 /// the base tuple size
 template <typename T>
 struct type_count_base<T, typename std::enable_if<is_tuple_like<T>::value && !is_mutable_container<T>::value>::type> {
-    static constexpr int value{ // cppcheck-suppress unusedStructMember
-        std::tuple_size<typename std::decay<T>::type>::value};
+    static constexpr int value{// cppcheck-suppress unusedStructMember
+                               std::tuple_size<typename std::decay<T>::type>::value};
 };
 
 /// Type count base for containers is the type_count_base of the individual element

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -322,7 +322,8 @@ struct type_count_base<T,
 /// the base tuple size
 template <typename T>
 struct type_count_base<T, typename std::enable_if<is_tuple_like<T>::value && !is_mutable_container<T>::value>::type> {
-    static constexpr int value{std::tuple_size<typename std::decay<T>::type>::value}; // cppcheck-suppress unusedStructMember
+    static constexpr int value{
+        std::tuple_size<typename std::decay<T>::type>::value};  // cppcheck-suppress unusedStructMember
 };
 
 /// Type count base for containers is the type_count_base of the individual element

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -504,6 +504,19 @@ TEST_CASE_METHOD(TApp, "TupleDefault", "[app]") {
     CHECK(pr == pr2);
 }
 
+TEST_CASE_METHOD(TApp, "TupleDefaultSingle", "[app]") {
+    std::tuple<std::string> pr{"test_tuple"};
+    auto *opt = app.add_option("-i", pr)->expected(0, 1);
+    args = {"-i"};
+    run();
+    CHECK(app.count("-i") == 1u);
+
+    std::tuple<std::string> pr2{"total3"};
+    opt->default_val(pr2);
+    run();
+    CHECK(pr == pr2);
+}
+
 TEST_CASE_METHOD(TApp, "TupleComplex", "[app]") {
     std::tuple<double, std::string, int, std::pair<std::string, std::string>> pr{57.5, "test", 5, {"total", "total2"}};
     auto *opt = app.add_option("-i", pr)->expected(0, 4);

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -518,6 +518,12 @@ TEST_CASE_METHOD(TApp, "TupleComplex", "[app]") {
     CHECK(pr == pr2);
 }
 
+TEST_CASE_METHOD(TApp, "invalidDefault", "[app]") {
+    int pr{ 5 };
+    auto *opt=app.add_option("-i", pr)->expected(1)->multi_option_policy(CLI::MultiOptionPolicy::Throw)->delimiter(',')->force_callback();
+    CHECK_THROWS(opt->default_val("4,6,2,8"));
+}
+
 TEST_CASE_METHOD(TApp, "TogetherInt", "[app]") {
     int i{0};
     app.add_option("-i,--int", i);

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -519,8 +519,12 @@ TEST_CASE_METHOD(TApp, "TupleComplex", "[app]") {
 }
 
 TEST_CASE_METHOD(TApp, "invalidDefault", "[app]") {
-    int pr{ 5 };
-    auto *opt=app.add_option("-i", pr)->expected(1)->multi_option_policy(CLI::MultiOptionPolicy::Throw)->delimiter(',')->force_callback();
+    int pr{5};
+    auto *opt = app.add_option("-i", pr)
+                    ->expected(1)
+                    ->multi_option_policy(CLI::MultiOptionPolicy::Throw)
+                    ->delimiter(',')
+                    ->force_callback();
     CHECK_THROWS(opt->default_val("4,6,2,8"));
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -286,7 +286,7 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL Coverage)
   include(CodeCoverage)
-  setup_target_for_coverage(
+  setup_target_for_coverage_lcov(
     NAME
     CLI11_coverage
     EXECUTABLE

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -52,6 +52,12 @@ TEST_CASE("TypeTools: tuple", "[helpers]") {
 TEST_CASE("TypeTools: tuple_to_string", "[helpers]") {
     std::pair<double, std::string> p1{0.999, "kWh"};
     CHECK(CLI::detail::to_string(p1) == "[0.999,kWh]");
+
+    const std::tuple<std::string> t1{"kWh"};
+    CHECK(CLI::detail::to_string(t1) == "kWh");
+
+    const std::tuple<double> td{0.999};
+    CHECK(CLI::detail::to_string(td) == "0.999");
 }
 
 TEST_CASE("TypeTools: type_size", "[helpers]") {

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -120,7 +120,7 @@ TEST_CASE_METHOD(TApp, "EnumCheckedTransform", "[transform]") {
 // from to-mas-kral Issue #1086
 TEST_CASE_METHOD(TApp, "EnumCheckedTransformUint8", "[transform]") {
     enum class FooType : std::uint8_t { A, B };
-    auto type = FooType::A;
+    auto type = FooType::B;
 
     const std::map<std::string, FooType> foo_map{
         {"a", FooType::A},
@@ -129,7 +129,10 @@ TEST_CASE_METHOD(TApp, "EnumCheckedTransformUint8", "[transform]") {
 
     app.add_option("-f,--foo", type, "FooType")
         ->transform(CLI::CheckedTransformer(foo_map, CLI::ignore_case))
-        ->default_val(FooType::A);
+        ->default_val(FooType::A)->force_callback();
+
+    run();
+    CHECK(type==FooType::A);
 }
 
 // from jzakrzewski Issue #330

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -124,15 +124,16 @@ TEST_CASE_METHOD(TApp, "EnumCheckedTransformUint8", "[transform]") {
 
     const std::map<std::string, FooType> foo_map{
         {"a", FooType::A},
-        { "b", FooType::B },
+        {"b", FooType::B},
     };
 
     app.add_option("-f,--foo", type, "FooType")
         ->transform(CLI::CheckedTransformer(foo_map, CLI::ignore_case))
-        ->default_val(FooType::A)->force_callback();
+        ->default_val(FooType::A)
+        ->force_callback();
 
     run();
-    CHECK(type==FooType::A);
+    CHECK(type == FooType::A);
 }
 
 // from jzakrzewski Issue #330

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -117,6 +117,21 @@ TEST_CASE_METHOD(TApp, "EnumCheckedTransform", "[transform]") {
     CHECK_THROWS_AS(run(), CLI::ValidationError);
 }
 
+// from to-mas-kral Issue #1086
+TEST_CASE_METHOD(TApp, "EnumCheckedTransformUint8", "[transform]") {
+    enum class FooType : std::uint8_t { A, B };
+    auto type = FooType::A;
+
+    const std::map<std::string, FooType> foo_map{
+        {"a", FooType::A},
+        { "b", FooType::B },
+    };
+
+    app.add_option("-f,--foo", type, "FooType")
+        ->transform(CLI::CheckedTransformer(foo_map, CLI::ignore_case))
+        ->default_val(FooType::A);
+}
+
 // from jzakrzewski Issue #330
 TEST_CASE_METHOD(TApp, "EnumCheckedDefaultTransform", "[transform]") {
     enum class existing : std::int16_t { abort, overwrite, remove };


### PR DESCRIPTION
Fixes issue #1086.

In the default_val enums of uint8_t would read in as a string as they could be converted to a string.  This worked ok for normal values, but when a check was added for specific strings, it caused an error when the default_val was added.   This PR fixes the issue.  

The builder for coverage was updated to CMake 3.31 (by github),  this triggered an error in the coverage tool script.  This led to updating that script, which led to uncovering some missing coverage, which led to additional tests, which led to some issues around single element tuples support from #1081, which led to a few other issues that came up in the to_string operation and templates.   