### PR TITLE
fix: promoting uint8_t/int8_t to make it casting result printable

### DIFF
--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -776,18 +776,6 @@ class Option : public OptionBase<Option> {
                 _validate_results(results_);
                 current_option_state_ = old_option_state;
             }
-        } catch(const ValidationError &err) {
-            // this should be done
-            results_ = std::move(old_results);
-            current_option_state_ = old_option_state;
-            // try an alternate way to convert
-            std::string alternate = detail::value_string(val);
-            if(!alternate.empty() && alternate != val_str) {
-                return default_val(alternate);
-            }
-
-            throw ValidationError(get_name(),
-                                  std::string("given default value does not pass validation :") + err.what());
         } catch(const ConversionError &err) {
             // this should be done
             results_ = std::move(old_results);

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -33,7 +33,8 @@ namespace enums {
 template <typename T, typename = typename std::enable_if<std::is_enum<T>::value>::type>
 std::ostream &operator<<(std::ostream &in, const T &item) {
     // make sure this is out of the detail namespace otherwise it won't be found when needed
-    return in << static_cast<typename std::underlying_type<T>::type>(item);
+    // https://isocpp.org/wiki/faq/input-output#print-char-or-ptr-as-number
+    return in << +static_cast<typename std::underlying_type<T>::type>(item);
 }
 
 }  // namespace enums

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -38,6 +38,9 @@ TEST_CASE("TypeTools: Streaming", "[helpers]") {
 
     CHECK(std::string("string") == CLI::detail::to_string("string"));
     CHECK(std::string("string") == CLI::detail::to_string(std::string("string")));
+
+    enum class t1 : std::uint8_t { enum1, enum2 };
+    CHECK(CLI::detail::to_string(t1::enum1) == "0");
 }
 
 TEST_CASE("TypeTools: tuple", "[helpers]") {


### PR DESCRIPTION
The underlying type of uint8_t/int8_t is unsigned char and signed char, but IOStreams was specified to treat them just like char.

so promoting the casting value to get the expected value.