### PR TITLE
add tests and fixes for array options

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
     steps:
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: "3.7"
+          versionSpec: "3.11"
       - script: python3 -m pip install meson ninja
         displayName: install meson
       - script: mkdir tests/mesonTest/subprojects
@@ -140,6 +140,7 @@ jobs:
         clang3.4:
           containerImage: silkeh/clang:3.4
           cli11.std: 11
+          cli11.options: -DCLI11_WARNINGS_AS_ERRORS=OFF
         clang8:
           containerImage: silkeh/clang:8
           cli11.std: 14

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -219,6 +219,12 @@ add_cli_exe(modhelp modhelp.cpp)
 add_test(NAME modhelp COMMAND modhelp -a test -h)
 set_property(TEST modhelp PROPERTY PASS_REGULAR_EXPRESSION "Option -a string in help: test")
 
+if (CMAKE_CXX_STANDARD GREATER 16)
+    add_cli_exe(array_option array_option.cpp)
+    add_test(NAME array_option COMMAND array_option --a 1 2)
+    set_property(TEST array_option PROPERTY PASS_REGULAR_EXPRESSION "pass")
+    
+endif()
 add_subdirectory(subcom_in_files)
 add_test(NAME subcom_in_files COMMAND subcommand_main subcommand_a -f this.txt --with-foo)
 set_property(TEST subcom_in_files PROPERTY PASS_REGULAR_EXPRESSION "Working on file: this\.txt"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -219,11 +219,11 @@ add_cli_exe(modhelp modhelp.cpp)
 add_test(NAME modhelp COMMAND modhelp -a test -h)
 set_property(TEST modhelp PROPERTY PASS_REGULAR_EXPRESSION "Option -a string in help: test")
 
-if (CMAKE_CXX_STANDARD GREATER 16)
-    add_cli_exe(array_option array_option.cpp)
-    add_test(NAME array_option COMMAND array_option --a 1 2)
-    set_property(TEST array_option PROPERTY PASS_REGULAR_EXPRESSION "pass")
-    
+if(CMAKE_CXX_STANDARD GREATER 16)
+  add_cli_exe(array_option array_option.cpp)
+  add_test(NAME array_option COMMAND array_option --a 1 2)
+  set_property(TEST array_option PROPERTY PASS_REGULAR_EXPRESSION "pass")
+
 endif()
 add_subdirectory(subcom_in_files)
 add_test(NAME subcom_in_files COMMAND subcommand_main subcommand_a -f this.txt --with-foo)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -219,12 +219,10 @@ add_cli_exe(modhelp modhelp.cpp)
 add_test(NAME modhelp COMMAND modhelp -a test -h)
 set_property(TEST modhelp PROPERTY PASS_REGULAR_EXPRESSION "Option -a string in help: test")
 
-if(CMAKE_CXX_STANDARD GREATER 16)
-  add_cli_exe(array_option array_option.cpp)
-  add_test(NAME array_option COMMAND array_option --a 1 2)
-  set_property(TEST array_option PROPERTY PASS_REGULAR_EXPRESSION "pass")
+add_cli_exe(array_option array_option.cpp)
+add_test(NAME array_option COMMAND array_option --a 1 2)
+set_property(TEST array_option PROPERTY PASS_REGULAR_EXPRESSION "pass")
 
-endif()
 add_subdirectory(subcom_in_files)
 add_test(NAME subcom_in_files COMMAND subcommand_main subcommand_a -f this.txt --with-foo)
 set_property(TEST subcom_in_files PROPERTY PASS_REGULAR_EXPRESSION "Working on file: this\.txt"

--- a/examples/array_option.cpp
+++ b/examples/array_option.cpp
@@ -3,13 +3,12 @@
 #include <CLI/CLI.hpp>
 
 // from @gourin https://github.com/CLIUtils/CLI11/issues/1135
-int main(int argc, char** argv)
-{
-   std::array<int, 2> a{ 0, 1};
-   CLI::App app{"My app"};
-   app.add_option("--a", a, "an array")->capture_default_str();
-   app.parse(argc, argv);
+int main(int argc, char **argv) {
+    std::array<int, 2> a{0, 1};
+    CLI::App app{"My app"};
+    app.add_option("--a", a, "an array")->capture_default_str();
+    app.parse(argc, argv);
 
-    std::cout<<"pass\n";
+    std::cout << "pass\n";
     return 0;
 }

--- a/examples/array_option.cpp
+++ b/examples/array_option.cpp
@@ -1,0 +1,15 @@
+#include <array>
+
+#include <CLI/CLI.hpp>
+
+// from @gourin https://github.com/CLIUtils/CLI11/issues/1135
+int main(int argc, char** argv)
+{
+   std::array<int, 2> a{ 0, 1};
+   CLI::App app{"My app"};
+   app.add_option("--a", a, "an array")->capture_default_str();
+   app.parse(argc, argv);
+
+    std::cout<<"pass\n";
+    return 0;
+}

--- a/examples/array_option.cpp
+++ b/examples/array_option.cpp
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-// Code modified from @gourin https://github.com/CLIUtils/CLI11/issues/1135
+// Code modified from Loic Gouarin(https://github.com/gouarin) https://github.com/CLIUtils/CLI11/issues/1135
 
 #include <CLI/CLI.hpp>
 #include <array>

--- a/examples/array_option.cpp
+++ b/examples/array_option.cpp
@@ -1,8 +1,16 @@
-#include <array>
+// Copyright (c) 2017-2025, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
 
+// Code modified from @gourin https://github.com/CLIUtils/CLI11/issues/1135
+
+
+#include <array>
+#include <iostream>
 #include <CLI/CLI.hpp>
 
-// from @gourin https://github.com/CLIUtils/CLI11/issues/1135
 int main(int argc, char **argv) {
     std::array<int, 2> a{0, 1};
     CLI::App app{"My app"};

--- a/examples/array_option.cpp
+++ b/examples/array_option.cpp
@@ -6,10 +6,9 @@
 
 // Code modified from @gourin https://github.com/CLIUtils/CLI11/issues/1135
 
-
+#include <CLI/CLI.hpp>
 #include <array>
 #include <iostream>
-#include <CLI/CLI.hpp>
 
 int main(int argc, char **argv) {
     std::array<int, 2> a{0, 1};

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -387,7 +387,7 @@ inline std::string to_string(T &&) {
 /// convert a readable container to a string
 template <typename T,
           enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
-                          !is_ostreamable<T>::value && is_readable_container<T>::value,
+                          !is_ostreamable<T>::value && is_readable_container<T>::value && !is_tuple_like<T>::value,
                       detail::enabler> = detail::dummy>
 inline std::string to_string(T &&variable) {
     auto cval = variable.begin();

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -1497,7 +1497,7 @@ bool lexical_conversion(const std::vector<std ::string> &strings, AssignTo &outp
     using FirstType = typename std::remove_const<typename std::tuple_element<0, ConvertTo>::type>::type;
     using SecondType = typename std::tuple_element<1, ConvertTo>::type;
     FirstType v1;
-    SecondType v2;
+    SecondType v2{};
     bool retval = lexical_assign<FirstType, FirstType>(strings[0], v1);
     retval = retval && lexical_assign<SecondType, SecondType>((strings.size() > 1) ? strings[1] : std::string{}, v2);
     if(retval) {

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -27,6 +27,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <array>
 
 using Catch::literals::operator"" _a;
 
@@ -910,6 +911,51 @@ TEST_CASE_METHOD(TApp, "vectorPairTypeRange", "[optiontype]") {
     CHECK(custom_opt[1].second.empty());
     CHECK(-1 == custom_opt[2].first);
     CHECK("str4" == custom_opt[2].second);
+}
+
+TEST_CASE_METHOD(TApp, "ArrayTriple", "[optiontype]") {
+
+    using TY=std::array<int, 3>;
+    TY custom_opt;
+
+    app.add_option("posit", custom_opt);
+
+    args = {"12", "1","5"};
+
+    run();
+   CHECK(12 == custom_opt[0]);
+    CHECK(1 == custom_opt[1]);
+    CHECK(5 == custom_opt[2]);
+
+   // enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
+    //    !is_ostreamable<T>::value && is_tuple_like<T>::value && type_count_base<T>::value >= 2,
+     //   detail::enabler>>
+
+    CHECK(!std::is_convertible<TY,std::string>::value);
+    CHECK(!std::is_constructible<std::string,TY>::value);
+    CHECK(!CLI::detail::is_ostreamable<TY>::value);
+    auto ts=std::tuple_size<typename std::decay<TY>::type>::value;
+    CHECK(ts==3);
+    
+   auto vb= CLI::detail::type_count_base<TY>::value;
+   CHECK(vb>=2);
+   CHECK(!CLI::detail::is_complex<TY>::value);
+   CHECK(CLI::detail::is_tuple_like<TY>::value);
+}
+
+TEST_CASE_METHOD(TApp, "ArrayPair", "[optiontype]") {
+
+    using TY=std::array<int, 2>;
+    TY custom_opt;
+
+    app.add_option("posit", custom_opt);
+
+    args = {"12", "1"};
+
+    run();
+    CHECK(12 == custom_opt[0]);
+    CHECK(1 == custom_opt[1]);
+
 }
 
 // now with independent type sizes and expected this is possible

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -9,6 +9,7 @@
 #include "catch.hpp"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cmath>
 #include <complex>
@@ -27,7 +28,6 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <array>
 
 using Catch::literals::operator"" _a;
 
@@ -915,37 +915,37 @@ TEST_CASE_METHOD(TApp, "vectorPairTypeRange", "[optiontype]") {
 
 TEST_CASE_METHOD(TApp, "ArrayTriple", "[optiontype]") {
 
-    using TY=std::array<int, 3>;
+    using TY = std::array<int, 3>;
     TY custom_opt;
 
     app.add_option("posit", custom_opt);
 
-    args = {"12", "1","5"};
+    args = {"12", "1", "5"};
 
     run();
-   CHECK(12 == custom_opt[0]);
+    CHECK(12 == custom_opt[0]);
     CHECK(1 == custom_opt[1]);
     CHECK(5 == custom_opt[2]);
 
-   // enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
+    // enable_if_t<!std::is_convertible<T, std::string>::value && !std::is_constructible<std::string, T>::value &&
     //    !is_ostreamable<T>::value && is_tuple_like<T>::value && type_count_base<T>::value >= 2,
-     //   detail::enabler>>
+    //   detail::enabler>>
 
-    CHECK(!std::is_convertible<TY,std::string>::value);
-    CHECK(!std::is_constructible<std::string,TY>::value);
+    CHECK(!std::is_convertible<TY, std::string>::value);
+    CHECK(!std::is_constructible<std::string, TY>::value);
     CHECK(!CLI::detail::is_ostreamable<TY>::value);
-    auto ts=std::tuple_size<typename std::decay<TY>::type>::value;
-    CHECK(ts==3);
-    
-   auto vb= CLI::detail::type_count_base<TY>::value;
-   CHECK(vb>=2);
-   CHECK(!CLI::detail::is_complex<TY>::value);
-   CHECK(CLI::detail::is_tuple_like<TY>::value);
+    auto ts = std::tuple_size<typename std::decay<TY>::type>::value;
+    CHECK(ts == 3);
+
+    auto vb = CLI::detail::type_count_base<TY>::value;
+    CHECK(vb >= 2);
+    CHECK(!CLI::detail::is_complex<TY>::value);
+    CHECK(CLI::detail::is_tuple_like<TY>::value);
 }
 
 TEST_CASE_METHOD(TApp, "ArrayPair", "[optiontype]") {
 
-    using TY=std::array<int, 2>;
+    using TY = std::array<int, 2>;
     TY custom_opt;
 
     app.add_option("posit", custom_opt);
@@ -955,7 +955,6 @@ TEST_CASE_METHOD(TApp, "ArrayPair", "[optiontype]") {
     run();
     CHECK(12 == custom_opt[0]);
     CHECK(1 == custom_opt[1]);
-
 }
 
 // now with independent type sizes and expected this is possible


### PR DESCRIPTION
Fixes #1135.  Adds enable check to certain to_string functions as some std::array operations were ambiguous.  

The addition of the capability to convert tuples to strings created an ambiguity in the case std::array, which acts like a tuple and a container.   So it worked with the container conversion before, but could also work with the new tuple conversion.  And we didn't have any tests to catch this.   

This PR resolves the ambiguity, and adds some tests to check that array is handled well.
