### PR TITLE
Float parsing negative

### DIFF
--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1091,7 +1091,7 @@ CLI11_NODISCARD CLI11_INLINE detail::Classifier App::_recognize(const std::strin
         return detail::Classifier::LONG;
     if(detail::split_short(current, dummy1, dummy2)) {
         if((dummy1[0] >= '0' && dummy1[0] <= '9')||(dummy1[0]=='.'&&dummy2.size()>0&&(dummy2[0] >= '0' && dummy2[0] <= '9'))) {
-            //need to check if it looks like a number
+            //it looks like a number but check if it could be an option
             if(get_option_no_throw(std::string{'-', dummy1[0]}) == nullptr) {
                 return detail::Classifier::NONE;
             }

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1091,7 +1091,7 @@ CLI11_NODISCARD CLI11_INLINE detail::Classifier App::_recognize(const std::strin
         return detail::Classifier::LONG;
     if(detail::split_short(current, dummy1, dummy2)) {
         if((dummy1[0] >= '0' && dummy1[0] <= '9') ||
-           (dummy1[0] == '.' && dummy2.size() > 0 && (dummy2[0] >= '0' && dummy2[0] <= '9'))) {
+           (dummy1[0] == '.' && !dummy2.empty() && (dummy2[0] >= '0' && dummy2[0] <= '9'))) {
             // it looks like a number but check if it could be an option
             if(get_option_no_throw(std::string{'-', dummy1[0]}) == nullptr) {
                 return detail::Classifier::NONE;

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1090,8 +1090,9 @@ CLI11_NODISCARD CLI11_INLINE detail::Classifier App::_recognize(const std::strin
     if(detail::split_long(current, dummy1, dummy2))
         return detail::Classifier::LONG;
     if(detail::split_short(current, dummy1, dummy2)) {
-        if((dummy1[0] >= '0' && dummy1[0] <= '9')||(dummy1[0]=='.'&&dummy2.size()>0&&(dummy2[0] >= '0' && dummy2[0] <= '9'))) {
-            //it looks like a number but check if it could be an option
+        if((dummy1[0] >= '0' && dummy1[0] <= '9') ||
+           (dummy1[0] == '.' && dummy2.size() > 0 && (dummy2[0] >= '0' && dummy2[0] <= '9'))) {
+            // it looks like a number but check if it could be an option
             if(get_option_no_throw(std::string{'-', dummy1[0]}) == nullptr) {
                 return detail::Classifier::NONE;
             }

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1090,7 +1090,8 @@ CLI11_NODISCARD CLI11_INLINE detail::Classifier App::_recognize(const std::strin
     if(detail::split_long(current, dummy1, dummy2))
         return detail::Classifier::LONG;
     if(detail::split_short(current, dummy1, dummy2)) {
-        if(dummy1[0] >= '0' && dummy1[0] <= '9') {
+        if((dummy1[0] >= '0' && dummy1[0] <= '9')||(dummy1[0]=='.'&&dummy2.size()>0&&(dummy2[0] >= '0' && dummy2[0] <= '9'))) {
+            //need to check if it looks like a number
             if(get_option_no_throw(std::string{'-', dummy1[0]}) == nullptr) {
                 return detail::Classifier::NONE;
             }

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -829,10 +829,9 @@ TEST_CASE_METHOD(TApp, "doubleVector", "[optiontype]") {
 
     std::vector<double> custom_opt;
 
-    auto *opt = app.add_option("--fp", custom_opt);
+    app.add_option("--fp", custom_opt);
 
     args = {"--fp", "12.7", "1.5"};
-
     run();
     CHECK(12.7 == Approx(custom_opt[0]));
     CHECK(1.5 == Approx(custom_opt[1]));

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -231,6 +231,9 @@ static const std::map<std::string, double> testValuesDouble{
     {"-3.14159  ", -3.14159},
     {"+1.0", 1.0},
     {"-0.01", -0.01},
+    {"-.01", -0.01},
+    {"-.3251", -0.3251},
+    {"+.3251", 0.3251},
     {"5e22", 5e22},
     {" 5e22", 5e22},
     {" 5e22  ", 5e22},
@@ -819,6 +822,29 @@ TEST_CASE_METHOD(TApp, "floatPair", "[optiontype]") {
     run();
     CHECK(3.4f == Approx(custom_opt.first));
     CHECK(2.7f == Approx(custom_opt.second));
+}
+
+// now with tuple support this is possible
+TEST_CASE_METHOD(TApp, "doubleVector", "[optiontype]") {
+
+    std::vector<double> custom_opt;
+
+    auto *opt = app.add_option("--fp", custom_opt);
+
+    args = {"--fp", "12.7", "1.5"};
+
+    run();
+    CHECK(12.7 == Approx(custom_opt[0]));
+    CHECK(1.5 == Approx(custom_opt[1]));
+    args = {"--fp", "12.7", "-.5"};
+    run();
+    CHECK(12.7 == Approx(custom_opt[0]));
+    CHECK(-0.5 == Approx(custom_opt[1]));
+
+    args = {"--fp", "-.7", "+.5"};
+    run();
+    CHECK(-0.7 == Approx(custom_opt[0]));
+    CHECK(0.5 == Approx(custom_opt[1]));
 }
 
 // now with independent type sizes and expected this is possible


### PR DESCRIPTION
Fixes #1139 
Fix a bug relating to parsing negative floating point values with no zero before decimal point in a context where an option could be possible.   