### PR TITLE
add flags on the formatter to disable formatting 

### DIFF
--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -56,6 +56,10 @@ class FormatterBase {
     /// The width of the footer paragraph
     std::size_t footer_paragraph_width_{80};
 
+    /// options controlling formatting for footer and descriptions
+    bool enable_description_formatting_{true};
+    bool enable_footer_formatting_{true};
+
     /// @brief The required help printout labels (user changeable)
     /// Values are Needs, Excludes, etc.
     std::map<std::string, std::string> labels_{};
@@ -81,7 +85,7 @@ class FormatterBase {
     /// @name Setters
     ///@{
 
-    /// Set the "REQUIRED" label
+    /// Set the "REQUIRED" or other labels
     void label(std::string key, std::string val) { labels_[key] = val; }
 
     /// Set the left column width (options/flags/subcommands)
@@ -95,7 +99,10 @@ class FormatterBase {
 
     /// Set the footer paragraph width
     void footer_paragraph_width(std::size_t val) { footer_paragraph_width_ = val; }
-
+    /// enable formatting for description paragraph
+    void enable_description_formatting(bool value=true){enable_description_formatting_=value;}
+    /// disable formatting for footer paragraph
+    void enable_footer_formatting(bool value=true){enable_footer_formatting_=value;}
     ///@}
     /// @name Getters
     ///@{
@@ -118,6 +125,13 @@ class FormatterBase {
 
     /// Get the current footer paragraph width
     CLI11_NODISCARD std::size_t get_footer_paragraph_width() const { return footer_paragraph_width_; }
+
+
+    /// Get the current status of description paragraph formatting
+    CLI11_NODISCARD bool is_description_paragraph_formatting_enabled() const { return enable_description_formatting_; }
+
+    /// Get the current status of whether footer paragraph formatting is enabled
+    CLI11_NODISCARD std::size_t is_footer_paragraph_formatting_enabled() const { return enable_footer_formatting_; }
 
     ///@}
 };

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -100,9 +100,9 @@ class FormatterBase {
     /// Set the footer paragraph width
     void footer_paragraph_width(std::size_t val) { footer_paragraph_width_ = val; }
     /// enable formatting for description paragraph
-    void enable_description_formatting(bool value=true){enable_description_formatting_=value;}
+    void enable_description_formatting(bool value = true) { enable_description_formatting_ = value; }
     /// disable formatting for footer paragraph
-    void enable_footer_formatting(bool value=true){enable_footer_formatting_=value;}
+    void enable_footer_formatting(bool value = true) { enable_footer_formatting_ = value; }
     ///@}
     /// @name Getters
     ///@{
@@ -125,7 +125,6 @@ class FormatterBase {
 
     /// Get the current footer paragraph width
     CLI11_NODISCARD std::size_t get_footer_paragraph_width() const { return footer_paragraph_width_; }
-
 
     /// Get the current status of description paragraph formatting
     CLI11_NODISCARD bool is_description_paragraph_formatting_enabled() const { return enable_description_formatting_; }

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -130,7 +130,7 @@ class FormatterBase {
     CLI11_NODISCARD bool is_description_paragraph_formatting_enabled() const { return enable_description_formatting_; }
 
     /// Get the current status of whether footer paragraph formatting is enabled
-    CLI11_NODISCARD std::size_t is_footer_paragraph_formatting_enabled() const { return enable_footer_formatting_; }
+    CLI11_NODISCARD bool is_footer_paragraph_formatting_enabled() const { return enable_footer_formatting_; }
 
     ///@}
 };

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -163,26 +163,20 @@ CLI11_INLINE std::string Formatter::make_help(const App *app, std::string name, 
             out << app->get_group() << ':';
         }
     }
-    if (is_description_paragraph_formatting_enabled())
-    {
+    if(is_description_paragraph_formatting_enabled()) {
         detail::streamOutAsParagraph(
             out, make_description(app), description_paragraph_width_, "");  // Format description as paragraph
-    }
-    else
-    {
-        out<<make_description(app)<<'\n';
+    } else {
+        out << make_description(app) << '\n';
     }
     out << make_usage(app, name);
     out << make_positionals(app);
     out << make_groups(app, mode);
     out << make_subcommands(app, mode);
-    if (is_footer_paragraph_formatting_enabled())
-    {
+    if(is_footer_paragraph_formatting_enabled()) {
         detail::streamOutAsParagraph(out, make_footer(app), footer_paragraph_width_);  // Format footer as paragraph
-    }
-    else
-    {
-        out<<make_footer(app)<<'\n';
+    } else {
+        out << make_footer(app) << '\n';
     }
 
     return out.str();
@@ -245,17 +239,12 @@ CLI11_INLINE std::string Formatter::make_expanded(const App *sub, AppFormatMode 
     std::stringstream out;
     out << sub->get_display_name(true) << '\n';
 
-    if (is_description_paragraph_formatting_enabled())
-    {
+    if(is_description_paragraph_formatting_enabled()) {
         detail::streamOutAsParagraph(
             out, make_description(sub), description_paragraph_width_, "  ");  // Format description as paragraph
+    } else {
+        out << make_description(sub) << '\n';
     }
-    else
-    {
-        out<<make_description(sub)<<'\n';
-    }
-
-    
 
     if(sub->get_name().empty() && !sub->get_aliases().empty()) {
         detail::format_aliases(out, sub->get_aliases(), column_width_ + 2);
@@ -264,13 +253,10 @@ CLI11_INLINE std::string Formatter::make_expanded(const App *sub, AppFormatMode 
     out << make_positionals(sub);
     out << make_groups(sub, mode);
     out << make_subcommands(sub, mode);
-    if (is_footer_paragraph_formatting_enabled())
-    {
+    if(is_footer_paragraph_formatting_enabled()) {
         detail::streamOutAsParagraph(out, make_footer(sub), footer_paragraph_width_);  // Format footer as paragraph
-    }
-    else
-    {
-        out<<make_footer(sub)<<'\n';
+    } else {
+        out << make_footer(sub) << '\n';
     }
     out << '\n';
     return out.str();

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -163,14 +163,27 @@ CLI11_INLINE std::string Formatter::make_help(const App *app, std::string name, 
             out << app->get_group() << ':';
         }
     }
-
-    detail::streamOutAsParagraph(
-        out, make_description(app), description_paragraph_width_, "");  // Format description as paragraph
+    if (is_description_paragraph_formatting_enabled())
+    {
+        detail::streamOutAsParagraph(
+            out, make_description(app), description_paragraph_width_, "");  // Format description as paragraph
+    }
+    else
+    {
+        out<<make_description(app)<<'\n';
+    }
     out << make_usage(app, name);
     out << make_positionals(app);
     out << make_groups(app, mode);
     out << make_subcommands(app, mode);
-    detail::streamOutAsParagraph(out, make_footer(app), footer_paragraph_width_);  // Format footer as paragraph
+    if (is_footer_paragraph_formatting_enabled())
+    {
+        detail::streamOutAsParagraph(out, make_footer(app), footer_paragraph_width_);  // Format footer as paragraph
+    }
+    else
+    {
+        out<<make_footer(app)<<'\n';
+    }
 
     return out.str();
 }
@@ -232,8 +245,17 @@ CLI11_INLINE std::string Formatter::make_expanded(const App *sub, AppFormatMode 
     std::stringstream out;
     out << sub->get_display_name(true) << '\n';
 
-    detail::streamOutAsParagraph(
-        out, make_description(sub), description_paragraph_width_, "  ");  // Format description as paragraph
+    if (is_description_paragraph_formatting_enabled())
+    {
+        detail::streamOutAsParagraph(
+            out, make_description(sub), description_paragraph_width_, "  ");  // Format description as paragraph
+    }
+    else
+    {
+        out<<make_description(sub)<<'\n';
+    }
+
+    
 
     if(sub->get_name().empty() && !sub->get_aliases().empty()) {
         detail::format_aliases(out, sub->get_aliases(), column_width_ + 2);
@@ -242,8 +264,14 @@ CLI11_INLINE std::string Formatter::make_expanded(const App *sub, AppFormatMode 
     out << make_positionals(sub);
     out << make_groups(sub, mode);
     out << make_subcommands(sub, mode);
-    detail::streamOutAsParagraph(out, make_footer(sub), footer_paragraph_width_);  // Format footer as paragraph
-
+    if (is_footer_paragraph_formatting_enabled())
+    {
+        detail::streamOutAsParagraph(out, make_footer(sub), footer_paragraph_width_);  // Format footer as paragraph
+    }
+    else
+    {
+        out<<make_footer(sub)<<'\n';
+    }
     out << '\n';
     return out.str();
 }

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -195,3 +195,42 @@ TEST_CASE("Formatter: NamelessSubInGroup", "[formatter]") {
     CHECK_THAT(help, Contains("sub2"));
     CHECK(help.find("pos") == std::string::npos);
 }
+
+
+TEST_CASE("Formatter: Footer", "[formatter]") {
+    CLI::App app{"My prog"};
+    std::string footer_string{"this is       a test of the footer systemsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss to  Pr e  s  e  r  v  e  SPA C ES"};
+    app.footer(footer_string);
+    app.add_flag("--option", "MyFlag");
+    int val{0};
+   app.get_formatter()->footer_paragraph_width(50);
+   app.get_formatter()->enable_footer_formatting(false);
+    std::string help = app.help("", CLI::AppFormatMode::Normal);
+    CHECK_THAT(help, Contains("is       a"));
+    CHECK_THAT(help, Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
+    CHECK_THAT(help, Contains(footer_string));
+    app.get_formatter()->enable_footer_formatting(true);
+    help = app.help("", CLI::AppFormatMode::Normal);
+    CHECK_THAT(help, !Contains("is       a"));
+    CHECK_THAT(help, !Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
+    CHECK_THAT(help, !Contains(footer_string));
+}
+
+TEST_CASE("Formatter: Description", "[formatter]") {
+    CLI::App app{"My prog"};
+    std::string desc_string{"this is       a test of the footer systemsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss to  Pr e  s  e  r  v  e  SPA C ES"};
+    app.description(desc_string);
+    app.add_flag("--option", "MyFlag");
+    int val{0};
+    app.get_formatter()->description_paragraph_width(50);
+    app.get_formatter()->enable_description_formatting(false);
+    std::string help = app.help("", CLI::AppFormatMode::Normal);
+    CHECK_THAT(help, Contains("is       a"));
+    CHECK_THAT(help, Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
+    CHECK_THAT(help, Contains(desc_string));
+    app.get_formatter()->enable_description_formatting(true);
+    help = app.help("", CLI::AppFormatMode::Normal);
+    CHECK_THAT(help, !Contains("is       a"));
+    CHECK_THAT(help, !Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
+    CHECK_THAT(help, !Contains(desc_string));
+}

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -205,11 +205,13 @@ TEST_CASE("Formatter: Footer", "[formatter]") {
     app.add_flag("--option", "MyFlag");
     app.get_formatter()->footer_paragraph_width(50);
     app.get_formatter()->enable_footer_formatting(false);
+    CHECK(!app.get_formatter()->is_footer_paragraph_formatting_enabled());
     std::string help = app.help("", CLI::AppFormatMode::Normal);
     CHECK_THAT(help, Contains("is       a"));
     CHECK_THAT(help, Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
     CHECK_THAT(help, Contains(footer_string));
     app.get_formatter()->enable_footer_formatting(true);
+    CHECK(app.get_formatter()->is_footer_paragraph_formatting_enabled());
     help = app.help("", CLI::AppFormatMode::Normal);
     CHECK_THAT(help, !Contains("is       a"));
     CHECK_THAT(help, !Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
@@ -225,11 +227,13 @@ TEST_CASE("Formatter: Description", "[formatter]") {
     app.add_flag("--option", "MyFlag");
     app.get_formatter()->description_paragraph_width(50);
     app.get_formatter()->enable_description_formatting(false);
+    CHECK(!app.get_formatter()->is_description_paragraph_formatting_enabled());
     std::string help = app.help("", CLI::AppFormatMode::Normal);
     CHECK_THAT(help, Contains("is       a"));
     CHECK_THAT(help, Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
     CHECK_THAT(help, Contains(desc_string));
     app.get_formatter()->enable_description_formatting(true);
+    CHECK(app.get_formatter()->is_description_paragraph_formatting_enabled());
     help = app.help("", CLI::AppFormatMode::Normal);
     CHECK_THAT(help, !Contains("is       a"));
     CHECK_THAT(help, !Contains("to  Pr e  s  e  r  v  e  SPA C ES"));

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -196,15 +196,16 @@ TEST_CASE("Formatter: NamelessSubInGroup", "[formatter]") {
     CHECK(help.find("pos") == std::string::npos);
 }
 
-
 TEST_CASE("Formatter: Footer", "[formatter]") {
     CLI::App app{"My prog"};
-    std::string footer_string{"this is       a test of the footer systemsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss to  Pr e  s  e  r  v  e  SPA C ES"};
+    std::string footer_string{"this is       a test of the footer "
+                              "systemsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss to  Pr e  s "
+                              " e  r  v  e  SPA C ES"};
     app.footer(footer_string);
     app.add_flag("--option", "MyFlag");
     int val{0};
-   app.get_formatter()->footer_paragraph_width(50);
-   app.get_formatter()->enable_footer_formatting(false);
+    app.get_formatter()->footer_paragraph_width(50);
+    app.get_formatter()->enable_footer_formatting(false);
     std::string help = app.help("", CLI::AppFormatMode::Normal);
     CHECK_THAT(help, Contains("is       a"));
     CHECK_THAT(help, Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
@@ -218,7 +219,9 @@ TEST_CASE("Formatter: Footer", "[formatter]") {
 
 TEST_CASE("Formatter: Description", "[formatter]") {
     CLI::App app{"My prog"};
-    std::string desc_string{"this is       a test of the footer systemsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss to  Pr e  s  e  r  v  e  SPA C ES"};
+    std::string desc_string{"this is       a test of the footer "
+                            "systemsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss to  Pr e  s  "
+                            "e  r  v  e  SPA C ES"};
     app.description(desc_string);
     app.add_flag("--option", "MyFlag");
     int val{0};

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -210,9 +210,20 @@ TEST_CASE("Formatter: Footer", "[formatter]") {
     CHECK_THAT(help, Contains("is       a"));
     CHECK_THAT(help, Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
     CHECK_THAT(help, Contains(footer_string));
+
+    help = app.help("", CLI::AppFormatMode::Sub);
+    CHECK_THAT(help, Contains("is       a"));
+    CHECK_THAT(help, Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
+    CHECK_THAT(help, Contains(footer_string));
+
     app.get_formatter()->enable_footer_formatting(true);
     CHECK(app.get_formatter()->is_footer_paragraph_formatting_enabled());
     help = app.help("", CLI::AppFormatMode::Normal);
+    CHECK_THAT(help, !Contains("is       a"));
+    CHECK_THAT(help, !Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
+    CHECK_THAT(help, !Contains(footer_string));
+
+    help = app.help("", CLI::AppFormatMode::Sub);
     CHECK_THAT(help, !Contains("is       a"));
     CHECK_THAT(help, !Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
     CHECK_THAT(help, !Contains(footer_string));
@@ -232,10 +243,23 @@ TEST_CASE("Formatter: Description", "[formatter]") {
     CHECK_THAT(help, Contains("is       a"));
     CHECK_THAT(help, Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
     CHECK_THAT(help, Contains(desc_string));
+
+    help = app.help("", CLI::AppFormatMode::Sub);
+    CHECK_THAT(help, Contains("is       a"));
+    CHECK_THAT(help, Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
+    CHECK_THAT(help, Contains(desc_string));
+
     app.get_formatter()->enable_description_formatting(true);
     CHECK(app.get_formatter()->is_description_paragraph_formatting_enabled());
     help = app.help("", CLI::AppFormatMode::Normal);
     CHECK_THAT(help, !Contains("is       a"));
     CHECK_THAT(help, !Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
     CHECK_THAT(help, !Contains(desc_string));
+
+    help = app.help("", CLI::AppFormatMode::Sub);
+    CHECK_THAT(help, !Contains("is       a"));
+    CHECK_THAT(help, !Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
+    CHECK_THAT(help, !Contains(desc_string));
 }
+
+

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -203,7 +203,6 @@ TEST_CASE("Formatter: Footer", "[formatter]") {
                               " e  r  v  e  SPA C ES"};
     app.footer(footer_string);
     app.add_flag("--option", "MyFlag");
-    int val{0};
     app.get_formatter()->footer_paragraph_width(50);
     app.get_formatter()->enable_footer_formatting(false);
     std::string help = app.help("", CLI::AppFormatMode::Normal);
@@ -224,7 +223,6 @@ TEST_CASE("Formatter: Description", "[formatter]") {
                             "e  r  v  e  SPA C ES"};
     app.description(desc_string);
     app.add_flag("--option", "MyFlag");
-    int val{0};
     app.get_formatter()->description_paragraph_width(50);
     app.get_formatter()->enable_description_formatting(false);
     std::string help = app.help("", CLI::AppFormatMode::Normal);

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -261,5 +261,3 @@ TEST_CASE("Formatter: Description", "[formatter]") {
     CHECK_THAT(help, !Contains("to  Pr e  s  e  r  v  e  SPA C ES"));
     CHECK_THAT(help, !Contains(desc_string));
 }
-
-


### PR DESCRIPTION
add flags on the formatter to disable formatting for the description and footer to allow things like word art or custom formatting.

One possible solution for #1145