### PR TITLE
Default value conversion error if the application locale is set

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -961,6 +961,13 @@ bool integral_conversion(const std::string &input, T &output) noexcept {
         output = (output_sll < 0) ? static_cast<T>(0) : static_cast<T>(output_sll);
         return (static_cast<std::int64_t>(output) == output_sll);
     }
+    // remove locale-specific group separators
+    char group_separator = std::use_facet<std::numpunct<char>>(std::locale()).thousands_sep();
+    if(input.find_first_of(group_separator) != std::string::npos) {
+        std::string nstring = input;
+        nstring.erase(std::remove(nstring.begin(), nstring.end(), group_separator), nstring.end());
+        return integral_conversion(nstring, output);
+    }
     // remove separators
     if(input.find_first_of("_'") != std::string::npos) {
         std::string nstring = input;
@@ -1018,6 +1025,13 @@ bool integral_conversion(const std::string &input, T &output) noexcept {
         // this is to deal with a few oddities with flags and wrapper int types
         output = static_cast<T>(1);
         return true;
+    }
+    // remove locale-specific group separators
+    char group_separator = std::use_facet<std::numpunct<char>>(std::locale()).thousands_sep();
+    if(input.find_first_of(group_separator) != std::string::npos) {
+        std::string nstring = input;
+        nstring.erase(std::remove(nstring.begin(), nstring.end(), group_separator), nstring.end());
+        return integral_conversion(nstring, output);
     }
     // remove separators and trailing spaces
     if(input.find_first_of("_'") != std::string::npos) {
@@ -1160,6 +1174,13 @@ bool lexical_cast(const std::string &input, T &output) {
         }
     }
 
+    // remove locale-specific group separators
+    char group_separator = std::use_facet<std::numpunct<char>>(std::locale()).thousands_sep();
+    if(input.find_first_of(group_separator) != std::string::npos) {
+        std::string nstring = input;
+        nstring.erase(std::remove(nstring.begin(), nstring.end(), group_separator), nstring.end());
+        return lexical_cast(nstring, output);
+    }
     // remove separators
     if(input.find_first_of("_'") != std::string::npos) {
         std::string nstring = input;

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2706,7 +2706,7 @@ TEST_CASE_METHOD(TApp, "BadUserSepParse", "[app]") {
     std::vector<int> vals;
     app.add_option("--idx", vals);
 
-    args = {"--idx", "1,2,3"};
+    args = {"--idx", "1;2;3"};
 
     CHECK_THROWS_AS(run(), CLI::ConversionError);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(CLI11_TESTS
     StringParseTest
     ComplexTypeTest
     TrueFalseTest
+    localeTest
     OptionGroupTest
     EncodingTest)
 

--- a/tests/localeTest.cpp
+++ b/tests/localeTest.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2017-2025, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "app_helper.hpp"
+
+#include <complex>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <locale>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+// Custom facet for thousands separator
+class CustomThousandsSeparator : public std::numpunct<char> {
+  protected:
+    char do_thousands_sep() const override { return '|'; }     // Space separator
+    std::string do_grouping() const override { return "\2"; }  // Group digits in sets of 2
+};
+
+// derived from https://github.com/CLIUtils/CLI11/pull/1160
+TEST_CASE_METHOD(TApp, "locale", "[separators]") {
+    std::locale customLocale(std::locale::classic(), new CustomThousandsSeparator);
+    std::locale::global(customLocale);  // Set as the default system-wide locale
+
+    // Ensure standard streams use the custom locale automatically
+    std::cout.imbue(std::locale());
+    std::int64_t foo;
+    std::uint64_t bar;
+    float qux;
+
+    app.add_option("FOO", foo, "Foo option")->default_val(1234567)->force_callback();
+    app.add_option("BAR", bar, "Bar option")->default_val(2345678)->force_callback();
+    app.add_option("QUX", qux, "QUX option")->default_val(3456.78)->force_callback();
+
+    CHECK_NOTHROW(run());
+    CHECK(foo == 1234567);
+    CHECK(bar == 2345678);
+    CHECK_THAT(qux, Catch::Matchers::WithinAbs(3456.78, 0.01));
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -57,6 +57,7 @@ testnames = [
     ['StringParseTest', {}],
     ['ComplexTypeTest', {}],
     ['TrueFalseTest', {}],
+    ['localeTest', {}],
     ['OptionGroupTest', {}],
     ['EncodingTest', {}],
     # multi-only


### PR DESCRIPTION
**Short description**
Application fails with `CLI::ConversionError` in some locales if the application locale is set.

**Root cause**
CLI11 uses `std::stringstream` to format default value and `strtol`/`strtod` to parse them back. The first method adds locale-specific thousand separators but the second method parses the number only up to the first separator. This causes an exception when the same value is converted to string representation and then parsed back.

Examples: in _en_US_ locale 1234.56 is "1,234.56" and in de_DE locale 1234.56 is "1.234,56".

**Reproduction**
```c++
#include <string>
#include <CLI/CLI.hpp>

int main(int argc, const char **argv)
{
    std::locale::global(std::locale(""));
    CLI::App app{"Bug report app"};
    long foo;

    app.add_option("FOO", foo, "Foo option")
        ->envname("FOO")
        ->default_val(1234567);
    CLI11_PARSE(app, argc, argv);

    return 0;
}
```
Output:
```
$ g++ -Wall -Wextra -I CLI11/include/ cli11-bug-locale-string.cpp -o cli11-bug-locale-string
$ for locale in C en_US de_DE fr_FR de_CH; do echo "locale $locale"; LC_NUMERIC=$locale.UTF-8 ./cli11-bug-locale-string && echo OK; echo; done
locale C
OK

locale en_US
terminate called after throwing an instance of 'CLI::ConversionError'
what():  The value FOO is not an allowed value for given default value("1,234,567") produces an error : Could not convert: FOO = 1,234,567
Aborted (core dumped)

locale de_DE
terminate called after throwing an instance of 'CLI::ConversionError'
what():  The value FOO is not an allowed value for given default value("1.234.567") produces an error : Could not convert: FOO = 1.234.567
Aborted (core dumped)

locale fr_FR
terminate called after throwing an instance of 'CLI::ConversionError'
what():  The value FOO is not an allowed value for given default value("1 234 567") produces an error : Could not convert: FOO = 1 234 567
Aborted (core dumped)

locale de_CH
OK
```

**Fix description**
The fix strips group separators from the input string. This extends a bit the logic introduced in change #968 for `_` and `'` separators.
There are no unit tests for the change because it requires to have all mentioned locales to be installed in the system.