### PR TITLE
Multiple footer printing in help

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -733,6 +733,9 @@ class App {
         auto *ptr = option_group.get();
         // move to App_p for overload resolution on older gcc versions
         App_p app_ptr = std::dynamic_pointer_cast<App>(option_group);
+        //don't inherit the footer in option groups and clear the help flag by default
+        app_ptr->footer_="";
+        app_ptr->set_help_flag();
         add_subcommand(std::move(app_ptr));
         return ptr;
     }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -733,8 +733,8 @@ class App {
         auto *ptr = option_group.get();
         // move to App_p for overload resolution on older gcc versions
         App_p app_ptr = std::dynamic_pointer_cast<App>(option_group);
-        //don't inherit the footer in option groups and clear the help flag by default
-        app_ptr->footer_="";
+        // don't inherit the footer in option groups and clear the help flag by default
+        app_ptr->footer_ = "";
         app_ptr->set_help_flag();
         add_subcommand(std::move(app_ptr));
         return ptr;

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -91,9 +91,9 @@ TEST_CASE("THelp: FooterOptionGroup", "[help]") {
 
     app.footer("Report bugs to bugs@example.com");
 
-    auto group_a = app.add_option_group("group-a", "");
+    app.add_option_group("group-a", "");
 
-    auto group_b = app.add_option_group("group-b", "");
+    app.add_option_group("group-b", "");
 
     std::string help = app.help();
 

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -85,6 +85,25 @@ TEST_CASE("THelp: FooterCallbackBoth", "[help]") {
     CHECK_THAT(help, Contains("foot!!!!"));
 }
 
+/// @brief from github issue #1156
+TEST_CASE("THelp: FooterOptionGroup", "[help]") {
+    CLI::App app{"My prog"};
+
+    app.footer("Report bugs to bugs@example.com");
+
+    auto group_a = app.add_option_group("group-a", "");
+
+    auto group_b = app.add_option_group("group-b", "");
+
+    std::string help = app.help();
+
+    auto footer_loc=help.find("bugs@example.com");
+    auto footer_loc2=help.find("bugs@example.com",footer_loc+10);
+    CHECK(footer_loc!=std::string::npos);
+//should only see the footer once
+    CHECK(footer_loc2==std::string::npos);
+}
+
 TEST_CASE("THelp: OptionalPositional", "[help]") {
     CLI::App app{"My prog", "program"};
 

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -97,11 +97,11 @@ TEST_CASE("THelp: FooterOptionGroup", "[help]") {
 
     std::string help = app.help();
 
-    auto footer_loc=help.find("bugs@example.com");
-    auto footer_loc2=help.find("bugs@example.com",footer_loc+10);
-    CHECK(footer_loc!=std::string::npos);
-//should only see the footer once
-    CHECK(footer_loc2==std::string::npos);
+    auto footer_loc = help.find("bugs@example.com");
+    auto footer_loc2 = help.find("bugs@example.com", footer_loc + 10);
+    CHECK(footer_loc != std::string::npos);
+    // should only see the footer once
+    CHECK(footer_loc2 == std::string::npos);
 }
 
 TEST_CASE("THelp: OptionalPositional", "[help]") {


### PR DESCRIPTION
Fixes #1156 

For option groups removes inheritance of the footer and help option, so those are not printed by default for option groups.   It is still possible to set them again on the option group.  