### PR TITLE
Update version in license to match source.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-CLI11 2.2 Copyright (c) 2017-2025 University of Cincinnati, developed by Henry
+CLI11 2.5 Copyright (c) 2017-2025 University of Cincinnati, developed by Henry
 Schreiner under NSF AWARD 1414736. All rights reserved.
 
 Redistribution and use in source and binary forms of CLI11, with or without


### PR DESCRIPTION
For packagers that need to install license files, it helps when the version in the license matches the version of the source used in the package.