### PR TITLE
chore: require CMake 3.14+

### DIFF
--- a/.github/actions/quick_cmake/action.yml
+++ b/.github/actions/quick_cmake/action.yml
@@ -1,5 +1,5 @@
 name: Quick CMake config
-description: "Runs CMake 3.10+ (if already setup)"
+description: "Runs CMake 3.15+ (if already setup)"
 inputs:
   args:
     description: "Other arguments"

--- a/.github/actions/quick_cmake/action.yml
+++ b/.github/actions/quick_cmake/action.yml
@@ -1,5 +1,5 @@
 name: Quick CMake config
-description: "Runs CMake 3.15+ (if already setup)"
+description: "Runs CMake 3.14+ (if already setup)"
 inputs:
   args:
     description: "Other arguments"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -255,11 +255,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check CMake 3.14.7
+        uses: ./.github/actions/quick_cmake
+        with:
+          cmake-version: "3.14.7"
+          args: -DCLI11_SANITIZERS=ON -DCLI11_BUILD_EXAMPLES_JSON=ON
+        if: success() || failure()
+
       - name: Check CMake 3.15
         uses: ./.github/actions/quick_cmake
         with:
           cmake-version: "3.15"
-          args: -DCLI11_SANITIZERS=ON -DCLI11_BUILD_EXAMPLES_JSON=ON
         if: success() || failure()
 
       - name: Check CMake 3.16

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -255,12 +255,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check CMake 3.14.7
+      - name: Check CMake 3.14
         uses: ./.github/actions/quick_cmake
         with:
-          cmake-version: "3.14.7"
+          cmake-version: "3.14"
           args: -DCLI11_SANITIZERS=ON -DCLI11_BUILD_EXAMPLES_JSON=ON
-        if: success() || failure()
 
       - name: Check CMake 3.15
         uses: ./.github/actions/quick_cmake
@@ -284,7 +283,6 @@ jobs:
         uses: ./.github/actions/quick_cmake
         with:
           cmake-version: "3.17"
-        if: success() || failure()
 
       - name: Check CMake 3.18
         uses: ./.github/actions/quick_cmake

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -255,41 +255,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check CMake 3.10
-        uses: ./.github/actions/quick_cmake
-        with:
-          cmake-version: "3.10"
-        if: success() || failure()
-
-      - name: Check CMake 3.11
-        uses: ./.github/actions/quick_cmake
-        with:
-          cmake-version: "3.11"
-        if: success() || failure()
-
-      - name: Check CMake 3.12
-        uses: ./.github/actions/quick_cmake
-        with:
-          cmake-version: "3.12"
-        if: success() || failure()
-
-      - name: Check CMake 3.13
-        uses: ./.github/actions/quick_cmake
-        with:
-          cmake-version: "3.13"
-        if: success() || failure()
-
-      - name: Check CMake 3.14.7
-        uses: ./.github/actions/quick_cmake
-        with:
-          cmake-version: "3.14.7"
-          args: -DCLI11_SANITIZERS=ON -DCLI11_BUILD_EXAMPLES_JSON=ON
-        if: success() || failure()
-
       - name: Check CMake 3.15
         uses: ./.github/actions/quick_cmake
         with:
           cmake-version: "3.15"
+          args: -DCLI11_SANITIZERS=ON -DCLI11_BUILD_EXAMPLES_JSON=ON
         if: success() || failure()
 
       - name: Check CMake 3.16
@@ -396,7 +366,7 @@ jobs:
           cmake-version: "3.31"
           args: -DCLI11_SANITIZERS=ON -DCLI11_BUILD_EXAMPLES_JSON=ON
         if: success() || failure()
-      
+
       - name: Check CMake 4.0
         uses: ./.github/actions/quick_cmake
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.14.7...4.0)
-# Note: this is a header only library. If you have an older CMake than 3.14.7,
+cmake_minimum_required(VERSION 3.14...4.0)
+# Note: this is a header only library. If you have an older CMake than 3.14,
 # just add the CLI11/include directory and that's all you need to do.
 
 set(VERSION_REGEX "#define CLI11_VERSION[ \t]+\"(.+)\"")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.10...4.0)
-# Note: this is a header only library. If you have an older CMake than 3.10,
+cmake_minimum_required(VERSION 3.15...4.0)
+# Note: this is a header only library. If you have an older CMake than 3.15,
 # just add the CLI11/include directory and that's all you need to do.
 
 set(VERSION_REGEX "#define CLI11_VERSION[ \t]+\"(.+)\"")
@@ -39,16 +39,13 @@ endif()
 include(CMakeDependentOption)
 include(GNUInstallDirs)
 
-if(NOT CMAKE_VERSION VERSION_LESS 3.11)
-  include(FetchContent)
-endif()
+include(FetchContent)
 
 list(APPEND force-libcxx "CMAKE_CXX_COMPILER_ID STREQUAL \"Clang\"")
 list(APPEND force-libcxx "CMAKE_SYSTEM_NAME STREQUAL \"Linux\"")
 list(APPEND force-libcxx "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME")
 
 list(APPEND build-docs "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME")
-list(APPEND build-docs "NOT CMAKE_VERSION VERSION_LESS 3.11")
 list(APPEND build-docs "Doxygen_FOUND")
 
 # Necessary to support paths with spaces, see #457
@@ -68,8 +65,7 @@ endif()
 option(CLI11_WARNINGS_AS_ERRORS "Turn all warnings into errors (for CI)")
 option(CLI11_SINGLE_FILE "Generate a single header file")
 option(CLI11_PRECOMPILED "Generate a precompiled static library instead of a header-only" OFF)
-cmake_dependent_option(CLI11_SANITIZERS "Download the sanitizers CMake config" OFF
-                       "NOT CMAKE_VERSION VERSION_LESS 3.15" OFF)
+option(CLI11_SANITIZERS "Download the sanitizers CMake config" OFF)
 
 cmake_dependent_option(CLI11_BUILD_DOCS "Build CLI11 documentation" ON "${build-docs}" OFF)
 
@@ -80,7 +76,7 @@ cmake_dependent_option(CLI11_BUILD_EXAMPLES "Build CLI11 examples" ON
                        "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME;${examples_EXIST}" OFF)
 
 cmake_dependent_option(CLI11_BUILD_EXAMPLES_JSON "Build CLI11 json example" OFF
-                       "CLI11_BUILD_EXAMPLES;NOT CMAKE_VERSION VERSION_LESS 3.15" OFF)
+                       "CLI11_BUILD_EXAMPLES" OFF)
 
 cmake_dependent_option(CLI11_SINGLE_FILE_TESTS "Duplicate all the tests for a single file build"
                        OFF "BUILD_TESTING;CLI11_SINGLE_FILE" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.15...4.0)
-# Note: this is a header only library. If you have an older CMake than 3.15,
+cmake_minimum_required(VERSION 3.14.7...4.0)
+# Note: this is a header only library. If you have an older CMake than 3.14.7,
 # just add the CLI11/include directory and that's all you need to do.
 
 set(VERSION_REGEX "#define CLI11_VERSION[ \t]+\"(.+)\"")
@@ -65,7 +65,8 @@ endif()
 option(CLI11_WARNINGS_AS_ERRORS "Turn all warnings into errors (for CI)")
 option(CLI11_SINGLE_FILE "Generate a single header file")
 option(CLI11_PRECOMPILED "Generate a precompiled static library instead of a header-only" OFF)
-option(CLI11_SANITIZERS "Download the sanitizers CMake config" OFF)
+cmake_dependent_option(CLI11_SANITIZERS "Download the sanitizers CMake config" OFF
+                       "NOT CMAKE_VERSION VERSION_LESS 3.15" OFF)
 
 cmake_dependent_option(CLI11_BUILD_DOCS "Build CLI11 documentation" ON "${build-docs}" OFF)
 
@@ -76,7 +77,7 @@ cmake_dependent_option(CLI11_BUILD_EXAMPLES "Build CLI11 examples" ON
                        "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME;${examples_EXIST}" OFF)
 
 cmake_dependent_option(CLI11_BUILD_EXAMPLES_JSON "Build CLI11 json example" OFF
-                       "CLI11_BUILD_EXAMPLES" OFF)
+                       "CLI11_BUILD_EXAMPLES;NOT CMAKE_VERSION VERSION_LESS 3.15" OFF)
 
 cmake_dependent_option(CLI11_SINGLE_FILE_TESTS "Duplicate all the tests for a single file build"
                        OFF "BUILD_TESTING;CLI11_SINGLE_FILE" OFF)

--- a/book/code/CMakeLists.txt
+++ b/book/code/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.11...3.31)
+cmake_minimum_required(VERSION 3.15...4.0)
 
 project(CLI11_Examples LANGUAGES CXX)
 
-# Using CMake 3.11's ability to set imported interface targets
+# Using CMake ability to set imported interface targets
 add_library(CLI11::CLI11 IMPORTED INTERFACE)
 target_include_directories(CLI11::CLI11 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/../../include")
 target_compile_features(CLI11::CLI11 INTERFACE cxx_std_11)

--- a/book/code/CMakeLists.txt
+++ b/book/code/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.0)
+cmake_minimum_required(VERSION 3.14...4.0)
 
 project(CLI11_Examples LANGUAGES CXX)
 

--- a/cmake/CLI11Warnings.cmake
+++ b/cmake/CLI11Warnings.cmake
@@ -32,6 +32,4 @@ target_compile_options(
             $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:${unix-warnings}
             $<$<BOOL:${CLI11_WARNINGS_AS_ERRORS}>:-Werror>>)
 
-if(NOT CMAKE_VERSION VERSION_LESS 3.13)
-  target_link_options(CLI11_warnings INTERFACE $<$<BOOL:${CLI11_FORCE_LIBCXX}>:-stdlib=libc++>)
-endif()
+target_link_options(CLI11_warnings INTERFACE $<$<BOOL:${CLI11_FORCE_LIBCXX}>:-stdlib=libc++>)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_cli_exe T)
   endif()
 endfunction()
 
-if(CLI11_BUILD_EXAMPLES_JSON AND CMAKE_VERSION VERSION_GREATER "3.14.7")
+if(CLI11_BUILD_EXAMPLES_JSON)
   message(STATUS "Using nlohmann/json")
   FetchContent_Declare(
     json

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_cli_exe T)
   endif()
 endfunction()
 
-if(CLI11_BUILD_EXAMPLES_JSON)
+if(CLI11_BUILD_EXAMPLES_JSON AND CMAKE_VERSION VERSION_GREATER "3.14.7")
   message(STATUS "Using nlohmann/json")
   FetchContent_Declare(
     json

--- a/single-include/CMakeLists.txt
+++ b/single-include/CMakeLists.txt
@@ -1,16 +1,9 @@
 if(CLI11_SINGLE_FILE)
   # Single file test
-  if(CMAKE_VERSION VERSION_LESS 3.12)
-    find_package(PythonInterp REQUIRED)
-    add_executable(Python::Interpreter IMPORTED)
-    set_target_properties(Python::Interpreter PROPERTIES IMPORTED_LOCATION "${PYTHON_EXECUTABLE}"
-                                                         VERSION "${PYTHON_VERSION_STRING}")
-  else()
-    find_package(
-      Python
-      COMPONENTS Interpreter
-      REQUIRED)
-  endif()
+  find_package(
+    Python
+    COMPONENTS Interpreter
+    REQUIRED)
 
   file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/single-include")
   add_custom_command(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(CLI11_SANITIZERS)
+if(CLI11_SANITIZERS AND ${CMAKE_VERSION} VERSION_GREATER "3.15")
   message(STATUS "Using arsenm/sanitizers-cmake")
   FetchContent_Declare(
     sanitizers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(CLI11_SANITIZERS AND ${CMAKE_VERSION} VERSION_GREATER "3.15.0")
+if(CLI11_SANITIZERS)
   message(STATUS "Using arsenm/sanitizers-cmake")
   FetchContent_Declare(
     sanitizers
@@ -320,7 +320,7 @@ if(CLI11_INSTALL_PACKAGE_TESTS)
 
   file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/find_package_tests")
 
-  if(MSVC AND ${CMAKE_VERSION} VERSION_GREATER 3.12.9)
+  if(MSVC)
     # Tests for other CMake projects including and using CLI11 using find_package
     add_test(
       NAME find-package-testsA

--- a/tests/find_package_tests/CMakeLists.txt
+++ b/tests/find_package_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10...3.26)
+cmake_minimum_required(VERSION 3.15...4.0)
 
 project(CLI11-find-package-test)
 

--- a/tests/find_package_tests/CMakeLists.txt
+++ b/tests/find_package_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.0)
+cmake_minimum_required(VERSION 3.14...4.0)
 
 project(CLI11-find-package-test)
 

--- a/tests/package_config_tests/CMakeLists.txt
+++ b/tests/package_config_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10...3.26)
+cmake_minimum_required(VERSION 3.15...4.0)
 
 project(CLI11-package-config-test)
 

--- a/tests/package_config_tests/CMakeLists.txt
+++ b/tests/package_config_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.0)
+cmake_minimum_required(VERSION 3.14...4.0)
 
 project(CLI11-package-config-test)
 


### PR DESCRIPTION
3.15 is a good minimum these days, and what pybind11, etc. now use. (Edit: we are using some really old docker containers, so let's do 3.14+ for now).
