### PR TITLE
reorder the processing of requirements and callbacks.  

### DIFF
--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <exception>
 // [CLI11:public_includes:end]
 
 namespace CLI {
@@ -1415,6 +1416,7 @@ CLI11_INLINE void App::_process() {
     // help takes precedence over other potential errors and config and environment shouldn't be processed if help
     // throws
     _process_help_flags();
+    std::exception_ptr config_exception;
     try {
         // the config file might generate a FileError but that should not be processed until later in the process
         // to allow for help, version and other errors to generate first.
@@ -1423,15 +1425,17 @@ CLI11_INLINE void App::_process() {
         // process env shouldn't throw but no reason to process it if config generated an error
         _process_env();
     } catch(const CLI::FileError &) {
-        // callbacks can generate exceptions which should take priority
-        // over the config file error if one exists.
-        _process_callbacks();
-        throw;
+        config_exception = std::current_exception();  
     }
+    // callbacks and requirements processing can generate exceptions which should take priority
+    // over the config file error if one exists.
+    _process_requirements();
 
     _process_callbacks();
 
-    _process_requirements();
+    if (config_exception) {
+        std::rethrow_exception(config_exception);
+    }
 }
 
 CLI11_INLINE void App::_process_extras() {

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -16,12 +16,12 @@
 
 // [CLI11:public_includes:set]
 #include <algorithm>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-#include <exception>
 // [CLI11:public_includes:end]
 
 namespace CLI {
@@ -1425,7 +1425,7 @@ CLI11_INLINE void App::_process() {
         // process env shouldn't throw but no reason to process it if config generated an error
         _process_env();
     } catch(const CLI::FileError &) {
-        config_exception = std::current_exception();  
+        config_exception = std::current_exception();
     }
     // callbacks and requirements processing can generate exceptions which should take priority
     // over the config file error if one exists.
@@ -1433,7 +1433,7 @@ CLI11_INLINE void App::_process() {
 
     _process_callbacks();
 
-    if (config_exception) {
+    if(config_exception) {
         std::rethrow_exception(config_exception);
     }
 }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2058,15 +2058,16 @@ TEST_CASE_METHOD(TApp, "NeedsFlags", "[app]") {
 }
 
 TEST_CASE_METHOD(TApp, "needsOptionFunction", "[app]") {
-    std::string s1{ "A" };
-    std::string s2{ "B" };
+    std::string s1{"A"};
+    std::string s2{"B"};
     app.add_flag("-s,--string");
-    app.add_option_function<std::string>("file", [&](std::string const& str) { s1=str; }, "input file");
-    app.add_option_function<std::string>("--something", [&](std::string const& str ) { s2=str; }, "something")->needs("file");
-    args = {"--something","C"};
+    app.add_option_function<std::string>("file", [&](std::string const &str) { s1 = str; }, "input file");
+    app.add_option_function<std::string>(
+           "--something", [&](std::string const &str) { s2 = str; }, "something")
+        ->needs("file");
+    args = {"--something", "C"};
     CHECK_THROWS_AS(run(), CLI::RequiresError);
-    CHECK(s2=="B");
-
+    CHECK(s2 == "B");
 }
 
 TEST_CASE_METHOD(TApp, "ExcludesFlags", "[app]") {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2057,6 +2057,18 @@ TEST_CASE_METHOD(TApp, "NeedsFlags", "[app]") {
     CHECK_NOTHROW(opt->needs(opt));
 }
 
+TEST_CASE_METHOD(TApp, "needsOptionFunction", "[app]") {
+    std::string s1{ "A" };
+    std::string s2{ "B" };
+    app.add_flag("-s,--string");
+    app.add_option_function<std::string>("file", [&](std::string const& str) { s1=str; }, "input file");
+    app.add_option_function<std::string>("--something", [&](std::string const& str ) { s2=str; }, "something")->needs("file");
+    args = {"--something","C"};
+    CHECK_THROWS_AS(run(), CLI::RequiresError);
+    CHECK(s2=="B");
+
+}
+
 TEST_CASE_METHOD(TApp, "ExcludesFlags", "[app]") {
     CLI::Option *opt = app.add_flag("-s,--string");
     app.add_flag("--nostr")->excludes(opt);

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -803,7 +803,7 @@ TEST_CASE_METHOD(TApp, "IniRequiredNoDefault", "[config]") {
 
     int two{0};
     app.add_option("--two", two);
-    REQUIRE_THROWS_AS(run(), CLI::FileError);
+    REQUIRE_THROWS_AS(run(), CLI::RequiredError);
     // test to make sure help still gets called correctly
     // GitHub issue #533 https://github.com/CLIUtils/CLI11/issues/553
     args = {"--help"};
@@ -932,7 +932,7 @@ TEST_CASE_METHOD(TApp, "IniEnvironmentalFileName", "[config]") {
 
     unset_env("CONFIG");
 
-    CHECK_THROWS_AS(run(), CLI::FileError);
+    CHECK_THROWS_AS(run(), CLI::RequiredError);
 }
 
 TEST_CASE_METHOD(TApp, "MultiConfig", "[config]") {


### PR DESCRIPTION
Check the requirements first.
Previously the callbacks were done first,  but with custom callbacks this cause side effects unexpectedly.  