### PR TITLE
use of string_view in as<T> method

### DIFF
--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -319,7 +319,7 @@ class Option : public OptionBase<Option> {
     /// complete Results of parsing
     results_t results_{};
     /// results after reduction
-    results_t proc_results_{};
+    mutable results_t proc_results_{};
     /// enumeration for the option state machine
     enum class option_state : char {
         parsing = 0,       //!< The option is currently collecting parsed results
@@ -700,7 +700,9 @@ class Option : public OptionBase<Option> {
             } else {
                 res = reduced_results();
             }
-            retval = detail::lexical_conversion<T, T>(res, output);
+            //store the results in a stable location if the output is a view
+            proc_results_=std::move(res);
+            retval = detail::lexical_conversion<T, T>(proc_results_, output);
         }
         if(!retval) {
             throw ConversionError(get_name(), results_);

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -700,8 +700,8 @@ class Option : public OptionBase<Option> {
             } else {
                 res = reduced_results();
             }
-            //store the results in a stable location if the output is a view
-            proc_results_=std::move(res);
+            // store the results in a stable location if the output is a view
+            proc_results_ = std::move(res);
             retval = detail::lexical_conversion<T, T>(proc_results_, output);
         }
         if(!retval) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -710,6 +710,7 @@ TEST_CASE_METHOD(TApp, "StrangeOptionNames", "[app]") {
     CHECK(app["--{}"]->as<int>() == 5);
 }
 
+
 TEST_CASE_METHOD(TApp, "singledash", "[app]") {
     app.add_option("-t");
     try {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -710,7 +710,6 @@ TEST_CASE_METHOD(TApp, "StrangeOptionNames", "[app]") {
     CHECK(app["--{}"]->as<int>() == 5);
 }
 
-
 TEST_CASE_METHOD(TApp, "singledash", "[app]") {
     app.add_option("-t");
     try {

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -396,12 +396,12 @@ TEST_CASE_METHOD(TApp, "AsStringView", "[app]") {
     args = {};
     run();
     std::string_view inputStr = app["--input"]->as<std::string_view>();
-    CHECK(inputStr=="optionA");
+    CHECK(inputStr == "optionA");
 
-    args = {"--input","optionC"};
+    args = {"--input", "optionC"};
     run();
     inputStr = app["--input"]->as<std::string_view>();
-    CHECK(inputStr=="optionC");
+    CHECK(inputStr == "optionC");
 }
 
 #endif
@@ -414,12 +414,12 @@ TEST_CASE_METHOD(TApp, "AsStringRef", "[app]") {
     args = {};
     run();
     const std::string &inputStr = app["--input"]->as<std::string>();
-    CHECK(inputStr=="optionA");
+    CHECK(inputStr == "optionA");
 
-    args = {"--input","optionC"};
+    args = {"--input", "optionC"};
     run();
     const std::string &inputStr2 = app["--input"]->as<std::string>();
-    CHECK(inputStr2=="optionC");
+    CHECK(inputStr2 == "optionC");
 }
 
 TEST_CASE_METHOD(TApp, "VectorExpectedRange", "[optiontype]") {

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -390,9 +390,7 @@ TEST_CASE_METHOD(TApp, "stringLikeTests", "[optiontype]") {
 // test code from https://github.com/CLIUtils/CLI11/issues/881
 // https://github.com/Jean1995
 TEST_CASE_METHOD(TApp, "AsStringView", "[app]") {
-    app.add_option("--input", "input option")
-        ->default_val("optA")
-        ->check(CLI::IsMember({"optA", "optB", "optC"}));
+    app.add_option("--input", "input option")->default_val("optA")->check(CLI::IsMember({"optA", "optB", "optC"}));
 
     args = {};
     run();
@@ -408,9 +406,7 @@ TEST_CASE_METHOD(TApp, "AsStringView", "[app]") {
 #endif
 
 TEST_CASE_METHOD(TApp, "AsStringRef", "[app]") {
-    app.add_option("--input", "input option")
-        ->default_val("optA")
-        ->check(CLI::IsMember({"optA", "optB", "optC"}));
+    app.add_option("--input", "input option")->default_val("optA")->check(CLI::IsMember({"optA", "optB", "optC"}));
 
     args = {};
     run();

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -387,39 +387,40 @@ TEST_CASE_METHOD(TApp, "stringLikeTests", "[optiontype]") {
 
 #if CLI11_HAS_FILESYSTEM
 #include <string_view>
-
+// test code from https://github.com/CLIUtils/CLI11/issues/881
+// https://github.com/Jean1995
 TEST_CASE_METHOD(TApp, "AsStringView", "[app]") {
     app.add_option("--input", "input option")
-        ->default_val("optionA")
-        ->check(CLI::IsMember({"optionA", "optionB", "optionC"}));
+        ->default_val("optA")
+        ->check(CLI::IsMember({"optA", "optB", "optC"}));
 
     args = {};
     run();
-    std::string_view inputStr = app["--input"]->as<std::string_view>();
-    CHECK(inputStr == "optionA");
+    auto inputStr = app["--input"]->as<std::string_view>();
+    CHECK(inputStr == "optA");
 
-    args = {"--input", "optionC"};
+    args = {"--input", "optC"};
     run();
     inputStr = app["--input"]->as<std::string_view>();
-    CHECK(inputStr == "optionC");
+    CHECK(inputStr == "optC");
 }
 
 #endif
 
 TEST_CASE_METHOD(TApp, "AsStringRef", "[app]") {
     app.add_option("--input", "input option")
-        ->default_val("optionA")
-        ->check(CLI::IsMember({"optionA", "optionB", "optionC"}));
+        ->default_val("optA")
+        ->check(CLI::IsMember({"optA", "optB", "optC"}));
 
     args = {};
     run();
     const std::string &inputStr = app["--input"]->as<std::string>();
-    CHECK(inputStr == "optionA");
+    CHECK(inputStr == "optA");
 
-    args = {"--input", "optionC"};
+    args = {"--input", "optC"};
     run();
     const std::string &inputStr2 = app["--input"]->as<std::string>();
-    CHECK(inputStr2 == "optionC");
+    CHECK(inputStr2 == "optC");
 }
 
 TEST_CASE_METHOD(TApp, "VectorExpectedRange", "[optiontype]") {

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -385,6 +385,43 @@ TEST_CASE_METHOD(TApp, "stringLikeTests", "[optiontype]") {
     CHECK("bca" == m_type.m_value);
 }
 
+#if CLI11_HAS_FILESYSTEM
+#include <string_view>
+
+TEST_CASE_METHOD(TApp, "AsStringView", "[app]") {
+    app.add_option("--input", "input option")
+        ->default_val("optionA")
+        ->check(CLI::IsMember({"optionA", "optionB", "optionC"}));
+
+    args = {};
+    run();
+    std::string_view inputStr = app["--input"]->as<std::string_view>();
+    CHECK(inputStr=="optionA");
+
+    args = {"--input","optionC"};
+    run();
+    inputStr = app["--input"]->as<std::string_view>();
+    CHECK(inputStr=="optionC");
+}
+
+#endif
+
+TEST_CASE_METHOD(TApp, "AsStringRef", "[app]") {
+    app.add_option("--input", "input option")
+        ->default_val("optionA")
+        ->check(CLI::IsMember({"optionA", "optionB", "optionC"}));
+
+    args = {};
+    run();
+    const std::string &inputStr = app["--input"]->as<std::string>();
+    CHECK(inputStr=="optionA");
+
+    args = {"--input","optionC"};
+    run();
+    const std::string &inputStr2 = app["--input"]->as<std::string>();
+    CHECK(inputStr2=="optionC");
+}
+
 TEST_CASE_METHOD(TApp, "VectorExpectedRange", "[optiontype]") {
     std::vector<std::string> strvec;
 


### PR DESCRIPTION
Address Issue #881, allowing use of string_view in the as<XX> method on options.