### PR TITLE
fix edge case with config files pointer 

### DIFF
--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -681,18 +681,15 @@ class Option : public OptionBase<Option> {
         bool retval = false;
         if(current_option_state_ >= option_state::reduced || (results_.size() == 1 && validators_.empty())) {
             const results_t &res = (proc_results_.empty()) ? results_ : proc_results_;
-            if (!res.empty())
-            {
+            if(!res.empty()) {
                 retval = detail::lexical_conversion<T, T>(res, output);
-            }
-            else
-            {
+            } else {
                 results_t res2;
                 res2.emplace_back();
                 proc_results_ = std::move(res2);
                 retval = detail::lexical_conversion<T, T>(proc_results_, output);
             }
-            
+
         } else {
             results_t res;
             if(results_.empty()) {

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -681,7 +681,18 @@ class Option : public OptionBase<Option> {
         bool retval = false;
         if(current_option_state_ >= option_state::reduced || (results_.size() == 1 && validators_.empty())) {
             const results_t &res = (proc_results_.empty()) ? results_ : proc_results_;
-            retval = detail::lexical_conversion<T, T>(res, output);
+            if (!res.empty())
+            {
+                retval = detail::lexical_conversion<T, T>(res, output);
+            }
+            else
+            {
+                results_t res2;
+                res2.emplace_back();
+                proc_results_ = std::move(res2);
+                retval = detail::lexical_conversion<T, T>(proc_results_, output);
+            }
+            
         } else {
             results_t res;
             if(results_.empty()) {

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -4210,7 +4210,7 @@ TEST_CASE_METHOD(TApp, "RoundTripArrayFloat", "[config]") {
 }
 
 // Code from https://github.com/CLIUtils/CLI11/issues/1197
-TEST_CASE_METHOD(TApp,"CrashTest", "[config]") {
+TEST_CASE_METHOD(TApp, "CrashTest", "[config]") {
     args = {"spdlog", "--level=off"};
 
     app.configurable()->allow_config_extras(false);
@@ -4223,9 +4223,9 @@ TEST_CASE_METHOD(TApp,"CrashTest", "[config]") {
 
     run();
 
-    auto *ptr= app.get_config_ptr();
+    auto *ptr = app.get_config_ptr();
     std::string conf_filename;
     CHECK_NOTHROW(conf_filename = ptr->as<std::string>());
     CHECK(conf_filename.empty());
-    CHECK(level=="off");
+    CHECK(level == "off");
 }

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -4208,3 +4208,24 @@ TEST_CASE_METHOD(TApp, "RoundTripArrayFloat", "[config]") {
     CHECK(cv[0] == -1.0F);
     CHECK(cv[1] == 1.0F);
 }
+
+// Code from https://github.com/CLIUtils/CLI11/issues/1197
+TEST_CASE_METHOD(TApp,"CrashTest", "[config]") {
+    args = {"spdlog", "--level=off"};
+
+    app.configurable()->allow_config_extras(false);
+    app.set_config("--conf")->check(CLI::ExistingFile);
+
+    std::string level;
+
+    auto *command = app.add_subcommand("spdlog");
+    command->add_option("--level", level, "Log level")->default_val("info");
+
+    run();
+
+    auto *ptr= app.get_config_ptr();
+    std::string conf_filename;
+    CHECK_NOTHROW(conf_filename = ptr->as<std::string>());
+    CHECK(conf_filename.empty());
+    CHECK(level=="off");
+}

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1516,6 +1516,14 @@ TEST_CASE("Types: LexicalConversionVectorDouble", "[helpers]") {
     CHECK(-3.54 == Approx(x[2]));
 }
 
+TEST_CASE("Types: LexicalConversionEmptyVectorDouble", "[helpers]") {
+    CLI::results_t input = {};
+    std::vector<double> x;
+    bool res = CLI::detail::lexical_conversion<std::vector<double>, std::vector<double>>(input, x);
+    CHECK(res);
+    CHECK(0 == x.size());
+}
+
 static_assert(!CLI::detail::is_tuple_like<std::vector<double>>::value, "vector should not be like a tuple");
 static_assert(CLI::detail::is_tuple_like<std::pair<double, double>>::value, "pair of double should be like a tuple");
 static_assert(CLI::detail::is_tuple_like<std::array<double, 4>>::value, "std::array<double,4> should be like a tuple");

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1521,7 +1521,7 @@ TEST_CASE("Types: LexicalConversionEmptyVectorDouble", "[helpers]") {
     std::vector<double> x;
     bool res = CLI::detail::lexical_conversion<std::vector<double>, std::vector<double>>(input, x);
     CHECK(res);
-    CHECK(0 == x.size());
+    CHECK(x.empty());
 }
 
 static_assert(!CLI::detail::is_tuple_like<std::vector<double>>::value, "vector should not be like a tuple");


### PR DESCRIPTION
generating a seg fault if no default and no config file provided.

Fixes #1197 

This was likely introduced by the combination of fixes for some issues with the config parsing and some updates to the as<T> method a while back.   This edge case on the handling of the config pointer with as was not overlooked in the earlier testing.
 