### PR TITLE
Recursive needs processing

### DIFF
--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1414,7 +1414,7 @@ CLI11_INLINE void App::_process_requirements() {
                 }
             }
         }
-        if(sub->count() > 0 || sub->name_.empty() && need_subcommands_.find(sub.get()) == need_subcommands_.end()) {
+        if((sub->count() > 0 || sub->name_.empty()) && need_subcommands_.find(sub.get()) == need_subcommands_.end()) {
             sub->_process_requirements();
         }
 

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1317,10 +1317,22 @@ CLI11_INLINE void App::_process_requirements() {
             missing_need = opt->get_name();
         }
     }
+    for(const auto &subc : need_subcommands_) { // Process subcommands given on the commandline first
+        if (subc->count() > 0) {
+            subc->_process_requirements();
+        }
+    }
     for(const auto &subc : need_subcommands_) {
-        if(subc->count_all() == 0) {
-            missing_needed = true;
-            missing_need = subc->get_display_name();
+        if (subc->count() == 0) {
+            try {
+                subc->_process_requirements();
+            } catch (const CLI::RequiresError&) {
+                throw RequiresError(get_display_name(), subc->name_);
+            }
+            if(subc->count_all() == 0) {
+                missing_needed = true;
+                missing_need = subc->get_display_name();
+            }
         }
     }
     if(missing_needed) {
@@ -1402,7 +1414,7 @@ CLI11_INLINE void App::_process_requirements() {
                 }
             }
         }
-        if(sub->count() > 0 || sub->name_.empty()) {
+        if(sub->count() > 0 || sub->name_.empty() && need_subcommands_.find(sub.get()) == need_subcommands_.end()) {
             sub->_process_requirements();
         }
 


### PR DESCRIPTION
The current way needs relations are checked in void App::_process_requirements() is missleading.
Assume you have an application 'test' with a CLI11 config system configuring following needs relations between some subcommands:

```
app ---> sub1 ---> sub11
     |         |-> sub12
     |-> sub2 ---> sub21
```
A) Current needs processing gives:
```
./test                              -> test requires sub2  // OK for the user
./test sub2                         -> test requires sub1  // OK for the user
./test sub2 sub1                    -> sub2 requires sub21 // Confuses user
./test sub2 sub1 sub21              -> sub1 requires sub12 // Confuses user
./test sub2 sub1 sub21 sub12        -> sub1 requires sub11 // Hm
./test sub2 sub1 sub21 sub12 sub11  -> complete
```

B) Recursive needs processing gives:
```
./test                              -> test requires sub2  // OK
./test sub2                         -> sub2 requires sub21 // More intuitive for user
./test sub2 sub21                   -> test requires sub1  // More intuitive for user
./test sub2 sub21 sub1              -> sub1 requires sub12 // OK
./test sub2 sub21 sub1 sub12        -> sub1 requires sub11 // OK
./test sub2 sub21 sub1 sub12 sub11  -> complete
```