### PR TITLE
Add a required_callback to inject user defined requirement checks

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -146,6 +146,9 @@ class App {
     /// This is a function that runs when all processing has completed
     std::function<void()> final_callback_{};
 
+    /// This is a function tat runs after all standard requirement checks havv been processed
+    std::function<void()> require_callback_{};
+
     ///@}
     /// @name Options
     ///@{
@@ -373,6 +376,13 @@ class App {
     ///
     App *preparse_callback(std::function<void(std::size_t)> pp_callback) {
         pre_parse_callback_ = std::move(pp_callback);
+        return this;
+    }
+
+    /// Set a callback to execute after all standard requirement checks have been processed
+    ///
+    App *require_callback(std::function<void()> req_callback) {
+        require_callback_ = std::move(req_callback);
         return this;
     }
 

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1410,6 +1410,10 @@ CLI11_INLINE void App::_process_requirements() {
             throw(CLI::RequiredError(sub->get_display_name()));
         }
     }
+
+    if (require_callback_) {
+        require_callback_();
+    }
 }
 
 CLI11_INLINE void App::_process() {


### PR DESCRIPTION
In some situations the standard requirement checks are not sufficient. In such cases the user can provide a required_callback doing additional requirement checks. This callback is executed after all standard requirement checks.