### PR TITLE
ensure the parse order is reset on clear()

### DIFF
--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -582,6 +582,7 @@ CLI11_INLINE void App::clear() {
 
     missing_.clear();
     parsed_subcommands_.clear();
+    parse_order_.clear();
     for(const Option_p &opt : options_) {
         opt->clear();
     }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2016,6 +2016,8 @@ TEST_CASE_METHOD(TApp, "OriginalOrder", "[app]") {
     CHECK(std::vector<int>({2}) == st2);
 
     CHECK(std::vector<CLI::Option *>({op1, op2, op1, op1}) == app.parse_order());
+    app.clear();
+    CHECK(app.parse_order().empty());
 }
 
 TEST_CASE_METHOD(TApp, "NeedsFlags", "[app]") {


### PR DESCRIPTION
Fixes #1216 