### PR TITLE
ci(cifuzz): keep dry-run until google/oss-fuzz#14131 merges

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,31 +1,23 @@
 name: CIFuzz
-
 on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   fuzz:
     runs-on: ubuntu-latest
-    # keep CI green while OSS-Fuzz project is not merged yet
-    continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-
       - name: Build Fuzzers (dry run)
         uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
         with:
           oss-fuzz-project-name: cli11
           language: c++
-    dry-run: true
+          dry-run: true
 
       - name: Run Fuzzers (dry run)
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
         with:
           oss-fuzz-project-name: cli11
           language: c++
-    dry-run: true
           fuzz-seconds: 600
+          dry-run: true

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -20,10 +20,12 @@ jobs:
         with:
           oss-fuzz-project-name: cli11
           language: c++
+    dry-run: true
 
       - name: Run Fuzzers (dry run)
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
         with:
           oss-fuzz-project-name: cli11
           language: c++
+    dry-run: true
           fuzz-seconds: 600

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           oss-fuzz-project-name: cli11
           language: c++
-          dry-run: true
 
       - name: Run Fuzzers (dry run)
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
@@ -28,4 +27,3 @@ jobs:
           oss-fuzz-project-name: cli11
           language: c++
           fuzz-seconds: 600
-          dry-run: true

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           oss-fuzz-project-name: cli11
           language: c++
+    dry-run: true
           dry-run: true
 
       - name: Run Fuzzers (dry run)
@@ -19,5 +20,6 @@ jobs:
         with:
           oss-fuzz-project-name: cli11
           language: c++
+    dry-run: true
           fuzz-seconds: 600
           dry-run: true

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -12,7 +12,6 @@ jobs:
         with:
           oss-fuzz-project-name: cli11
           language: c++
-          dry-run: true
 
       - name: Run Fuzzers (dry run)
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
@@ -20,4 +19,3 @@ jobs:
           oss-fuzz-project-name: cli11
           language: c++
           fuzz-seconds: 600
-          dry-run: true

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           oss-fuzz-project-name: cli11
           language: c++
+          dry-run: true
 
       - name: Run Fuzzers (dry run)
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
@@ -19,3 +20,4 @@ jobs:
           oss-fuzz-project-name: cli11
           language: c++
           fuzz-seconds: 600
+          dry-run: true

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest
@@ -11,15 +14,13 @@ jobs:
         uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
         with:
           oss-fuzz-project-name: cli11
-          language: c++
-    dry-run: true
+          language: 'c++'
           dry-run: true
 
       - name: Run Fuzzers (dry run)
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
         with:
           oss-fuzz-project-name: cli11
-          language: c++
-    dry-run: true
+          language: 'c++'
           fuzz-seconds: 600
           dry-run: true


### PR DESCRIPTION
Flip CIFuzz out of dry‑run now that cli11 exists in OSS‑Fuzz.