### PR TITLE
ci(cifuzz): enable real fuzzing (remove dry-run)

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -15,7 +15,6 @@ jobs:
         with:
           oss-fuzz-project-name: cli11
           language: 'c++'
-          dry-run: true
 
       - name: Run Fuzzers (dry run)
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
@@ -23,4 +22,3 @@ jobs:
           oss-fuzz-project-name: cli11
           language: 'c++'
           fuzz-seconds: 600
-          dry-run: true


### PR DESCRIPTION
Now that cli11 is in OSS‑Fuzz, switch CIFuzz from dry‑run to live per the CI docs.