### PR TITLE
Fix incorrect links to validator examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1752,9 +1752,9 @@ brief description of each is included here
   Short example of subcommands
 - [validators](https://github.com/CLIUtils/CLI11/blob/main/examples/validators.cpp):
   Example illustrating use of validators
-- [custom validators](https://github.com/CLIUtils/CLI11/blob/main/examples/custom_validators.cpp):
+- [custom validators](https://github.com/CLIUtils/CLI11/blob/main/examples/custom_validator.cpp):
   Example illustrating use of validators
-- [date validators](https://github.com/CLIUtils/CLI11/blob/main/examples/date_validators.cpp):
+- [date validators](https://github.com/CLIUtils/CLI11/blob/main/examples/date_validator.cpp):
   Example illustrating use of validators
 
 ## Contribute


### PR DESCRIPTION
8c77664bd07b9901ad7a3c4c425179c49bd845e1 added the files and the links, but the links were off by one character and therefore don't work. This PR fixes them