### PR TITLE
Add reverse_string utility function in cliutils namespace

### DIFF
--- a/include/cliutils/custom_util.hpp
+++ b/include/cliutils/custom_util.hpp
@@ -4,9 +4,6 @@
 namespace cliutils {
 
 // Returns the reverse of a given string
-inline std::string reverse_string(const std::string &input) {
-    return std::string(input.rbegin(), input.rend());
-}
+inline std::string reverse_string(const std::string &input) { return std::string(input.rbegin(), input.rend()); }
 
-}
-
+}  // namespace cliutils

--- a/include/cliutils/custom_util.hpp
+++ b/include/cliutils/custom_util.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+
+namespace cliutils {
+
+// Returns the reverse of a given string
+inline std::string reverse_string(const std::string &input) {
+    return std::string(input.rbegin(), input.rend());
+}
+
+}

--- a/include/cliutils/custom_util.hpp
+++ b/include/cliutils/custom_util.hpp
@@ -9,3 +9,4 @@ inline std::string reverse_string(const std::string &input) {
 }
 
 }
+


### PR DESCRIPTION
### Summary
Added a small utility function reverse_string() under include/cliutils/custom_util.hpp.

### Details
- Returns the reversed string of given input.
- This is a minimal code-only addition, no documentation or example.
- Code compiles independently with existing includes.
