### PR TITLE
add an option for full install, 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -258,6 +258,8 @@ jobs:
         run: cmake --build build  -j2
       - name: install
         run: cmake --install build
+      - name: Configure2
+        run: cmake -S . -B build -DCLI11_INSTALL_PACKAGE_TESTS=ON -DCMAKE_INSTALL_PREFIX=/home/runner/work/install
       - name: Run tests
         run: ctest --output-on-failure -L Packaging
         working-directory: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -244,6 +244,23 @@ jobs:
       - name: Run tests
         run: ctest --output-on-failure -L Packaging
         working-directory: build
+
+  install-precompiled-all:
+    name: install tests precompiled full install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Configure
+        run: cmake -S . -B build -DCLI11_INSTALL_PACKAGE_TESTS=ON -DCLI11_ENABLE_EXTRA_VALIDATORS=ON -DCMAKE_INSTALL_PREFIX=/home/runner/work/install -DCLI11_PRECOMPILED=ON -DCLI11_FULL_INSTALL=ON
+      - name: Build
+        run: cmake --build build  -j2
+      - name: install
+        run: cmake --install build
+      - name: Run tests
+        run: ctest --output-on-failure -L Packaging
+        working-directory: build
   
   install-precompiled-macos:
     name: install tests precompiled macos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,10 @@ cmake_dependent_option(CLI11_BUILD_EXAMPLES "Build CLI11 examples" ON
 cmake_dependent_option(CLI11_BUILD_EXAMPLES_JSON "Build CLI11 json example" OFF
                        "CLI11_BUILD_EXAMPLES;NOT CMAKE_VERSION VERSION_LESS 3.15" OFF)
 
-cmake_dependent_option(CLI11_FULL_INSTALL "Install all headers regardless of SINGLE_FILE OR PRECOMPILED OPTIONS" OFF
-                       "CLI11_SINGLE_FILE OR CLI11_PRECOMPILED" OFF)
-                       
+cmake_dependent_option(
+  CLI11_FULL_INSTALL "Install all headers regardless of SINGLE_FILE OR PRECOMPILED OPTIONS" OFF
+  "CLI11_SINGLE_FILE OR CLI11_PRECOMPILED" OFF)
+
 cmake_dependent_option(CLI11_SINGLE_FILE_TESTS "Duplicate all the tests for a single file build"
                        OFF "BUILD_TESTING;CLI11_SINGLE_FILE" OFF)
 
@@ -96,7 +97,9 @@ cmake_dependent_option(
   CLI11_CUDA_TESTS "Build the tests with NVCC to check for warnings there - requires CMake 3.9+"
   OFF "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME" OFF)
 
-if(NOT CLI11_FULL_INSTALL AND CLI11_PRECOMPILED AND CLI11_SINGLE_FILE)
+if(NOT CLI11_FULL_INSTALL
+   AND CLI11_PRECOMPILED
+   AND CLI11_SINGLE_FILE)
   # Sanity check
   message(FATAL_ERROR "CLI11_PRECOMPILE and CLI11_SINGLE_FILE are mutually exclusive")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,9 @@ cmake_dependent_option(CLI11_BUILD_EXAMPLES "Build CLI11 examples" ON
 cmake_dependent_option(CLI11_BUILD_EXAMPLES_JSON "Build CLI11 json example" OFF
                        "CLI11_BUILD_EXAMPLES;NOT CMAKE_VERSION VERSION_LESS 3.15" OFF)
 
+cmake_dependent_option(CLI11_FULL_INSTALL "Install all headers regardless of SINGLE_FILE OR PRECOMPILED OPTIONS" OFF
+                       "CLI11_SINGLE_FILE OR CLI11_PRECOMPILED" OFF)
+                       
 cmake_dependent_option(CLI11_SINGLE_FILE_TESTS "Duplicate all the tests for a single file build"
                        OFF "BUILD_TESTING;CLI11_SINGLE_FILE" OFF)
 
@@ -93,7 +96,7 @@ cmake_dependent_option(
   CLI11_CUDA_TESTS "Build the tests with NVCC to check for warnings there - requires CMake 3.9+"
   OFF "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME" OFF)
 
-if(CLI11_PRECOMPILED AND CLI11_SINGLE_FILE)
+if(NOT CLI11_FULL_INSTALL AND CLI11_PRECOMPILED AND CLI11_SINGLE_FILE)
   # Sanity check
   message(FATAL_ERROR "CLI11_PRECOMPILE and CLI11_SINGLE_FILE are mutually exclusive")
 endif()
@@ -171,7 +174,7 @@ if(CLI11_CUDA_TESTS)
 endif()
 
 # This folder should be installed
-if(CLI11_INSTALL)
+if(CLI11_INSTALL OR CLI11_FULL_INSTALL)
 
   # Use find_package on the installed package
   # Since we have no custom code, we can directly write this

--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -185,6 +185,7 @@ default to off if CLI11 is used as a subdirectory in another project.
 | `CLI11_BUILD_EXAMPLES=ON`      | Build the example programs.                                                      |
 | `CLI11_BUILD_EXAMPLES_JSON=ON` | Build some additional example using json libraries                               |
 | `CLI11_INSTALL=ON`             | install CLI11 to the install folder during the install process                   |
+| `CLI11_FULL_INSTALL=ON`        | install all CLI11 headers regardless of other settings                           |
 | `CLI11_FORCE_LIBCXX=OFF`       | use libc++ instead of libstdc++ if building with clang on linux                  |
 | `CLI11_CUDA_TESTS=OFF`         | build the tests with NVCC                                                        |
 | `CLI11_BUILD_TESTS=ON`         | Build the tests.                                                                 |

--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -185,7 +185,7 @@ default to off if CLI11 is used as a subdirectory in another project.
 | `CLI11_BUILD_EXAMPLES=ON`      | Build the example programs.                                                      |
 | `CLI11_BUILD_EXAMPLES_JSON=ON` | Build some additional example using json libraries                               |
 | `CLI11_INSTALL=ON`             | install CLI11 to the install folder during the install process                   |
-| `CLI11_FULL_INSTALL=ON`        | install all CLI11 headers regardless of other settings                           |
+| `CLI11_FULL_INSTALL=ON`        | install all CLI11 headers/libraries regardless of other settings                 |
 | `CLI11_FORCE_LIBCXX=OFF`       | use libc++ instead of libstdc++ if building with clang on linux                  |
 | `CLI11_CUDA_TESTS=OFF`         | build the tests with NVCC                                                        |
 | `CLI11_BUILD_TESTS=ON`         | Build the tests.                                                                 |

--- a/single-include/CMakeLists.txt
+++ b/single-include/CMakeLists.txt
@@ -17,7 +17,7 @@ if(CLI11_SINGLE_FILE)
   add_custom_target(CLI11-generate-single-file ALL
                     DEPENDS "${PROJECT_BINARY_DIR}/single-include/CLI11.hpp")
   set_property(TARGET CLI11-generate-single-file PROPERTY FOLDER "Scripts")
-  if(CLI11_INSTALL)
+  if(CLI11_INSTALL OR CLI11_FULL_INSTALL)
     install(FILES "${PROJECT_BINARY_DIR}/single-include/CLI11.hpp"
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,14 +44,14 @@ if(CMAKE_CXX_STANDARD LESS 14)
   target_compile_features(CLI11 INTERFACE cxx_std_11)
 endif()
 
-if(CLI11_INSTALL)
+if(CLI11_INSTALL OR CLI11_FULL_INSTALL)
 
   # Make an export target
   install(TARGETS CLI11 EXPORT CLI11Targets)
-  if(NOT CLI11_SINGLE_FILE)
+  if((NOT CLI11_SINGLE_FILE) OR CLI11_FULL_INSTALL)
     install(FILES ${CLI11_headers} ${CLI11_library_headers}
             DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/CLI")
-    if(NOT CLI11_PRECOMPILED)
+    if((NOT CLI11_PRECOMPILED) OR CLI11_FULL_INSTALL)
       install(FILES ${CLI11_impl_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/CLI/impl")
     endif()
   endif()


### PR DESCRIPTION
include impl headers with precompiled option.

This may be necessary for some package installs if they wish to include the precompiled static library alongside the header only install.  inspired by #1198 