### PR TITLE
Issue #1258

### DIFF
--- a/include/CLI/ExtraValidators.hpp
+++ b/include/CLI/ExtraValidators.hpp
@@ -358,7 +358,9 @@ class CheckedTransformer : public Validator {
             out += detail::generate_map(detail::smart_deref(mapping)) + " OR {";
             out += detail::join(
                 detail::smart_deref(mapping),
-                [](const iteration_type_t &v) { return detail::value_string(detail::pair_adaptor<element_t>::second(v)); },
+                [](const iteration_type_t &v) {
+                    return detail::value_string(detail::pair_adaptor<element_t>::second(v));
+                },
                 ",");
             out.push_back('}');
             return out;

--- a/include/CLI/ExtraValidators.hpp
+++ b/include/CLI/ExtraValidators.hpp
@@ -358,7 +358,7 @@ class CheckedTransformer : public Validator {
             out += detail::generate_map(detail::smart_deref(mapping)) + " OR {";
             out += detail::join(
                 detail::smart_deref(mapping),
-                [](const iteration_type_t &v) { return detail::to_string(detail::pair_adaptor<element_t>::second(v)); },
+                [](const iteration_type_t &v) { return detail::value_string(detail::pair_adaptor<element_t>::second(v)); },
                 ",");
             out.push_back('}');
             return out;

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -815,7 +815,7 @@ class Option : public OptionBase<Option> {
     /// Set the default value and validate the results and run the callback if appropriate to set the value into the
     /// bound value only available for types that can be converted to a string
     template <typename X> Option *default_val(const X &val) {
-        std::string val_str = detail::to_string(val);
+        std::string val_str = detail::value_string(val);
         auto old_option_state = current_option_state_;
         results_t old_results{std::move(results_)};
         results_.clear();

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -195,8 +195,8 @@ inline std::ostream &operator<<(std::ostream &os, Color c) { return os << (c == 
 TEST_CASE_METHOD(TApp, "streamTransformCheck", "[transform]") {
 
     std::map<std::string, Color> color_map = {
-        {"red", Color::kRed},    // User types "red"
-        {"blue", Color::kBlue}   // User types "blue"
+        {"red", Color::kRed},   // User types "red"
+        {"blue", Color::kBlue}  // User types "blue"
     };
     Color color = Color::kRed;
 

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -189,7 +189,7 @@ TEST_CASE_METHOD(TApp, "SimpleTransformFn", "[transform]") {
 enum class Color { kRed, kBlue };
 
 // operator<< outputs full enum name (standard practice)
-inline std::ostream &operator<<(std::ostream &os, Color c) { return os << (c == Color::kRed ? "kRed" : "kBlue"); };
+inline std::ostream &operator<<(std::ostream &os, Color c) { return os << (c == Color::kRed ? "kRed" : "kBlue"); }
 
 // test from https://github.com/CLIUtils/CLI11/issues/1258 [huweiATgithub](https://github.com/huweiATgithub)
 TEST_CASE_METHOD(TApp, "streamTransformCheck", "[transform]") {

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -159,7 +159,24 @@ TEST_CASE_METHOD(TApp, "EnumCheckedDefaultTransform", "[transform]") {
 
 // test from https://github.com/CLIUtils/CLI11/issues/369  [Jakub Zakrzewski](https://github.com/jzakrzewski)
 TEST_CASE_METHOD(TApp, "EnumCheckedDefaultTransformCallback", "[transform]") {
+    enum class existing : std::int16_t { abort, overwrite, remove };
+    auto cmd = std::make_shared<CLI::App>("deploys the repository somewhere", "deploy");
+    cmd->add_option("--existing", "What to do if file already exists in the destination")
+        ->transform(
+            CLI::CheckedTransformer(std::unordered_map<std::string, existing>{{"abort", existing::abort},
+                                                                              {"overwrite", existing::overwrite},
+                                                                              {"delete", existing::remove},
+                                                                              {"remove", existing::remove}}))
+        ->default_val("abort");
 
+    cmd->callback([cmd]() { CHECK(cmd->get_option("--existing")->as<existing>() == existing::abort); });
+    app.add_subcommand(cmd);
+
+    args = {"deploy"};
+    run();
+}
+
+TEST_CASE_METHOD(TApp, "SimpleTransformFn", "[transform]") {
     int value{0};
     auto *opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", "1"}}, CLI::ignore_case));
     args = {"-s", "ONE"};
@@ -178,8 +195,8 @@ inline std::ostream &operator<<(std::ostream &os, Color c) { return os << (c == 
 TEST_CASE_METHOD(TApp, "streamTransformCheck", "[transform]") {
 
     std::map<std::string, Color> color_map = {
-        {"red", Color::kRed},   // User types "red"
-        {"blue", Color::kBlue}  // User types "blue"
+        {"red", Color::kRed},    // User types "red"
+        {"blue", Color::kBlue}   // User types "blue"
     };
     Color color = Color::kRed;
 

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -160,7 +160,6 @@ TEST_CASE_METHOD(TApp, "EnumCheckedDefaultTransform", "[transform]") {
 // test from https://github.com/CLIUtils/CLI11/issues/369  [Jakub Zakrzewski](https://github.com/jzakrzewski)
 TEST_CASE_METHOD(TApp, "EnumCheckedDefaultTransformCallback", "[transform]") {
 
-
     int value{0};
     auto *opt = app.add_option("-s", value)->transform(CLI::Transformer({{"one", "1"}}, CLI::ignore_case));
     args = {"-s", "ONE"};
@@ -173,16 +172,14 @@ TEST_CASE_METHOD(TApp, "EnumCheckedDefaultTransformCallback", "[transform]") {
 enum class Color { kRed, kBlue };
 
 // operator<< outputs full enum name (standard practice)
-inline std::ostream& operator<<(std::ostream& os, Color c) {
-    return os << (c == Color::kRed ? "kRed" : "kBlue");
-};
+inline std::ostream &operator<<(std::ostream &os, Color c) { return os << (c == Color::kRed ? "kRed" : "kBlue"); };
 
 // test from https://github.com/CLIUtils/CLI11/issues/1258 [huweiATgithub](https://github.com/huweiATgithub)
 TEST_CASE_METHOD(TApp, "streamTransformCheck", "[transform]") {
 
     std::map<std::string, Color> color_map = {
-        {"red", Color::kRed},    // User types "red"
-        {"blue", Color::kBlue}   // User types "blue"
+        {"red", Color::kRed},   // User types "red"
+        {"blue", Color::kBlue}  // User types "blue"
     };
     Color color = Color::kRed;
 
@@ -191,8 +188,6 @@ TEST_CASE_METHOD(TApp, "streamTransformCheck", "[transform]") {
         ->default_val(Color::kRed);  // BUG: Validates "kRed" against {"red", "blue"}
 
     CHECK_NOTHROW(app.parse(""));  // Should use default
-
-    
 }
 
 #if defined(CLI11_HAS_STRING_VIEW)


### PR DESCRIPTION
fix an issue where an enumeration with a stream output method would generate strings that could not be converted back to the original enumeration value.

Fixes Issue #1258 

recent changes fixed a few issues with the default_val method.  The method used the to_string, which in cases where a user supplied a streaming operation to enumerations they could not be converted back to the enumeration properly resulting in some errors and confusing help output.   