### PR TITLE
Extras configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,11 +1132,11 @@ option_groups. These are:
   - `CLI::ExtrasMode::Ignore`: ignore any unrecognized argument, do not generate
     an error.
   - `CLI::ExtrasMode::AssumeSingleArgument`: After an unrecognized flag or
-    option argument, if the following arugment is not a flag or option argument
+    option argument, if the following argument is not a flag or option argument
     assume it an argument and treat it as also unrecognized even if it would
     otherwise go to a positional argument
   - `CLI::ExtrasMode::AssumeMultipleArguments`:After an unrecognized flag or
-    option argument, if the following arugments are not a flag or option
+    option argument, if the following arguments are not a flag or option
     argument assume they are arguments and treat them as also unrecognized even
     if it would otherwise go to a positional argument
   - `CLI::ExtrasMode::Capture`: capture all unrecognized arguments, same as

--- a/README.md
+++ b/README.md
@@ -1123,13 +1123,24 @@ option_groups. These are:
   executes after the first argument of an application is processed. See
   [Subcommand callbacks](#callbacks) for some additional details.
 - `.allow_extras()`: Do not throw an error if extra arguments are left over.
-- `.allow_extras(CLI::ExtrasMode)`: Specify the method of handling unrecognized arguments. 
-  - `CLI::ExtrasMode::Error`: generate an error on unrecognized argument. Same as `.allow_extras(false)`.
-  - `CLI::ExtrasMode::ErrorImmediately`: generate an error immediately on parsing an unrecognized option`.
-  - `CLI::ExtrasMode::Ignore`: ignore any unrecognized argument, do not generate an error.
-  - `CLI::ExtrasMode::AssumeSingleArgument`: After an unrecognized flag or option argument, if the following arugment is not a flag or option argument assume it an argument and treat it as also unrecognized even if it would otherwise go to a positional argument
-  - `CLI::ExtrasMode::AssumeMultipleArguments`:After an unrecognized flag or option argument, if the following arugments are not a flag or option argument assume they are arguments and treat them as also unrecognized even if it would otherwise go to a positional argument
-  - `CLI::ExtrasMode::Capture`: capture all unrecognized arguments, same as `true` for `.allow_extras`:
+- `.allow_extras(CLI::ExtrasMode)`: Specify the method of handling unrecognized
+  arguments.
+  - `CLI::ExtrasMode::Error`: generate an error on unrecognized argument. Same
+    as `.allow_extras(false)`.
+  - `CLI::ExtrasMode::ErrorImmediately`: generate an error immediately on
+    parsing an unrecognized option`.
+  - `CLI::ExtrasMode::Ignore`: ignore any unrecognized argument, do not generate
+    an error.
+  - `CLI::ExtrasMode::AssumeSingleArgument`: After an unrecognized flag or
+    option argument, if the following arugment is not a flag or option argument
+    assume it an argument and treat it as also unrecognized even if it would
+    otherwise go to a positional argument
+  - `CLI::ExtrasMode::AssumeMultipleArguments`:After an unrecognized flag or
+    option argument, if the following arugments are not a flag or option
+    argument assume they are arguments and treat them as also unrecognized even
+    if it would otherwise go to a positional argument
+  - `CLI::ExtrasMode::Capture`: capture all unrecognized arguments, same as
+    `true` for `.allow_extras`:
 - `.positionals_at_end()`: Specify that positional arguments occur as the last
   arguments and throw an error if an unexpected positional is encountered.
 - `.prefix_command()`: Like `allow_extras`, but stop processing immediately on

--- a/README.md
+++ b/README.md
@@ -1123,6 +1123,13 @@ option_groups. These are:
   executes after the first argument of an application is processed. See
   [Subcommand callbacks](#callbacks) for some additional details.
 - `.allow_extras()`: Do not throw an error if extra arguments are left over.
+- `.allow_extras(CLI::ExtrasMode)`: Specify the method of handling unrecognized arguments. 
+  - `CLI::ExtrasMode::Error`: generate an error on unrecognized argument. Same as `.allow_extras(false)`.
+  - `CLI::ExtrasMode::ErrorImmediately`: generate an error immediately on parsing an unrecognized option`.
+  - `CLI::ExtrasMode::Ignore`: ignore any unrecognized argument, do not generate an error.
+  - `CLI::ExtrasMode::AssumeSingleArgument`: After an unrecognized flag or option argument, if the following arugment is not a flag or option argument assume it an argument and treat it as also unrecognized even if it would otherwise go to a positional argument
+  - `CLI::ExtrasMode::AssumeMultipleArguments`:After an unrecognized flag or option argument, if the following arugments are not a flag or option argument assume they are arguments and treat them as also unrecognized even if it would otherwise go to a positional argument
+  - `CLI::ExtrasMode::Capture`: capture all unrecognized arguments, same as `true` for `.allow_extras`:
 - `.positionals_at_end()`: Specify that positional arguments occur as the last
   arguments and throw an error if an unexpected positional is encountered.
 - `.prefix_command()`: Like `allow_extras`, but stop processing immediately on

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -67,14 +67,13 @@ CLI11_INLINE std::string help(const App *app, const Error &e);
 }  // namespace FailureMessage
 
 /// enumeration of modes of how to deal with command line extras
-enum class ExtrasMode:std::uint8_t{Error=0, Ignore,AssumeSingleArgument,AssumeMultipleArguments,Capture};
+enum class ExtrasMode : std::uint8_t { Error = 0, Ignore, AssumeSingleArgument, AssumeMultipleArguments, Capture };
 
 /// enumeration of modes of how to deal with extras in config files
-enum class ConfigExtrasMode : std::uint8_t { Error = 0, Ignore, IgnoreAll, Capture};
+enum class ConfigExtrasMode : std::uint8_t { Error = 0, Ignore, IgnoreAll, Capture };
 
 /// @brief  enumeration of modes of how to deal with extras in config files
 enum class config_extras_mode : std::uint8_t { error = 0, ignore, ignore_all, capture };
-
 
 /// @brief  enumeration of prefix command modes, separator requires that the first extra argument be a "--", other
 /// unrecognized arguments will cause an error. on allows the first extra to trigger prefix mode regardless of other
@@ -395,7 +394,7 @@ class App {
 
     /// Remove the error when extras are left over on the command line.
     App *allow_extras(bool allow = true) {
-        allow_extras_ = allow?ExtrasMode::Capture:ExtrasMode::Error;
+        allow_extras_ = allow ? ExtrasMode::Capture : ExtrasMode::Error;
         return this;
     }
 
@@ -1198,7 +1197,7 @@ class App {
     CLI11_NODISCARD PrefixCommandMode get_prefix_command_mode() const { return prefix_command_; }
 
     /// Get the status of allow extras
-    CLI11_NODISCARD bool get_allow_extras() const { return allow_extras_>ExtrasMode::Ignore; }
+    CLI11_NODISCARD bool get_allow_extras() const { return allow_extras_ > ExtrasMode::Ignore; }
 
     /// Get the mode of allow_extras
     CLI11_NODISCARD ExtrasMode get_allow_extras_mode() const { return allow_extras_; }
@@ -1232,7 +1231,9 @@ class App {
     CLI11_NODISCARD bool get_validate_optional_arguments() const { return validate_optional_arguments_; }
 
     /// Get the status of allow extras
-    CLI11_NODISCARD config_extras_mode get_allow_config_extras() const { return static_cast<config_extras_mode>(allow_config_extras_); }
+    CLI11_NODISCARD config_extras_mode get_allow_config_extras() const {
+        return static_cast<config_extras_mode>(allow_config_extras_);
+    }
 
     /// Get a pointer to the help flag.
     Option *get_help_ptr() { return help_ptr_; }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -67,7 +67,7 @@ CLI11_INLINE std::string help(const App *app, const Error &e);
 }  // namespace FailureMessage
 
 /// enumeration of modes of how to deal with command line extras
-enum class ExtrasMode : std::uint8_t { Error = 0, Ignore, AssumeSingleArgument, AssumeMultipleArguments, Capture };
+enum class ExtrasMode:std::uint8_t{Error=0,ErrorImmediately, Ignore,AssumeSingleArgument,AssumeMultipleArguments,Capture};
 
 /// enumeration of modes of how to deal with extras in config files
 enum class ConfigExtrasMode : std::uint8_t { Error = 0, Ignore, IgnoreAll, Capture };

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -65,10 +65,13 @@ CLI11_INLINE std::string simple(const App *app, const Error &e);
 /// Printout the full help string on error (if this fn is set, the old default for CLI11)
 CLI11_INLINE std::string help(const App *app, const Error &e);
 }  // namespace FailureMessage
+/// enumeration of modes of how to deal with command line extras
 
+enum class ExtrasMode:std::uint8_t{error=0, ignore,assume_arguments,capture};
 /// enumeration of modes of how to deal with extras in config files
 enum class config_extras_mode : std::uint8_t { error = 0, ignore, ignore_all, capture };
 
+enum class ConfigExtrasMode : std::uint8_t { Error = 0, Ignore, IgnoreAll, Capture };
 /// @brief  enumeration of prefix command modes, separator requires that the first extra argument be a "--", other
 /// unrecognized arguments will cause an error. on allows the first extra to trigger prefix mode regardless of other
 /// recognized options
@@ -116,7 +119,7 @@ class App {
     std::string description_{};
 
     /// If true, allow extra arguments (ie, don't throw an error). INHERITABLE
-    bool allow_extras_{false};
+    bool allow_extras_{ExtrasMode::error};
 
     /// If ignore, allow extra arguments in the ini file (ie, don't throw an error). INHERITABLE
     /// if error, error on an extra argument, and if capture feed it to the app

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -67,11 +67,15 @@ CLI11_INLINE std::string help(const App *app, const Error &e);
 }  // namespace FailureMessage
 /// enumeration of modes of how to deal with command line extras
 
-enum class ExtrasMode:std::uint8_t{error=0, ignore,assume_arguments,capture};
+enum class ExtrasMode:std::uint8_t{Error=0, Ignore,AssumeArguments,Capture};
+
 /// enumeration of modes of how to deal with extras in config files
+enum class ConfigExtrasMode : std::uint8_t { Error = 0, Ignore, IgnoreAll, Capture};
+
+/// @brief  enumeration of modes of how to deal with extras in config files
 enum class config_extras_mode : std::uint8_t { error = 0, ignore, ignore_all, capture };
 
-enum class ConfigExtrasMode : std::uint8_t { Error = 0, Ignore, IgnoreAll, Capture };
+
 /// @brief  enumeration of prefix command modes, separator requires that the first extra argument be a "--", other
 /// unrecognized arguments will cause an error. on allows the first extra to trigger prefix mode regardless of other
 /// recognized options
@@ -119,11 +123,11 @@ class App {
     std::string description_{};
 
     /// If true, allow extra arguments (ie, don't throw an error). INHERITABLE
-    bool allow_extras_{ExtrasMode::error};
+    ExtrasMode allow_extras_{ExtrasMode::Error};
 
     /// If ignore, allow extra arguments in the ini file (ie, don't throw an error). INHERITABLE
     /// if error, error on an extra argument, and if capture feed it to the app
-    config_extras_mode allow_config_extras_{config_extras_mode::ignore};
+    ConfigExtrasMode allow_config_extras_{ConfigExtrasMode::Ignore};
 
     ///  If true, cease processing on an unrecognized option (implies allow_extras) INHERITABLE
     PrefixCommandMode prefix_command_{PrefixCommandMode::Off};
@@ -391,6 +395,12 @@ class App {
 
     /// Remove the error when extras are left over on the command line.
     App *allow_extras(bool allow = true) {
+        allow_extras_ = allow?ExtrasMode::Capture:ExtrasMode::Error;
+        return this;
+    }
+
+    /// Remove the error when extras are left over on the command line.
+    App *allow_extras(ExtrasMode allow) {
         allow_extras_ = allow;
         return this;
     }
@@ -464,16 +474,22 @@ class App {
     /// ignore extras in config files
     App *allow_config_extras(bool allow = true) {
         if(allow) {
-            allow_config_extras_ = config_extras_mode::capture;
-            allow_extras_ = true;
+            allow_config_extras_ = ConfigExtrasMode::Capture;
+            allow_extras_ = ExtrasMode::Capture;
         } else {
-            allow_config_extras_ = config_extras_mode::error;
+            allow_config_extras_ = ConfigExtrasMode::Error;
         }
         return this;
     }
 
     /// ignore extras in config files
     App *allow_config_extras(config_extras_mode mode) {
+        allow_config_extras_ = static_cast<ConfigExtrasMode>(mode);
+        return this;
+    }
+
+    /// ignore extras in config files
+    App *allow_config_extras(ConfigExtrasMode mode) {
         allow_config_extras_ = mode;
         return this;
     }
@@ -1182,7 +1198,10 @@ class App {
     CLI11_NODISCARD PrefixCommandMode get_prefix_command_mode() const { return prefix_command_; }
 
     /// Get the status of allow extras
-    CLI11_NODISCARD bool get_allow_extras() const { return allow_extras_; }
+    CLI11_NODISCARD bool get_allow_extras() const { return allow_extras_>ExtrasMode::Ignore; }
+
+    /// Get the mode of allow_extras
+    CLI11_NODISCARD ExtrasMode get_allow_extra_mode() const { return allow_extras_; }
 
     /// Get the status of required
     CLI11_NODISCARD bool get_required() const { return required_; }
@@ -1213,7 +1232,7 @@ class App {
     CLI11_NODISCARD bool get_validate_optional_arguments() const { return validate_optional_arguments_; }
 
     /// Get the status of allow extras
-    CLI11_NODISCARD config_extras_mode get_allow_config_extras() const { return allow_config_extras_; }
+    CLI11_NODISCARD config_extras_mode get_allow_config_extras() const { return static_cast<config_extras_mode>(allow_config_extras_); }
 
     /// Get a pointer to the help flag.
     Option *get_help_ptr() { return help_ptr_; }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -65,9 +65,9 @@ CLI11_INLINE std::string simple(const App *app, const Error &e);
 /// Printout the full help string on error (if this fn is set, the old default for CLI11)
 CLI11_INLINE std::string help(const App *app, const Error &e);
 }  // namespace FailureMessage
-/// enumeration of modes of how to deal with command line extras
 
-enum class ExtrasMode:std::uint8_t{Error=0, Ignore,AssumeArguments,Capture};
+/// enumeration of modes of how to deal with command line extras
+enum class ExtrasMode:std::uint8_t{Error=0, Ignore,AssumeSingleArgument,AssumeMultipleArguments,Capture};
 
 /// enumeration of modes of how to deal with extras in config files
 enum class ConfigExtrasMode : std::uint8_t { Error = 0, Ignore, IgnoreAll, Capture};
@@ -1201,7 +1201,7 @@ class App {
     CLI11_NODISCARD bool get_allow_extras() const { return allow_extras_>ExtrasMode::Ignore; }
 
     /// Get the mode of allow_extras
-    CLI11_NODISCARD ExtrasMode get_allow_extra_mode() const { return allow_extras_; }
+    CLI11_NODISCARD ExtrasMode get_allow_extras_mode() const { return allow_extras_; }
 
     /// Get the status of required
     CLI11_NODISCARD bool get_required() const { return required_; }

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -67,7 +67,14 @@ CLI11_INLINE std::string help(const App *app, const Error &e);
 }  // namespace FailureMessage
 
 /// enumeration of modes of how to deal with command line extras
-enum class ExtrasMode:std::uint8_t{Error=0,ErrorImmediately, Ignore,AssumeSingleArgument,AssumeMultipleArguments,Capture};
+enum class ExtrasMode : std::uint8_t {
+    Error = 0,
+    ErrorImmediately,
+    Ignore,
+    AssumeSingleArgument,
+    AssumeMultipleArguments,
+    Capture
+};
 
 /// enumeration of modes of how to deal with extras in config files
 enum class ConfigExtrasMode : std::uint8_t { Error = 0, Ignore, IgnoreAll, Capture };

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -986,7 +986,7 @@ CLI11_NODISCARD CLI11_INLINE std::vector<std::string> App::remaining(bool recurs
     }
     // Get from a subcommand that may allow extras
     if(recurse) {
-        if(allow_extras_==ExtrasMode::Error||allow_extras_==ExtrasMode::Ignore) {
+        if(allow_extras_ == ExtrasMode::Error || allow_extras_ == ExtrasMode::Ignore) {
             for(const auto &sub : subcommands_) {
                 if(sub->name_.empty() && !sub->missing_.empty()) {
                     for(const std::pair<detail::Classifier, std::string> &miss : sub->missing_) {
@@ -1461,13 +1461,13 @@ CLI11_INLINE void App::_process() {
 }
 
 CLI11_INLINE void App::_process_extras() {
-    if(allow_extras_==ExtrasMode::Error && prefix_command_ == PrefixCommandMode::Off) {
+    if(allow_extras_ == ExtrasMode::Error && prefix_command_ == PrefixCommandMode::Off) {
         std::size_t num_left_over = remaining_size();
         if(num_left_over > 0) {
             throw ExtrasError(name_, remaining(false));
         }
     }
-    if(allow_extras_==ExtrasMode::Error && prefix_command_ == PrefixCommandMode::SeparatorOnly) {
+    if(allow_extras_ == ExtrasMode::Error && prefix_command_ == PrefixCommandMode::SeparatorOnly) {
         std::size_t num_left_over = remaining_size();
         if(num_left_over > 0) {
             if(remaining(false).front() != "--") {
@@ -1730,7 +1730,7 @@ CLI11_INLINE bool App::_parse_single(std::vector<std::string> &args, bool &posit
         args.pop_back();
         positional_only = true;
         if(get_prefix_command()) {
-            //don't care about extras mode here
+            // don't care about extras mode here
             missing_.emplace_back(classifier, "--");
             while(!args.empty()) {
                 missing_.emplace_back(detail::Classifier::NONE, args.back());
@@ -2154,20 +2154,14 @@ App::_parse_arg(std::vector<std::string> &args, detail::Classifier current_type,
                 missing_.emplace_back(detail::Classifier::NONE, args.back());
                 args.pop_back();
             }
-        }
-        else if (allow_extras_ == ExtrasMode::AssumeSingleArgument)
-        {
-            if (!args.empty() && _recognize(args.back(), false) == detail::Classifier::NONE)
-            {
-                _move_to_missing(detail::Classifier::NONE,args.back());
+        } else if(allow_extras_ == ExtrasMode::AssumeSingleArgument) {
+            if(!args.empty() && _recognize(args.back(), false) == detail::Classifier::NONE) {
+                _move_to_missing(detail::Classifier::NONE, args.back());
                 args.pop_back();
             }
-        }
-        else if (allow_extras_ == ExtrasMode::AssumeMultipleArguments)
-        {
-            while (!args.empty() && _recognize(args.back(), false) == detail::Classifier::NONE)
-            {
-                _move_to_missing(detail::Classifier::NONE,args.back());
+        } else if(allow_extras_ == ExtrasMode::AssumeMultipleArguments) {
+            while(!args.empty() && _recognize(args.back(), false) == detail::Classifier::NONE) {
+                _move_to_missing(detail::Classifier::NONE, args.back());
                 args.pop_back();
             }
         }
@@ -2360,11 +2354,12 @@ CLI11_NODISCARD CLI11_INLINE const std::string &App::_compare_subcommand_names(c
 }
 
 inline bool capture_extras(ExtrasMode mode) {
-    return mode == ExtrasMode::Capture || mode == ExtrasMode::AssumeSingleArgument||mode==ExtrasMode::AssumeMultipleArguments;
+    return mode == ExtrasMode::Capture || mode == ExtrasMode::AssumeSingleArgument ||
+           mode == ExtrasMode::AssumeMultipleArguments;
 }
 CLI11_INLINE void App::_move_to_missing(detail::Classifier val_type, const std::string &val) {
-    if (capture_extras(allow_extras_) || subcommands_.empty() || get_prefix_command()) {
-        if (allow_extras_ != ExtrasMode::Ignore) {
+    if(capture_extras(allow_extras_) || subcommands_.empty() || get_prefix_command()) {
+        if(allow_extras_ != ExtrasMode::Ignore) {
             missing_.emplace_back(val_type, val);
         }
         return;
@@ -2376,11 +2371,10 @@ CLI11_INLINE void App::_move_to_missing(detail::Classifier val_type, const std::
             return;
         }
     }
-    if (allow_extras_ != ExtrasMode::Ignore) {
+    if(allow_extras_ != ExtrasMode::Ignore) {
         // if we haven't found any place to put them yet put them in missing
         missing_.emplace_back(val_type, val);
     }
-    
 }
 
 CLI11_INLINE void App::_move_option(Option *opt, App *app) {

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -2358,12 +2358,11 @@ inline bool capture_extras(ExtrasMode mode) {
            mode == ExtrasMode::AssumeMultipleArguments;
 }
 CLI11_INLINE void App::_move_to_missing(detail::Classifier val_type, const std::string &val) {
-    if (allow_extras_ == ExtrasMode::ErrorImmediately)
-    {
+    if(allow_extras_ == ExtrasMode::ErrorImmediately) {
         throw ExtrasError(name_, std::vector<std::string>{val});
     }
-    if (capture_extras(allow_extras_) || subcommands_.empty() || get_prefix_command()) {
-        if (allow_extras_ != ExtrasMode::Ignore) {
+    if(capture_extras(allow_extras_) || subcommands_.empty() || get_prefix_command()) {
+        if(allow_extras_ != ExtrasMode::Ignore) {
             missing_.emplace_back(val_type, val);
         }
         return;

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -2358,8 +2358,12 @@ inline bool capture_extras(ExtrasMode mode) {
            mode == ExtrasMode::AssumeMultipleArguments;
 }
 CLI11_INLINE void App::_move_to_missing(detail::Classifier val_type, const std::string &val) {
-    if(capture_extras(allow_extras_) || subcommands_.empty() || get_prefix_command()) {
-        if(allow_extras_ != ExtrasMode::Ignore) {
+    if (allow_extras_ == ExtrasMode::ErrorImmediately)
+    {
+        throw ExtrasError(name_, std::vector<std::string>{val});
+    }
+    if (capture_extras(allow_extras_) || subcommands_.empty() || get_prefix_command()) {
+        if (allow_extras_ != ExtrasMode::Ignore) {
             missing_.emplace_back(val_type, val);
         }
         return;

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2444,38 +2444,34 @@ TEST_CASE_METHOD(TApp, "AllowExtrasAssumptions", "[app]") {
     args = {"--one", "45", "--three", "27", "this"};
 
     REQUIRE_NOTHROW(run());
-    CHECK(one=="45");
+    CHECK(one == "45");
     CHECK(two == "this");
-    CHECK(app.remaining().size()==2U);
-
-
-   
+    CHECK(app.remaining().size() == 2U);
 
     two.clear();
     app.allow_extras(CLI::ExtrasMode::AssumeMultipleArguments);
 
     run();
-    CHECK(one=="45");
+    CHECK(one == "45");
     CHECK(two.empty());
-    CHECK(app.remaining().size()==3U);
+    CHECK(app.remaining().size() == 3U);
     app.allow_extras(CLI::ExtrasMode::AssumeSingleArgument);
     CHECK(app.get_allow_extras_mode() == CLI::ExtrasMode::AssumeSingleArgument);
-    args = {"--three", "27","--one", "45",  "this"};
+    args = {"--three", "27", "--one", "45", "this"};
     run();
-    CHECK(one=="45");
+    CHECK(one == "45");
     CHECK(two == "this");
-    CHECK(app.remaining().size()==2U);
+    CHECK(app.remaining().size() == 2U);
 
     app.allow_extras(CLI::ExtrasMode::AssumeMultipleArguments);
     CHECK(app.get_allow_extras_mode() == CLI::ExtrasMode::AssumeMultipleArguments);
-    args = {"--three", "27","extra","--one", "45",  "this"};
+    args = {"--three", "27", "extra", "--one", "45", "this"};
     one.clear();
     two.clear();
     run();
-    CHECK(one=="45");
+    CHECK(one == "45");
     CHECK(two == "this");
-    CHECK(app.remaining().size()==3U);
-
+    CHECK(app.remaining().size() == 3U);
 }
 
 TEST_CASE_METHOD(TApp, "PrefixCommand", "[app]") {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2474,28 +2474,27 @@ TEST_CASE_METHOD(TApp, "AllowExtrasAssumptions", "[app]") {
     CHECK(app.remaining().size() == 3U);
 }
 
-
 TEST_CASE_METHOD(TApp, "AllowExtrasImmediateError", "[app]") {
 
-    int v1{ 0 };
-    int v2{ 0 };
+    int v1{0};
+    int v2{0};
     app.add_option("-f", v1)->trigger_on_parse();
     app.add_option("-x", v2);
-    args = { "-x", "15", "-f", "17", "-g", "19" };
+    args = {"-x", "15", "-f", "17", "-g", "19"};
     CHECK_THROWS_AS(run(), CLI::ExtrasError);
-    CHECK(v1==17);
-    CHECK(app.remaining().size()==2U);
-    args = { "-x", "21", "-f", "23", "-g", "25" };
+    CHECK(v1 == 17);
+    CHECK(app.remaining().size() == 2U);
+    args = {"-x", "21", "-f", "23", "-g", "25"};
     app.allow_extras(CLI::ExtrasMode::ErrorImmediately);
     CHECK_THROWS_AS(run(), CLI::ExtrasError);
-    CHECK(v1==23); //-f still triggers
-    CHECK(v2==15);
-    CHECK(app.remaining().size()==0U);
-    args = { "-x", "27","-g", "29", "-f", "31"  };
+    CHECK(v1 == 23);  //-f still triggers
+    CHECK(v2 == 15);
+    CHECK(app.remaining().size() == 0U);
+    args = {"-x", "27", "-g", "29", "-f", "31"};
     CHECK_THROWS_AS(run(), CLI::ExtrasError);
-    CHECK(v1==23); // -f did not trigger
-    CHECK(v2==15);
-    CHECK(app.remaining().size()==0U);
+    CHECK(v1 == 23);  // -f did not trigger
+    CHECK(v2 == 15);
+    CHECK(app.remaining().size() == 0U);
 }
 
 TEST_CASE_METHOD(TApp, "PrefixCommand", "[app]") {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2487,14 +2487,14 @@ TEST_CASE_METHOD(TApp, "AllowExtrasImmediateError", "[app]") {
     args = {"-x", "21", "-f", "23", "-g", "25"};
     app.allow_extras(CLI::ExtrasMode::ErrorImmediately);
     CHECK_THROWS_AS(run(), CLI::ExtrasError);
-    CHECK(v1 == 23);  //-f still triggers
+    CHECK(v1 == 23);  // -f still triggers
     CHECK(v2 == 15);
-    CHECK(app.remaining().size() == 0U);
+    CHECK(app.remaining().empty());
     args = {"-x", "27", "-g", "29", "-f", "31"};
     CHECK_THROWS_AS(run(), CLI::ExtrasError);
     CHECK(v1 == 23);  // -f did not trigger
     CHECK(v2 == 15);
-    CHECK(app.remaining().size() == 0U);
+    CHECK(app.remaining().empty());
 }
 
 TEST_CASE_METHOD(TApp, "PrefixCommand", "[app]") {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2474,6 +2474,30 @@ TEST_CASE_METHOD(TApp, "AllowExtrasAssumptions", "[app]") {
     CHECK(app.remaining().size() == 3U);
 }
 
+
+TEST_CASE_METHOD(TApp, "AllowExtrasImmediateError", "[app]") {
+
+    int v1{ 0 };
+    int v2{ 0 };
+    app.add_option("-f", v1)->trigger_on_parse();
+    app.add_option("-x", v2);
+    args = { "-x", "15", "-f", "17", "-g", "19" };
+    CHECK_THROWS_AS(run(), CLI::ExtrasError);
+    CHECK(v1==17);
+    CHECK(app.remaining().size()==2U);
+    args = { "-x", "21", "-f", "23", "-g", "25" };
+    app.allow_extras(CLI::ExtrasMode::ErrorImmediately);
+    CHECK_THROWS_AS(run(), CLI::ExtrasError);
+    CHECK(v1==23); //-f still triggers
+    CHECK(v2==15);
+    CHECK(app.remaining().size()==0U);
+    args = { "-x", "27","-g", "29", "-f", "31"  };
+    CHECK_THROWS_AS(run(), CLI::ExtrasError);
+    CHECK(v1==23); // -f did not trigger
+    CHECK(v2==15);
+    CHECK(app.remaining().size()==0U);
+}
+
 TEST_CASE_METHOD(TApp, "PrefixCommand", "[app]") {
     int v1{0};
     int v2{0};
@@ -2526,8 +2550,6 @@ TEST_CASE_METHOD(TApp, "PrefixCommand", "[app]") {
 
 // makes sure the error throws on the rValue version of the parse
 TEST_CASE_METHOD(TApp, "ExtrasErrorRvalueParse", "[app]") {
-
-    args = {"-x", "45", "-f", "27"};
 
     CHECK_THROWS_AS(app.parse(std::vector<std::string>({"-x", "45", "-f", "27"})), CLI::ExtrasError);
 }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2391,6 +2391,12 @@ TEST_CASE_METHOD(TApp, "AllowExtras", "[app]") {
     REQUIRE_NOTHROW(run());
     CHECK(val);
     CHECK(std::vector<std::string>({"-x"}) == app.remaining());
+
+    app.allow_extras(CLI::ExtrasMode::Ignore);
+    val = false;
+    REQUIRE_NOTHROW(run());
+    CHECK(val);
+    CHECK(app.remaining().empty());
 }
 
 TEST_CASE_METHOD(TApp, "AllowExtrasOrder", "[app]") {
@@ -2410,7 +2416,6 @@ TEST_CASE_METHOD(TApp, "AllowExtrasOrder", "[app]") {
 TEST_CASE_METHOD(TApp, "AllowExtrasCascade", "[app]") {
 
     app.allow_extras();
-
     args = {"-x", "45", "-f", "27"};
     REQUIRE_NOTHROW(run());
     CHECK(std::vector<std::string>({"-x", "45", "-f", "27"}) == app.remaining());
@@ -2426,6 +2431,51 @@ TEST_CASE_METHOD(TApp, "AllowExtrasCascade", "[app]") {
     capp.parse(left_over);
     CHECK(45 == v1);
     CHECK(27 == v2);
+}
+
+TEST_CASE_METHOD(TApp, "AllowExtrasAssumptions", "[app]") {
+
+    app.allow_extras(CLI::ExtrasMode::AssumeSingleArgument);
+
+    std::string one;
+    std::string two;
+    app.add_option("--one", one);
+    app.add_option("two", two);
+    args = {"--one", "45", "--three", "27", "this"};
+
+    REQUIRE_NOTHROW(run());
+    CHECK(one=="45");
+    CHECK(two == "this");
+    CHECK(app.remaining().size()==2U);
+
+
+   
+
+    two.clear();
+    app.allow_extras(CLI::ExtrasMode::AssumeMultipleArguments);
+
+    run();
+    CHECK(one=="45");
+    CHECK(two.empty());
+    CHECK(app.remaining().size()==3U);
+    app.allow_extras(CLI::ExtrasMode::AssumeSingleArgument);
+    CHECK(app.get_allow_extras_mode() == CLI::ExtrasMode::AssumeSingleArgument);
+    args = {"--three", "27","--one", "45",  "this"};
+    run();
+    CHECK(one=="45");
+    CHECK(two == "this");
+    CHECK(app.remaining().size()==2U);
+
+    app.allow_extras(CLI::ExtrasMode::AssumeMultipleArguments);
+    CHECK(app.get_allow_extras_mode() == CLI::ExtrasMode::AssumeMultipleArguments);
+    args = {"--three", "27","extra","--one", "45",  "this"};
+    one.clear();
+    two.clear();
+    run();
+    CHECK(one=="45");
+    CHECK(two == "this");
+    CHECK(app.remaining().size()==3U);
+
 }
 
 TEST_CASE_METHOD(TApp, "PrefixCommand", "[app]") {

--- a/tests/OptionGroupTest.cpp
+++ b/tests/OptionGroupTest.cpp
@@ -706,6 +706,14 @@ TEST_CASE_METHOD(ManyGroups, "ExtrasFallDown", "[optiongroup]") {
     std::vector<std::string> extras{"--test1", "--flag", "extra"};
     CHECK(extras == app.remaining(true));
     CHECK(extras == main->remaining());
+    app.allow_extras(CLI::ExtrasMode::Ignore);
+
+    CHECK_NOTHROW(run());
+
+    CHECK(0u == app.remaining_size(false));
+
+    CHECK(extras == app.remaining(true));
+    CHECK(extras == main->remaining());
 }
 
 // Test the option Inheritance


### PR DESCRIPTION
Allow more control over how extras are interpreted.  Specifically allowing some assumptions to be made about arguments to unrecognized options.   With `CLI::ExtrasMode::AssumeMultipleArguments` all positional arguments following an unrecognized option will be considered extra as well even if there are open positional arguments.   With `CLI::ExtrasMode::AssumeSingleArgument` a positional argument following an unrecognized option will also be considered unrecognized and go into the `remaining()` bin.  