### PR TITLE
Fix 'UTF-8 config filenames not supported on Windows'  #912

### DIFF
--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -70,7 +70,12 @@ class Config {
 
     /// Parse a config file, throw an error (ParseError:ConfigParseError or FileError) on failure
     CLI11_NODISCARD std::vector<ConfigItem> from_file(const std::string &name) const {
+#if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
         std::ifstream input{to_path(name)};
+#else
+        std::ifstream input{name};
+#endif
+
         if(!input.good())
             throw FileError::Missing(name);
 

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 // [CLI11:public_includes:end]
-
+#include "Encoding.hpp"
 #include "Error.hpp"
 #include "StringTools.hpp"
 
@@ -70,7 +70,7 @@ class Config {
 
     /// Parse a config file, throw an error (ParseError:ConfigParseError or FileError) on failure
     CLI11_NODISCARD std::vector<ConfigItem> from_file(const std::string &name) const {
-        std::ifstream input{name};
+        std::ifstream input{to_path(name)};
         if(!input.good())
             throw FileError::Missing(name);
 


### PR DESCRIPTION
This PR should fix #912