### PR TITLE
fix: resolve C++26 template ambiguity for std::complex

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -544,7 +544,8 @@ template <typename T, std::size_t I>
 }
 
 /// Get the type size of the sum of type sizes for all the individual tuple types
-template <typename T> struct type_count<T, typename std::enable_if<is_tuple_like<T>::value && !is_complex<T>::value>::type> {
+template <typename T>
+struct type_count<T, typename std::enable_if<is_tuple_like<T>::value && !is_complex<T>::value>::type> {
     static constexpr int value{tuple_type_size<T, 0>()};
 };
 
@@ -593,7 +594,8 @@ template <typename T, std::size_t I>
 }
 
 /// Get the type size of the sum of type sizes for all the individual tuple types
-template <typename T> struct type_count_min<T, typename std::enable_if<is_tuple_like<T>::value && !is_complex<T>::value>::type> {
+template <typename T>
+struct type_count_min<T, typename std::enable_if<is_tuple_like<T>::value && !is_complex<T>::value>::type> {
     static constexpr int value{tuple_type_size_min<T, 0>()};
 };
 

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -544,7 +544,7 @@ template <typename T, std::size_t I>
 }
 
 /// Get the type size of the sum of type sizes for all the individual tuple types
-template <typename T> struct type_count<T, typename std::enable_if<is_tuple_like<T>::value>::type> {
+template <typename T> struct type_count<T, typename std::enable_if<is_tuple_like<T>::value && !is_complex<T>::value>::type> {
     static constexpr int value{tuple_type_size<T, 0>()};
 };
 
@@ -593,7 +593,7 @@ template <typename T, std::size_t I>
 }
 
 /// Get the type size of the sum of type sizes for all the individual tuple types
-template <typename T> struct type_count_min<T, typename std::enable_if<is_tuple_like<T>::value>::type> {
+template <typename T> struct type_count_min<T, typename std::enable_if<is_tuple_like<T>::value && !is_complex<T>::value>::type> {
     static constexpr int value{tuple_type_size_min<T, 0>()};
 };
 


### PR DESCRIPTION
In C++26, std::complex gained a tuple interface (P2819R2), causing template specialization ambiguity in type_count and type_count_min.

This change explicitly excludes is_complex from tuple-like template specializations, ensuring complex types are handled only by their dedicated specializations.

Fixes #1098