### PR TITLE
Fix build rules for Bazel 9

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 cc_library(
     name = "cli11",
     srcs = glob(["src/**/*.cpp"]),

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(name = "cli11")
 
 bazel_dep(name = "rules_cc", version = "0.2.16")
-bazel_dep(name = "catch2", version = "3.5.4", dev_dependency = True)
+bazel_dep(name = "catch2", version = "3.12.0", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,7 @@
-module(name = "cli11")
+module(
+    name = "cli11",
+    bazel_compatibility = [">=7.4.0"],
+)
 
 bazel_dep(name = "rules_cc", version = "0.2.16")
 bazel_dep(name = "catch2", version = "3.12.0", dev_dependency = True)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_binary(
     name = "ensure_utf8",
     srcs = ["applications/ensure_utf8.cpp"],


### PR DESCRIPTION
Fix build rules for Bazel 9

The cc_* rules have to be loaded explicitly from rules_cc now. I tested down to version 7.4.0 and added compatibility constraint (I also checked on main branch, it only works for version >= 7.4.0 too).