### PR TITLE
whitespace in option description

### DIFF
--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -610,13 +610,22 @@ CLI11_INLINE std::ostream &streamOutAsParagraph(std::ostream &out,
         std::size_t charsWritten = 0;
 
         while(iss >> word) {
-            if(word.length() + charsWritten > paragraphWidth) {
+            if(charsWritten>0 && (word.length() +1+ charsWritten > paragraphWidth)) {
                 out << '\n' << linePrefix;
                 charsWritten = 0;
             }
+            if (charsWritten == 0)
+            {
+                out << word;
+                charsWritten += word.length();
+            }
+            else {
+                out << ' ' << word;
+                charsWritten += word.length() + 1;
 
-            out << word << " ";
-            charsWritten += word.length() + 1;
+            }
+            
+            
         }
 
         if(!lss.eof())

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -610,22 +610,17 @@ CLI11_INLINE std::ostream &streamOutAsParagraph(std::ostream &out,
         std::size_t charsWritten = 0;
 
         while(iss >> word) {
-            if(charsWritten>0 && (word.length() +1+ charsWritten > paragraphWidth)) {
+            if(charsWritten > 0 && (word.length() + 1 + charsWritten > paragraphWidth)) {
                 out << '\n' << linePrefix;
                 charsWritten = 0;
             }
-            if (charsWritten == 0)
-            {
+            if(charsWritten == 0) {
                 out << word;
                 charsWritten += word.length();
-            }
-            else {
+            } else {
                 out << ' ' << word;
                 charsWritten += word.length() + 1;
-
             }
-            
-            
         }
 
         if(!lss.eof())

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -209,8 +209,8 @@ TEST_CASE("Formatter: AppCustomize", "[formatter]") {
     std::string help = app.help();
     CHECK_THAT(help, Contains("Run: [OPTIONS] [SUBCOMMANDS]\n\n"));
     CHECK_THAT(help, Contains("\nSUBCOMMANDS:\n"));
-    CHECK_THAT(help, Contains("  subcom1           This \n"));
-    CHECK_THAT(help, Contains("  subcom2           That \n"));
+    CHECK_THAT(help, Contains("  subcom1           This\n"));
+    CHECK_THAT(help, Contains("  subcom2           That\n"));
 }
 
 TEST_CASE("Formatter: AppCustomizeSimple", "[formatter]") {
@@ -225,8 +225,8 @@ TEST_CASE("Formatter: AppCustomizeSimple", "[formatter]") {
     std::string help = app.help();
     CHECK_THAT(help, Contains("Run: [OPTIONS] [SUBCOMMANDS]\n\n"));
     CHECK_THAT(help, Contains("\nSUBCOMMANDS:\n"));
-    CHECK_THAT(help, Contains("  subcom1           This \n"));
-    CHECK_THAT(help, Contains("  subcom2           That \n"));
+    CHECK_THAT(help, Contains("  subcom1           This\n"));
+    CHECK_THAT(help, Contains("  subcom2           That\n"));
 }
 
 TEST_CASE("Formatter: AllSub", "[formatter]") {

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -144,9 +144,8 @@ TEST_CASE("THelp: FooterSubcommandHelp", "[help]") {
 TEST_CASE("THelp: Description", "[help]") {
     CLI::App app{"My prog"};
     std::string x;
-    app.add_option("--option",x,"option description BD");
+    app.add_option("--option", x, "option description BD");
 
-   
     std::string help = app.help();
     CHECK_THAT(help, Contains("option description BD"));
     // there was an issue where an extra space was being generated in the description, so make sure that is not there

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -141,6 +141,18 @@ TEST_CASE("THelp: FooterSubcommandHelp", "[help]") {
     CHECK(footer_loc2 == std::string::npos);
 }
 
+TEST_CASE("THelp: Description", "[help]") {
+    CLI::App app{"My prog"};
+    std::string x;
+    app.add_option("--option",x,"option description BD");
+
+   
+    std::string help = app.help();
+    CHECK_THAT(help, Contains("option description BD"));
+    // there was an issue where an extra space was being generated in the description, so make sure that is not there
+    CHECK_THAT(help, !Contains("BD "));
+}
+
 TEST_CASE("THelp: OptionalPositional", "[help]") {
     CLI::App app{"My prog", "program"};
 


### PR DESCRIPTION
There was an extra space being added at the end of lines in option and app descriptions.  This change removes the extra spaces.

Fixes #1293
Fixes #1294