### PR TITLE
fix(StringTools): MISRA static analysis

### DIFF
--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -574,11 +574,11 @@ process_quoted_string(std::string &str, char string_char, char literal_char, boo
 }
 
 std::string get_environment_value(const std::string &env_name) {
-    char *buffer = nullptr;
     std::string ename_string;
 
 #ifdef _MSC_VER
     // Windows version
+    char *buffer = nullptr;
     std::size_t sz = 0;
     if(_dupenv_s(&buffer, &sz, env_name.c_str()) == 0 && buffer != nullptr) {
         ename_string = std::string(buffer);
@@ -586,6 +586,9 @@ std::string get_environment_value(const std::string &env_name) {
     }
 #else
     // This also works on Windows, but gives a warning
+
+    // MISRA static analysis need. MISRACPP2023-25_5_2-a-1
+    const char *buffer = nullptr;
     buffer = std::getenv(env_name.c_str());
     if(buffer != nullptr) {
         ename_string = std::string(buffer);


### PR DESCRIPTION
Fixed an issue with static analysis in the `get_environment_value` function.

Fixes #1298 