### PR TITLE
fix: remove en_US.UTF-8 from unicode locale fallback list

### DIFF
--- a/include/CLI/impl/Encoding_inl.hpp
+++ b/include/CLI/impl/Encoding_inl.hpp
@@ -33,7 +33,7 @@ namespace detail {
 #if !CLI11_HAS_CODECVT
 /// Attempt to set one of the acceptable unicode locales for conversion
 CLI11_INLINE void set_unicode_locale() {
-    static const std::array<const char *, 3> unicode_locales{{"C.UTF-8", "en_US.UTF-8", ".UTF-8"}};
+    static const std::array<const char *, 2> unicode_locales{{"C.UTF-8", ".UTF-8"}};
 
     for(const auto &locale_name : unicode_locales) {
         if(std::setlocale(LC_ALL, locale_name) != nullptr) {


### PR DESCRIPTION
## Summary

Remove `en_US.UTF-8` from the fallback locale list used by
`set_unicode_locale()`.

The current fallback list includes:
- `C.UTF-8`
- `en_US.UTF-8`
- `.UTF-8`

This change removes `en_US.UTF-8`, which can introduce unexpected behavior on
systems with a different default locale.

Closes #1141