### PR TITLE
fix for libc++/clang compilation on C++26

### DIFF
--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -121,10 +121,11 @@ CLI11_INLINE std::string Formatter::make_usage(const App *app, std::string name)
     // Print out positionals if any are left
     if(!positionals.empty()) {
         // Convert to help names
-        std::vector<std::string> positional_names(positionals.size());
-        std::transform(positionals.begin(), positionals.end(), positional_names.begin(), [this](const Option *opt) {
-            return make_option_usage(opt);
-        });
+        std::vector<std::string> positional_names;
+        positional_names.reserve(positionals.size());
+        for(const auto *opt : positionals) {
+            positional_names.push_back(make_option_usage(opt));
+        }
 
         out << " " << detail::join(positional_names, " ");
     }

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -26,7 +26,7 @@ using Catch::Matchers::WithinRel;     // NOLINT(google-global-names-in-headers)
 inline auto Contains(const std::string &x) { return Catch::Matchers::ContainsSubstring(x); }
 
 #else
-
+#include <new>
 #include <catch2/catch.hpp>
 
 using Catch::Equals;              // NOLINT(google-global-names-in-headers)

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -26,8 +26,8 @@ using Catch::Matchers::WithinRel;     // NOLINT(google-global-names-in-headers)
 inline auto Contains(const std::string &x) { return Catch::Matchers::ContainsSubstring(x); }
 
 #else
-#include <new>
 #include <catch2/catch.hpp>
+#include <new>
 
 using Catch::Equals;              // NOLINT(google-global-names-in-headers)
 using Catch::WithinRel;           // NOLINT(google-global-names-in-headers)


### PR DESCRIPTION
This PR fixes a compilation issue I had
```
ccakit@mccakit-pc:~/desktop/cppscan$ cmake --build build/
[1/2] Building CXX object apps/CMakeFiles/cppscan.dir/main.cpp.o
FAILED: [code=1] apps/CMakeFiles/cppscan.dir/main.cpp.o
/home/mccakit/dev/llvm/bin/clang++ --target=x86_64-unknown-linux-musl  -I/home/mccakit/desktop/cppscan/apps -isystem /home/mccakit/desktop/cppscan/conan/full_deploy/host/fmt/master/Release/x86_64/include -isystem /home/mccakit/dev/conan/p/b/vecto54b3b0abf5614/p/include/hs -isystem /home/mccakit/desktop/cppscan/conan/full_deploy/host/cli11/main/Release/x86_64/include --target=x86_64-unknown-linux-musl --sysroot=/home/mccakit/dev/musl/x64 -nostdinc++ -isystem /home/mccakit/dev/libcxx/x86_64-unknown-linux-musl/include/c++/v1 -std=c++26 -fPIC -O3 -DNDEBUG -O3 -DNDEBUG -fPIE -MD -MT apps/CMakeFiles/cppscan.dir/main.cpp.o -MF apps/CMakeFiles/cppscan.dir/main.cpp.o.d @apps/CMakeFiles/cppscan.dir/main.cpp.o.modmap -o apps/CMakeFiles/cppscan.dir/main.cpp.o -c /home/mccakit/desktop/cppscan/apps/main.cpp
In module 'cli11' imported from /home/mccakit/desktop/cppscan/apps/main.cpp:3:
/home/mccakit/desktop/cppscan/conan/full_deploy/host/cli11/main/Release/x86_64/include/CLI/impl/Formatter_inl.hpp:125:90: error: definition with same mangled name '_ZZNK3CLI9Formatter10make_usageEPKNS_3AppENSt3__112basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEEENKUlPKNS_6OptionEE_clESD_' as another definition
  125 |         std::transform(positionals.begin(), positionals.end(), positional_names.begin(), [this](const Option *opt) {
      |                                                                                          ^
/home/mccakit/desktop/cppscan/conan/full_deploy/host/cli11/main/Release/x86_64/include/CLI/impl/Formatter_inl.hpp:114:26: note: previous definition is here
  114 |         app->get_options([](const Option *opt) { return opt->nonpositional(); });
      |                          ^
1 error generated.
ninja: build stopped: subcommand failed.
mccakit@mccakit-pc:~/desktop/cppscan$
```