### PR TITLE
Support colored help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1514,13 +1514,14 @@ free to replace the formatter with a custom one by calling `formatter(fmt)` on
 an `App`. CLI11 comes with a default App formatter, `Formatter`. You can
 retrieve the formatter via `.get_formatter()` this will return a pointer to the
 current `Formatter`. It is customizable; you can set `label(key, value)` to
-replace the default labels like `REQUIRED`, and `OPTIONS`. You can also set
-`column_width(n)` to set the width of the columns before you add the functional
-to the app or option. Several other configuration options are also available in
-the `Formatter`. You can also override almost any stage of the formatting
-process in a subclass of either formatter. If you want to make a new formatter
-from scratch, you can do that too; you just need to implement the correct
-signature. see [formatting][] for more details.
+replace the default labels like `REQUIRED`, and `OPTIONS`. You can call
+`enable_color()` to enable colorful help. You can also set `column_width(n)` to
+set the width of the columns before you add the functional to the app or option.
+Several other configuration options are also available in the `Formatter`. You
+can also override almost any stage of the formatting process in a subclass of
+either formatter. If you want to make a new formatter from scratch, you can do
+that too; you just need to implement the correct signature. see [formatting][]
+for more details.
 
 ### Subclassing
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -260,6 +260,7 @@ set_property(TEST subcom_in_files PROPERTY PASS_REGULAR_EXPRESSION
                                            [=[Working on file: this\.txt.*Using foo!]=])
 
 add_cli_exe(formatter formatter.cpp)
+add_cli_exe(color_formatter color_formatter.cpp)
 
 add_cli_exe(nested nested.cpp)
 

--- a/examples/color_formatter.cpp
+++ b/examples/color_formatter.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-2026, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "CLI/CLI.hpp"
+#include <CLI/CLI.hpp>
+#include <iostream>
+
+int main(int argc, char **argv) {
+    CLI::App app("Color formatter example");
+    app.get_formatter()->enable_color();
+
+    app.add_flag("--flag", "This is a flag");
+
+    auto *sub1 = app.add_subcommand("one", "Description One");
+    sub1->add_flag("--oneflag", "Some flag");
+    auto *sub2 = app.add_subcommand("two", "Description Two");
+    sub2->add_flag("--twoflag", "Some other flag");
+
+    CLI11_PARSE(app, argc, argv);
+
+    std::cout << "This app was meant to show off the colorful formatter, run with -h" << '\n';
+
+    return 0;
+}

--- a/examples/color_formatter.cpp
+++ b/examples/color_formatter.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "CLI/CLI.hpp"
-#include <CLI/CLI.hpp>
 #include <iostream>
 
 int main(int argc, char **argv) {

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -96,8 +96,6 @@ class FormatterBase {
     virtual std::string make_help(const App *, std::string, AppFormatMode) const = 0;
 
     /// Detect whether the current terminal supports color output.
-    /// Respects NO_COLOR, FORCE_COLOR, and CLI11_COLOR environment variables,
-    /// then falls back to isatty() check.
     static bool terminal_supports_color();
 
     ///@}

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -67,6 +67,10 @@ class FormatterBase {
     bool enable_option_defaults_{true};
     bool enable_option_type_names_{true};
     bool enable_default_flag_values_{true};
+
+    /// whether color output is enabled
+    bool color_enabled_{false};
+
     /// @brief The required help printout labels (user changeable)
     /// Values are Needs, Excludes, etc.
     std::map<std::string, std::string> labels_{};
@@ -90,6 +94,11 @@ class FormatterBase {
 
     /// This is the key method that puts together help
     virtual std::string make_help(const App *, std::string, AppFormatMode) const = 0;
+
+    /// Detect whether the current terminal supports color output.
+    /// Respects NO_COLOR, FORCE_COLOR, and CLI11_COLOR environment variables,
+    /// then falls back to isatty() check.
+    static bool terminal_supports_color();
 
     ///@}
     /// @name Setters
@@ -127,6 +136,10 @@ class FormatterBase {
     void enable_option_type_names(bool value = true) { enable_option_type_names_ = value; }
     /// enable default flag values to be printed
     void enable_default_flag_values(bool value = true) { enable_default_flag_values_ = value; }
+
+    /// enable colorized help output
+    void enable_color(bool value = true) { color_enabled_ = value; }
+
     ///@}
     /// @name Getters
     ///@{
@@ -167,6 +180,14 @@ class FormatterBase {
 
     /// Get the current status of whether default flag values are printed
     CLI11_NODISCARD bool is_default_flag_values_enabled() const { return enable_default_flag_values_; }
+
+    /// Get the current status of whether color output is enabled
+    CLI11_NODISCARD bool is_color_enabled() const { return color_enabled_; }
+
+    /// Wrap text with an ANSI color code and reset suffix
+    CLI11_NODISCARD static std::string colorize(const std::string &text, const std::string &color) {
+        return color + text + CLI11_HELP_COLOR_RESET;
+    }
 
     ///@}
 };

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -182,4 +182,47 @@
 #else
 #define CLI11_MODULE_INLINE static
 #endif
+
+/** ANSI color codes for help output — override before including CLI11 to customize */
+#ifndef CLI11_HELP_COLOR_USAGE
+#define CLI11_HELP_COLOR_USAGE "\033[1;34m"
+#endif
+#ifndef CLI11_HELP_COLOR_PROGRAM
+#define CLI11_HELP_COLOR_PROGRAM "\033[1;32m"
+#endif
+#ifndef CLI11_HELP_COLOR_HEADER
+#define CLI11_HELP_COLOR_HEADER "\033[1;33m"
+#endif
+#ifndef CLI11_HELP_COLOR_SHORT_OPT
+#define CLI11_HELP_COLOR_SHORT_OPT "\033[1;32m"
+#endif
+#ifndef CLI11_HELP_COLOR_LONG_OPT
+#define CLI11_HELP_COLOR_LONG_OPT "\033[1;36m"
+#endif
+#ifndef CLI11_HELP_COLOR_POSITIONAL
+#define CLI11_HELP_COLOR_POSITIONAL "\033[1;36m"
+#endif
+#ifndef CLI11_HELP_COLOR_SUBCOMMAND
+#define CLI11_HELP_COLOR_SUBCOMMAND "\033[1;36m"
+#endif
+#ifndef CLI11_HELP_COLOR_REQUIRED
+#define CLI11_HELP_COLOR_REQUIRED "\033[1;31m"
+#endif
+#ifndef CLI11_HELP_COLOR_DEFAULT
+#define CLI11_HELP_COLOR_DEFAULT "\033[2m"
+#endif
+#ifndef CLI11_HELP_COLOR_RESET
+#define CLI11_HELP_COLOR_RESET "\033[0m"
+#endif
+
+/** Windows-specific includes */
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <io.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
 // [CLI11:macros_hpp:end]

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -215,14 +215,4 @@
 #define CLI11_HELP_COLOR_RESET "\033[0m"
 #endif
 
-/** Windows-specific includes */
-#ifdef _WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <io.h>
-#include <windows.h>
-#else
-#include <unistd.h>
-#endif
 // [CLI11:macros_hpp:end]

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -274,6 +274,10 @@ CLI11_INLINE std::ostream &streamOutAsParagraph(std::ostream &out,
                                                 const std::string &linePrefix = "",
                                                 bool skipPrefixOnFirstLine = false);
 
+/// Compute the visual (display) width of a string, ignoring ANSI escape sequences.
+/// This is needed for correct column alignment when strings contain color codes.
+CLI11_INLINE std::size_t visual_length(const std::string &str);
+
 }  // namespace detail
 
 // [CLI11:string_tools_hpp:end]

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -19,6 +19,16 @@
 #include <vector>
 // [CLI11:public_includes:end]
 
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <io.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
 namespace CLI {
 // [CLI11:formatter_inl_hpp:verbatim]
 

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -35,18 +35,6 @@ namespace CLI {
 // [CLI11:formatter_inl_hpp:verbatim]
 
 CLI11_INLINE bool FormatterBase::terminal_supports_color() {
-    // NO_COLOR convention (https://no-color.org)
-    if(std::getenv("NO_COLOR") != nullptr)
-        return false;
-
-    // Force color
-    if(std::getenv("FORCE_COLOR") != nullptr)
-        return true;
-
-    const char *cli11_color = std::getenv("CLI11_COLOR");
-    if(cli11_color != nullptr)
-        return std::string(cli11_color) != "0";
-
 #ifdef _WIN32
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
     if(hOut == INVALID_HANDLE_VALUE)

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -21,11 +21,48 @@
 
 namespace CLI {
 // [CLI11:formatter_inl_hpp:verbatim]
+
+CLI11_INLINE bool FormatterBase::terminal_supports_color() {
+    // NO_COLOR convention (https://no-color.org)
+    if(std::getenv("NO_COLOR") != nullptr)
+        return false;
+
+    // Force color
+    if(std::getenv("FORCE_COLOR") != nullptr)
+        return true;
+
+    const char *cli11_color = std::getenv("CLI11_COLOR");
+    if(cli11_color != nullptr)
+        return std::string(cli11_color) != "0";
+
+#ifdef _WIN32
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if(hOut == INVALID_HANDLE_VALUE)
+        return false;
+    DWORD dwMode = 0;
+    if(!GetConsoleMode(hOut, &dwMode))
+        return false;
+    // Try to enable VT processing; if already enabled or successfully set, color is supported
+    if((dwMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0)
+        return true;
+    dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    if(SetConsoleMode(hOut, dwMode))
+        return true;
+    return false;
+#else
+    return isatty(fileno(stdout)) != 0;
+#endif
+}
+
 CLI11_INLINE std::string
 Formatter::make_group(std::string group, bool is_positional, std::vector<const Option *> opts) const {
     std::stringstream out;
 
-    out << "\n" << group << ":\n";
+    if(color_enabled_) {
+        out << "\n" << colorize(group, CLI11_HELP_COLOR_HEADER) << ":\n";
+    } else {
+        out << "\n" << group << ":\n";
+    }
     for(const Option *opt : opts) {
         out << make_option(opt, is_positional);
     }
@@ -102,10 +139,18 @@ CLI11_INLINE std::string Formatter::make_usage(const App *app, std::string name)
     std::stringstream out;
     out << '\n';
 
-    if(name.empty())
-        out << get_label("Usage") << ':';
-    else
-        out << name;
+    if(name.empty()) {
+        std::string label = get_label("Usage");
+        if(color_enabled_)
+            out << colorize(label, CLI11_HELP_COLOR_HEADER) << ':';
+        else
+            out << label << ':';
+    } else {
+        if(color_enabled_)
+            out << colorize(name, CLI11_HELP_COLOR_HEADER);
+        else
+            out << name;
+    }
 
     std::vector<std::string> groups = app->get_groups();
 
@@ -208,7 +253,11 @@ CLI11_INLINE std::string Formatter::make_subcommands(const App *app, AppFormatMo
 
     // For each group, filter out and print subcommands
     for(const std::string &group : subcmd_groups_seen) {
-        out << '\n' << group << ":\n";
+        if(color_enabled_) {
+            out << '\n' << colorize(group, CLI11_HELP_COLOR_HEADER) << ":\n";
+        } else {
+            out << '\n' << group << ":\n";
+        }
         std::vector<const App *> subcommands_group = app->get_subcommands(
             [&group](const App *sub_app) { return detail::to_lower(sub_app->get_group()) == detail::to_lower(group); });
         for(const App *new_com : subcommands_group) {
@@ -228,9 +277,21 @@ CLI11_INLINE std::string Formatter::make_subcommands(const App *app, AppFormatMo
 
 CLI11_INLINE std::string Formatter::make_subcommand(const App *sub) const {
     std::stringstream out;
-    std::string name = "  " + sub->get_display_name(true) + (sub->get_required() ? " " + get_label("REQUIRED") : "");
+    std::string display_name = sub->get_display_name(true);
+    std::string required_label = sub->get_required() ? " " + get_label("REQUIRED") : "";
 
-    out << std::setw(static_cast<int>(column_width_)) << std::left << name;
+    if(color_enabled_) {
+        std::string name =
+            "  " + colorize(display_name, CLI11_HELP_COLOR_SUBCOMMAND) +
+            (sub->get_required() ? " " + colorize(get_label("REQUIRED"), CLI11_HELP_COLOR_REQUIRED) : "");
+        std::size_t visual_len = 2 + display_name.length() + required_label.length();
+        out << name;
+        if(visual_len < column_width_)
+            out << std::string(column_width_ - visual_len, ' ');
+    } else {
+        std::string name = "  " + display_name + required_label;
+        out << std::setw(static_cast<int>(column_width_)) << std::left << name;
+    }
     detail::streamOutAsParagraph(
         out, sub->get_description(), right_column_width_, std::string(column_width_, ' '), true);
     out << '\n';
@@ -239,7 +300,11 @@ CLI11_INLINE std::string Formatter::make_subcommand(const App *sub) const {
 
 CLI11_INLINE std::string Formatter::make_expanded(const App *sub, AppFormatMode mode) const {
     std::stringstream out;
-    out << sub->get_display_name(true) << '\n';
+    std::string display_name = sub->get_display_name(true);
+    if(color_enabled_)
+        out << colorize(display_name, CLI11_HELP_COLOR_SUBCOMMAND) << '\n';
+    else
+        out << display_name << '\n';
 
     if(is_description_paragraph_formatting_enabled()) {
         detail::streamOutAsParagraph(
@@ -277,13 +342,19 @@ CLI11_INLINE std::string Formatter::make_expanded(const App *sub, AppFormatMode 
 CLI11_INLINE std::string Formatter::make_option(const Option *opt, bool is_positional) const {
     std::stringstream out;
     if(is_positional) {
-        const std::string left = "  " + make_option_name(opt, true) + make_option_opts(opt);
+        const std::string name = make_option_name(opt, true);
+        const std::string left =
+            "  " + (color_enabled_ ? colorize(name, CLI11_HELP_COLOR_POSITIONAL) : name) + make_option_opts(opt);
         const std::string desc = make_option_desc(opt);
-        out << std::setw(static_cast<int>(column_width_)) << std::left << left;
+        const std::size_t visual_len = color_enabled_ ? detail::visual_length(left) : left.length();
+
+        out << left;
+        if(visual_len < column_width_)
+            out << std::string(column_width_ - visual_len, ' ');
 
         if(!desc.empty()) {
             bool skipFirstLinePrefix = true;
-            if(left.length() >= column_width_) {
+            if(visual_len >= column_width_) {
                 out << '\n';
                 skipFirstLinePrefix = false;
             }
@@ -317,47 +388,136 @@ CLI11_INLINE std::string Formatter::make_option(const Option *opt, bool is_posit
         const auto longNamesColumnWidth = static_cast<int>(column_width_) - shortNamesColumnWidth;
         int shortNamesOverSize = 0;
 
-        // Print short names
-        if(!shortNames.empty()) {
-            shortNames = "  " + shortNames;  // Indent
-            if(longNames.empty() && !opts.empty())
-                shortNames += opts;  // Add opts if only short names and no long names
-            if(!longNames.empty())
-                shortNames += ",";
-            if(static_cast<int>(shortNames.length()) >= shortNamesColumnWidth) {
-                shortNames += " ";
-                shortNamesOverSize = static_cast<int>(shortNames.length()) - shortNamesColumnWidth;
+        if(color_enabled_) {
+            // When colored, consider visual length (length without color codes)
+            std::string left_str;
+            std::size_t visual_left_len = 0;
+
+            // Print short names (colored)
+            if(!shortNames.empty()) {
+                std::string short_part = "  " + colorize(shortNames, CLI11_HELP_COLOR_SHORT_OPT);
+                std::size_t short_visual =
+                    2 + shortNames.length();  // Pre-colored length equals post-colored visual length
+
+                // Add opts if only short names and no long names
+                if(longNames.empty() && !opts.empty()) {
+                    short_part += opts;
+                    short_visual += opts.length();
+                }
+                if(!longNames.empty()) {
+                    short_part += ",";
+                    short_visual += 1;
+                }
+
+                if(static_cast<int>(short_visual) < shortNamesColumnWidth) {
+                    // Not full : Padding
+                    short_part += std::string(static_cast<std::size_t>(shortNamesColumnWidth) - short_visual, ' ');
+                    visual_left_len = static_cast<std::size_t>(shortNamesColumnWidth);
+                } else {
+                    // Full : Add a space
+                    short_part += " ";
+                    visual_left_len = short_visual + 1;
+                }
+
+                left_str += short_part;
+
+            } else {
+                // Padding
+                left_str += std::string(static_cast<std::size_t>(shortNamesColumnWidth), ' ');
+                visual_left_len = static_cast<std::size_t>(shortNamesColumnWidth);
             }
-            out << std::setw(shortNamesColumnWidth) << std::left << shortNames;
-        } else {
-            out << std::setw(shortNamesColumnWidth) << std::left << "";
-        }
 
-        // Adjust long name column width in case of short names column reaching into long names column
-        shortNamesOverSize =
-            (std::min)(shortNamesOverSize, longNamesColumnWidth);  // Prevent negative result with unsigned integers
-        const auto adjustedLongNamesColumnWidth = longNamesColumnWidth - shortNamesOverSize;
+            // Adjust long name column width in case of short names column reaching into long names column
+            shortNamesOverSize = static_cast<int>(visual_left_len) - shortNamesColumnWidth;
+            shortNamesOverSize = (std::min)(0, shortNamesOverSize);
+            shortNamesOverSize = (std::min)(shortNamesOverSize, longNamesColumnWidth);
+            const int adjustedLongNamesColumnWidth = longNamesColumnWidth - shortNamesOverSize;
 
-        // Print long names
-        if(!longNames.empty()) {
-            if(!opts.empty())
-                longNames += opts;
-            if(static_cast<int>(longNames.length()) >= adjustedLongNamesColumnWidth)
-                longNames += " ";
+            // Print long names (colored)
+            if(!longNames.empty()) {
+                std::string long_part = colorize(longNames, CLI11_HELP_COLOR_LONG_OPT);
+                std::size_t long_visual = longNames.length();  // Pre-colored length equals post-colored visual length
 
-            out << std::setw(adjustedLongNamesColumnWidth) << std::left << longNames;
-        } else {
-            out << std::setw(adjustedLongNamesColumnWidth) << std::left << "";
-        }
+                if(!opts.empty()) {
+                    long_part += opts;
+                    long_visual += opts.length();
+                }
 
-        if(!desc.empty()) {
-            bool skipFirstLinePrefix = true;
-            if(out.str().length() > column_width_) {
-                out << '\n';
-                skipFirstLinePrefix = false;
+                if(static_cast<int>(long_visual) < adjustedLongNamesColumnWidth) {
+                    // Not full : Padding
+                    long_part += std::string(static_cast<std::size_t>(adjustedLongNamesColumnWidth) - long_visual, ' ');
+                    visual_left_len += static_cast<std::size_t>(adjustedLongNamesColumnWidth);
+                } else {
+                    // Full : Add a space
+                    long_part += " ";
+                    visual_left_len += long_visual + 1;
+                }
+
+                left_str += long_part;
+
+            } else {
+                // Padding
+                left_str += std::string(static_cast<std::size_t>(adjustedLongNamesColumnWidth), ' ');
+                visual_left_len += static_cast<std::size_t>(adjustedLongNamesColumnWidth);
             }
-            detail::streamOutAsParagraph(
-                out, desc, right_column_width_, std::string(column_width_, ' '), skipFirstLinePrefix);
+
+            out << left_str;
+
+            if(!desc.empty()) {
+                bool skipFirstLinePrefix = true;
+
+                // Use the visual length instead of total string length
+                if(visual_left_len > column_width_) {
+                    out << '\n';
+                    skipFirstLinePrefix = false;
+                }
+                detail::streamOutAsParagraph(
+                    out, desc, right_column_width_, std::string(column_width_, ' '), skipFirstLinePrefix);
+            }
+        } else {
+            // When not colored, use setw approach with actual string lengths
+            // Print short names
+            if(!shortNames.empty()) {
+                shortNames = "  " + shortNames;  // Indent
+                if(longNames.empty() && !opts.empty())
+                    shortNames += opts;  // Add opts if only short names and no long names
+                if(!longNames.empty())
+                    shortNames += ",";
+                if(static_cast<int>(shortNames.length()) >= shortNamesColumnWidth) {
+                    shortNames += " ";
+                    shortNamesOverSize = static_cast<int>(shortNames.length()) - shortNamesColumnWidth;
+                }
+                out << std::setw(shortNamesColumnWidth) << std::left << shortNames;
+            } else {
+                out << std::setw(shortNamesColumnWidth) << std::left << "";
+            }
+
+            // Adjust long name column width in case of short names column reaching into long names column
+            shortNamesOverSize =
+                (std::min)(shortNamesOverSize, longNamesColumnWidth);  // Prevent negative result with unsigned integers
+            const auto adjustedLongNamesColumnWidth = longNamesColumnWidth - shortNamesOverSize;
+
+            // Print long names
+            if(!longNames.empty()) {
+                if(!opts.empty())
+                    longNames += opts;
+                if(static_cast<int>(longNames.length()) >= adjustedLongNamesColumnWidth)
+                    longNames += " ";
+
+                out << std::setw(adjustedLongNamesColumnWidth) << std::left << longNames;
+            } else {
+                out << std::setw(adjustedLongNamesColumnWidth) << std::left << "";
+            }
+
+            if(!desc.empty()) {
+                bool skipFirstLinePrefix = true;
+                if(out.str().length() > column_width_) {
+                    out << '\n';
+                    skipFirstLinePrefix = false;
+                }
+                detail::streamOutAsParagraph(
+                    out, desc, right_column_width_, std::string(column_width_, ' '), skipFirstLinePrefix);
+            }
         }
     }
 
@@ -393,16 +553,27 @@ CLI11_INLINE std::string Formatter::make_option_opts(const Option *opt) const {
                     out << " " << get_label(opt->get_type_name());
             }
             if(enable_option_defaults_) {
-                if(!opt->get_default_str().empty())
-                    out << " [" << opt->get_default_str() << "] ";
+                if(!opt->get_default_str().empty()) {
+                    std::string default_str = opt->get_default_str();
+                    default_str = " [" + default_str + "] ";
+                    if(color_enabled_)
+                        out << colorize(default_str, CLI11_HELP_COLOR_DEFAULT);
+                    else
+                        out << default_str;
+                }
             }
             if(opt->get_expected_max() == detail::expected_max_vector_size)
                 out << " ...";
             else if(opt->get_expected_min() > 1)
                 out << " x " << opt->get_expected();
 
-            if(opt->get_required())
-                out << " " << get_label("REQUIRED");
+            if(opt->get_required()) {
+                std::string req = get_label("REQUIRED");
+                if(color_enabled_)
+                    out << " " << colorize(req, CLI11_HELP_COLOR_REQUIRED);
+                else
+                    out << " " << req;
+            }
         }
         if(!opt->get_envname().empty())
             out << " (" << get_label("Env") << ":" << opt->get_envname() << ")";

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -17,7 +17,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-// [CLI11:public_includes:end]
 
 #ifdef _WIN32
 #ifndef NOMINMAX
@@ -28,6 +27,7 @@
 #else
 #include <unistd.h>
 #endif
+// [CLI11:public_includes:end]
 
 namespace CLI {
 // [CLI11:formatter_inl_hpp:verbatim]

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -17,7 +17,9 @@
 #include <string>
 #include <utility>
 #include <vector>
+// [CLI11:public_includes:end]
 
+// [CLI11:formatter_inl_includes:verbatim]
 #ifdef _WIN32
 #ifndef NOMINMAX
 #define NOMINMAX
@@ -27,7 +29,7 @@
 #else
 #include <unistd.h>
 #endif
-// [CLI11:public_includes:end]
+// [CLI11:formatter_inl_includes:end]
 
 namespace CLI {
 // [CLI11:formatter_inl_hpp:verbatim]

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -632,6 +632,23 @@ CLI11_INLINE std::ostream &streamOutAsParagraph(std::ostream &out,
     return out;
 }
 
+CLI11_INLINE std::size_t visual_length(const std::string &str) {
+    std::size_t len = 0;
+    bool in_escape = false;
+    for(char c : str) {
+        if(in_escape) {
+            if((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+                in_escape = false;  // End of CSI sequence
+            }
+        } else if(c == '\033') {
+            in_escape = true;
+        } else {
+            ++len;
+        }
+    }
+    return len;
+}
+
 }  // namespace detail
 // [CLI11:string_tools_inl_hpp:end]
 }  // namespace CLI

--- a/single-include/CLI11.hpp.in
+++ b/single-include/CLI11.hpp.in
@@ -46,6 +46,8 @@
 
 {argv_inl_includes}
 
+{formatter_inl_includes}
+
 namespace {namespace} {{
 
 {encoding_hpp}

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -356,3 +356,17 @@ TEST_CASE("Formatter: LongOptionAlignment", "[formatter]") {
     CHECK_THAT(help, Contains("\n  -h, --help                  Print"));
     CHECK_THAT(help, Contains("\n      --opt INT               Something"));
 }
+
+TEST_CASE("Formatter: Colored Help", "[formatter]") {
+    CLI::App app{"My prog"};
+
+    app.get_formatter()->enable_color();
+
+    int v{0};
+    app.add_option("--opt", v, "Something");
+
+    std::string help = app.help();
+
+    std::string expected = CLI11_HELP_COLOR_LONG_OPT + std::string("--opt") + CLI11_HELP_COLOR_RESET;
+    CHECK_THAT(help, Contains(expected));
+}


### PR DESCRIPTION
This PR adds support for the colored help output regarding the dicuss in issue: #1285 
Functions are added into the `Default Formatter`. When `color_enabled_` is true, ANSI codes are injected into the stream to display various colors. 

Certain formatting logic has been modified in the colored branch (`color_enabled_ == true`):
- Count `visual_length` instead of the actual length, for that the latter one include the ANSI codes, which are not displayed.
- Colorize the header/option/etc. before putting them to the stream.
- The color palette is defined as macros in `Macros.h`

Usage:
```cpp
app.get_formatter()->enable_color();
```

An example and a new test has been added. Readme has been updated as well. All tests are passed on my x86 Linux (Arch)
machine.


<img width="1686" height="1175" alt="ffb22712e2108d43bfcdb8943d82cf5b" src="https://github.com/user-attachments/assets/85f805b1-2dc4-45de-9c1b-80adbc337b18" />
