### PR TITLE
Handle nullopt as an appropriate argument that is consistent.  

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,7 +219,7 @@ jobs:
           containerImage: silkeh/clang:20
           cli11.std: 26
           cli11.options:
-            -DCMAKE_CXX_FLAGS="-std=c++2c -stdlib=libc++"
+            -DCMAKE_CXX_FLAGS="-std=c++2c -stdlib=libc++ -Wdocumentation"
             -DCLI11_ENABLE_EXTRA_VALIDATORS=1 -DCMAKE_CXX_COMPILER=clang++
             -DCLI11_FORCE_LIBCXX=ON -DCMAKE_LINKER_TYPE=LLD
     container: $[ variables['containerImage'] ]

--- a/fuzz/fuzzApp.cpp
+++ b/fuzz/fuzzApp.cpp
@@ -747,9 +747,6 @@ SubcommandData extract_subcomand_info(const std::string &description_string, std
     return sub_data;
 }
 
-//<option>name_string</option>
-//<vector>name_string</vector>
-//<flag>name_string</flag>
 /** generate additional options based on a string config*/
 std::size_t FuzzApp::add_custom_options(CLI::App *app, const std::string &description_string) {
     std::size_t current_index{0};

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -150,7 +150,7 @@ class FormatterBase {
     CLI11_NODISCARD std::size_t get_footer_paragraph_width() const { return footer_paragraph_width_; }
 
     /// @brief Get the current alignment ratio for long options within the left column
-    /// @return
+    /// @return The alignment ratio used for long options within the left column
     CLI11_NODISCARD float get_long_option_alignment_ratio() const { return long_option_alignment_ratio_; }
 
     /// Get the current status of description paragraph formatting

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -1394,14 +1394,32 @@ bool lexical_cast(const std::string & /*input*/, T & /*output*/) {
 /// Assign a value through lexical cast operations
 /// Strings can be empty so we need to do a little different
 template <typename AssignTo,
+    typename ConvertTo,
+    enable_if_t<std::is_same<AssignTo, ConvertTo>::value && !is_wrapper<AssignTo>::value &&
+    (classify_object<AssignTo>::value == object_category::string_assignable ||
+        classify_object<AssignTo>::value == object_category::string_constructible ||
+        classify_object<AssignTo>::value == object_category::wstring_assignable ||
+        classify_object<AssignTo>::value == object_category::wstring_constructible),
+    detail::enabler> = detail::dummy>
+bool lexical_assign(const std::string &input, AssignTo &output) {
+    return lexical_cast(input, output);
+}
+
+/// Assign a value through lexical cast operations
+/// Strings can be empty so we need to do a little different but also need to support wrappers
+template <typename AssignTo,
           typename ConvertTo,
-          enable_if_t<std::is_same<AssignTo, ConvertTo>::value &&
+          enable_if_t<std::is_same<AssignTo, ConvertTo>::value && is_wrapper<AssignTo>::value &&
                           (classify_object<AssignTo>::value == object_category::string_assignable ||
                            classify_object<AssignTo>::value == object_category::string_constructible ||
                            classify_object<AssignTo>::value == object_category::wstring_assignable ||
                            classify_object<AssignTo>::value == object_category::wstring_constructible),
                       detail::enabler> = detail::dummy>
-bool lexical_assign(const std::string &input, AssignTo &output) {
+bool lexical_assign(const std::string& input, AssignTo& output) {
+    if (input.empty()) {
+        output = AssignTo{};
+        return true;
+    }
     return lexical_cast(input, output);
 }
 

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -1394,13 +1394,13 @@ bool lexical_cast(const std::string & /*input*/, T & /*output*/) {
 /// Assign a value through lexical cast operations
 /// Strings can be empty so we need to do a little different
 template <typename AssignTo,
-    typename ConvertTo,
-    enable_if_t<std::is_same<AssignTo, ConvertTo>::value && !is_wrapper<AssignTo>::value &&
-    (classify_object<AssignTo>::value == object_category::string_assignable ||
-        classify_object<AssignTo>::value == object_category::string_constructible ||
-        classify_object<AssignTo>::value == object_category::wstring_assignable ||
-        classify_object<AssignTo>::value == object_category::wstring_constructible),
-    detail::enabler> = detail::dummy>
+          typename ConvertTo,
+          enable_if_t<std::is_same<AssignTo, ConvertTo>::value && !is_wrapper<AssignTo>::value &&
+                          (classify_object<AssignTo>::value == object_category::string_assignable ||
+                           classify_object<AssignTo>::value == object_category::string_constructible ||
+                           classify_object<AssignTo>::value == object_category::wstring_assignable ||
+                           classify_object<AssignTo>::value == object_category::wstring_constructible),
+                      detail::enabler> = detail::dummy>
 bool lexical_assign(const std::string &input, AssignTo &output) {
     return lexical_cast(input, output);
 }
@@ -1415,8 +1415,8 @@ template <typename AssignTo,
                            classify_object<AssignTo>::value == object_category::wstring_assignable ||
                            classify_object<AssignTo>::value == object_category::wstring_constructible),
                       detail::enabler> = detail::dummy>
-bool lexical_assign(const std::string& input, AssignTo& output) {
-    if (input.empty()) {
+bool lexical_assign(const std::string &input, AssignTo &output) {
+    if(input.empty()) {
         output = AssignTo{};
         return true;
     }

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -90,7 +90,7 @@ TEST_CASE_METHOD(TApp, "StdOptionalNulloptDefaultValConsistency", "[optional]") 
     CHECK_FALSE(opt_int.has_value());
     CHECK_FALSE(opt_string.has_value());
 
-    auto *optargs=app.add_option("-b", opt_string);
+    auto *optargs = app.add_option("-b", opt_string);
     optargs->default_val(std::nullopt);
 
     run();
@@ -108,7 +108,7 @@ TEST_CASE_METHOD(TApp, "StdOptionalEmptyOptConsistency", "[optional]") {
     CHECK_FALSE(opt_int.has_value());
     CHECK_FALSE(opt_string.has_value());
 
-    auto *optargs=app.add_option("-b", opt_string);
+    auto *optargs = app.add_option("-b", opt_string);
     optargs->default_val(opt_string);
 
     run();

--- a/tests/OptionalTest.cpp
+++ b/tests/OptionalTest.cpp
@@ -81,6 +81,42 @@ TEST_CASE_METHOD(TApp, "StdOptionalTest", "[optional]") {
     CHECK((opt && (3 == *opt)));
 }
 
+TEST_CASE_METHOD(TApp, "StdOptionalNulloptDefaultValConsistency", "[optional]") {
+    std::optional<int> opt_int;
+    app.add_option("-a", opt_int)->default_val(std::nullopt);
+
+    std::optional<std::string> opt_string;
+
+    CHECK_FALSE(opt_int.has_value());
+    CHECK_FALSE(opt_string.has_value());
+
+    auto *optargs=app.add_option("-b", opt_string);
+    optargs->default_val(std::nullopt);
+
+    run();
+
+    CHECK_FALSE(opt_int.has_value());
+    CHECK_FALSE(opt_string.has_value());
+}
+
+TEST_CASE_METHOD(TApp, "StdOptionalEmptyOptConsistency", "[optional]") {
+    std::optional<int> opt_int;
+    app.add_option("-a", opt_int)->default_val(opt_int);
+
+    std::optional<std::string> opt_string;
+
+    CHECK_FALSE(opt_int.has_value());
+    CHECK_FALSE(opt_string.has_value());
+
+    auto *optargs=app.add_option("-b", opt_string);
+    optargs->default_val(opt_string);
+
+    run();
+
+    CHECK_FALSE(opt_int.has_value());
+    CHECK_FALSE(opt_string.has_value());
+}
+
 TEST_CASE_METHOD(TApp, "StdOptionalVectorEmptyDirect", "[optional]") {
     std::optional<std::vector<int>> opt;
     app.add_option("-v,--vec", opt)->expected(0, 3)->allow_extra_args();


### PR DESCRIPTION
wrapper classes now convert an empty string into the default constructor.

Fixes #1331 