### PR TITLE
docs: mention Catch2 dependency for tests

### DIFF
--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -146,6 +146,12 @@ CLI11 has examples and tests that can be accessed using a CMake build on any
 platform. Simply build and run ctest to run the 200+ tests to ensure CLI11 works
 on your system.
 
+The test build uses Catch2. If Catch2 is not available as a CMake package,
+CLI11 will download the required Catch2 header during configuration. On systems
+without internet access, or where TLS connections to GitHub releases are
+blocked, install Catch2 separately or configure with `CLI11_BUILD_TESTS=OFF`
+until the dependency is available.
+
 As an example of the build system, the following code will download and test
 CLI11 in a simple Alpine Linux docker container [^1]:
 

--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -146,8 +146,8 @@ CLI11 has examples and tests that can be accessed using a CMake build on any
 platform. Simply build and run ctest to run the 200+ tests to ensure CLI11 works
 on your system.
 
-The test build uses Catch2. If Catch2 is not available as a CMake package,
-CLI11 will download the required Catch2 header during configuration. On systems
+The test build uses Catch2. If Catch2 is not available as a CMake package, CLI11
+will download the required Catch2 header during configuration. On systems
 without internet access, or where TLS connections to GitHub releases are
 blocked, install Catch2 separately or configure with `CLI11_BUILD_TESTS=OFF`
 until the dependency is available.


### PR DESCRIPTION
## Summary

Document that the CMake test build uses Catch2 and may try to download the Catch2 header during configuration if Catch2 is not installed.

## Motivation

This helps users understand configuration failures in restricted-network environments, where downloading from GitHub releases may fail.

## Testing

- Ran `ctest --test-dir out/build/x64-debug --output-on-failure`
- 83 tests passed
