### PR TITLE
add test and fix for empty transformer description

### DIFF
--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -465,7 +465,7 @@ class Option : public OptionBase<Option> {
     Option *transform(Validator_p validator);
 
     /// Adds a transforming Validator with a built in type name
-    Option *transform(Validator validator, const std::string &transform_name="");
+    Option *transform(Validator validator, const std::string &transform_name = "");
 
     /// Adds a transforming Validator with a built in type name and description
     Option *transform(Validator validator, const std::string &transform_description, const std::string &transform_name);

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -465,7 +465,10 @@ class Option : public OptionBase<Option> {
     Option *transform(Validator_p validator);
 
     /// Adds a transforming Validator with a built in type name
-    Option *transform(Validator validator, const std::string &transform_name = "");
+    Option *transform(Validator validator, const std::string &transform_name="");
+
+    /// Adds a transforming Validator with a built in type name and description
+    Option *transform(Validator validator, const std::string &transform_description, const std::string &transform_name);
 
     /// Adds a Validator-like function that can change result
     Option *transform(const std::function<std::string(std::string)> &transform_func,

--- a/include/CLI/impl/Option_inl.hpp
+++ b/include/CLI/impl/Option_inl.hpp
@@ -119,6 +119,16 @@ CLI11_INLINE Option *Option::transform(Validator validator, const std::string &t
     return this;
 }
 
+CLI11_INLINE Option *Option::transform(Validator validator, const std::string &transform_description, const std::string &transform_name) {
+    auto vp = std::make_shared<Validator>(std::move(validator));
+    if(!transform_name.empty()) {
+        vp->name(transform_name);
+    }
+    vp->description( transform_description);
+    validators_.insert(validators_.begin(), std::move(vp));
+    return this;
+}
+
 CLI11_INLINE Option *Option::transform(const std::function<std::string(std::string)> &transform_func,
                                        std::string transform_description,
                                        std::string transform_name) {

--- a/include/CLI/impl/Option_inl.hpp
+++ b/include/CLI/impl/Option_inl.hpp
@@ -119,12 +119,13 @@ CLI11_INLINE Option *Option::transform(Validator validator, const std::string &t
     return this;
 }
 
-CLI11_INLINE Option *Option::transform(Validator validator, const std::string &transform_description, const std::string &transform_name) {
+CLI11_INLINE Option *
+Option::transform(Validator validator, const std::string &transform_description, const std::string &transform_name) {
     auto vp = std::make_shared<Validator>(std::move(validator));
     if(!transform_name.empty()) {
         vp->name(transform_name);
     }
-    vp->description( transform_description);
+    vp->description(transform_description);
     validators_.insert(validators_.begin(), std::move(vp));
     return this;
 }

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -490,7 +490,7 @@ TEST_CASE_METHOD(TApp, "TransformEmptyDescription", "[transform]") {
     int result_number = 0;
 
     auto *opt = app.add_option("-n,--number", result_number, "My number")
-        ->transform(CLI::Transformer(numbers_type_map), "", "my number transform");
+                    ->transform(CLI::Transformer(numbers_type_map), "", "my number transform");
 
     args = {"--number", "two"};
     REQUIRE_NOTHROW(run());

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -458,6 +458,29 @@ TEST_CASE_METHOD(TApp, "TransformCascadeDeactivate", "[transform]") {
     CHECK_THROWS_AS(opt->get_validator("sdfsdf"), CLI::OptionNotFound);
 }
 
+// from GitHub issue: https://github.com/CLIUtils/CLI11/issues/1338
+// transform(Transformer(...), "", "") should hide transform help text
+// without disabling the transform behavior.
+TEST_CASE_METHOD(TApp, "TransformEmptyNameAndDescription", "[transform]") {
+    std::map<std::string, int> numbers_type_map{{"one", 1}, {"two", 2}, {"three", 3}};
+
+    int result_number = 0;
+
+    auto *opt = app.add_option("-n,--number", result_number, "My number")
+                    ->transform(CLI::Transformer(numbers_type_map), "", "");
+
+    args = {"--number", "two"};
+    REQUIRE_NOTHROW(run());
+    CHECK(app.count("--number") == 1u);
+    CHECK(opt->count() == 1u);
+    CHECK(result_number == 2);
+
+    auto help = app.help();
+    CHECK(help.find("one->1") == std::string::npos);
+    CHECK(help.find("two->2") == std::string::npos);
+    CHECK(help.find("three->3") == std::string::npos);
+}
+
 TEST_CASE_METHOD(TApp, "IntTransformFn", "[transform]") {
     std::string value;
     app.add_option("-s", value)

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -481,6 +481,29 @@ TEST_CASE_METHOD(TApp, "TransformEmptyNameAndDescription", "[transform]") {
     CHECK(help.find("three->3") == std::string::npos);
 }
 
+// from GitHub issue: https://github.com/CLIUtils/CLI11/issues/1338
+// transform(Transformer(...), "", "") should hide transform help text
+// without disabling the transform behavior.
+TEST_CASE_METHOD(TApp, "TransformEmptyDescription", "[transform]") {
+    std::map<std::string, int> numbers_type_map{{"one", 1}, {"two", 2}, {"three", 3}};
+
+    int result_number = 0;
+
+    auto *opt = app.add_option("-n,--number", result_number, "My number")
+        ->transform(CLI::Transformer(numbers_type_map), "", "my number transform");
+
+    args = {"--number", "two"};
+    REQUIRE_NOTHROW(run());
+    CHECK(app.count("--number") == 1u);
+    CHECK(opt->count() == 1u);
+    CHECK(result_number == 2);
+
+    auto help = app.help();
+    CHECK(help.find("one->1") == std::string::npos);
+    CHECK(help.find("two->2") == std::string::npos);
+    CHECK(help.find("three->3") == std::string::npos);
+}
+
 TEST_CASE_METHOD(TApp, "IntTransformFn", "[transform]") {
     std::string value;
     app.add_option("-s", value)


### PR DESCRIPTION
Fixes #1338 

The issue was that the incorrect overload was being activated and the transformer itself was getting wrapped in another layer that masked the change.   The solution was to add another overload for the first argument being a Validator object, and updating it with the other arguments.  