### PR TITLE
Fix/1350 cli existing file issue

### DIFF
--- a/include/CLI/impl/Validators_inl.hpp
+++ b/include/CLI/impl/Validators_inl.hpp
@@ -168,7 +168,10 @@ CLI11_INLINE path_type check_path(const char *file) noexcept {
 #endif
 
 CLI11_INLINE ExistingFileValidator::ExistingFileValidator() : Validator("FILE") {
-    func_ = [](std::string &filename) {
+    func_ = [](std::string &filename) -> std::string {
+        if (filename.empty())
+            return std::string("File name is missing.");
+
         auto path_result = check_path(filename.c_str());
         if(path_result == path_type::nonexistent) {
             return "File does not exist: " + filename;

--- a/include/CLI/impl/Validators_inl.hpp
+++ b/include/CLI/impl/Validators_inl.hpp
@@ -169,7 +169,7 @@ CLI11_INLINE path_type check_path(const char *file) noexcept {
 
 CLI11_INLINE ExistingFileValidator::ExistingFileValidator() : Validator("FILE") {
     func_ = [](std::string &filename) -> std::string {
-        if (filename.empty())
+        if(filename.empty())
             return std::string("File name is missing.");
 
         auto path_result = check_path(filename.c_str());

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2042,6 +2042,30 @@ TEST_CASE_METHOD(TApp, "FileExists", "[app]") {
     CHECK(!CLI::ExistingFile(myfile).empty());
 }
 
+TEST_CASE_METHOD(TApp, "ExistingFileEmptyDefaultValue", "[app]") {
+    std::string filename = "";
+
+    app.add_option("--file", filename)
+        ->check(CLI::ExistingFile);
+
+    args = {};  // <-- key case: option not provided
+
+    CHECK_NOTHROW(run());
+    CHECK(filename.empty());
+}
+
+TEST_CASE_METHOD(TApp, "ExistingFileEmptyStringIsRejected", "[app]") {
+    std::string filename = "initial_value";
+
+    app.add_option("--file", filename)
+        ->check(CLI::ExistingFile);
+
+    args = {"--file", ""};  // explicit empty string input
+
+    CHECK_THROWS_AS(run(), CLI::ValidationError);
+    CHECK(filename == "initial_value"); // ensure no overwrite
+}
+
 TEST_CASE_METHOD(TApp, "DefaultedResult", "[app]") {
     std::string sval = "NA";
     int ival{0};

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2069,8 +2069,7 @@ TEST_CASE_METHOD(TApp, "ExistingFileEmptyStringIsRejected", "[app]") {
 TEST_CASE_METHOD(TApp, "ExistingFileEmptyFilesystemPathIsRejected", "[app]") {
     std::filesystem::path filename{""};
 
-    app.add_option("--file", filename)
-        ->check(CLI::ExistingFile);
+    app.add_option("--file", filename)->check(CLI::ExistingFile);
 
     args = {"--file", ""};
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2064,6 +2064,27 @@ TEST_CASE_METHOD(TApp, "ExistingFileEmptyStringIsRejected", "[app]") {
     CHECK(filename == "initial_value");  // ensure no overwrite
 }
 
+// Test for empty file name using std::filesystem::path
+#if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
+TEST_CASE_METHOD(TApp, "ExistingFileEmptyFilesystemPathIsRejected", "[app]") {
+    std::filesystem::path filename{""};
+
+    app.add_option("--file", filename)
+        ->check(CLI::ExistingFile);
+
+    args = {"--file", ""};
+
+    try {
+        run();
+        FAIL("Expected ValidationError");
+    } catch(const CLI::ValidationError &err) {
+        CHECK(std::string(err.what()).find("File name is missing.") != std::string::npos);
+    }
+
+    CHECK(filename == std::filesystem::path{"initial_value"});
+}
+#endif
+
 TEST_CASE_METHOD(TApp, "DefaultedResult", "[app]") {
     std::string sval = "NA";
     int ival{0};

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2064,22 +2064,17 @@ TEST_CASE_METHOD(TApp, "ExistingFileEmptyStringIsRejected", "[app]") {
     CHECK(filename == "initial_value");  // ensure no overwrite
 }
 
-// Test for empty file name using std::filesystem::path
+// Test for file name using std::filesystem::path
 #if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
 TEST_CASE_METHOD(TApp, "ExistingFileEmptyFilesystemPathIsRejected", "[app]") {
-    std::filesystem::path filename{""};
+    std::filesystem::path filename{"initial_value"};
 
     app.add_option("--file", filename)
         ->check(CLI::ExistingFile);
 
     args = {"--file", ""};
 
-    try {
-        run();
-        FAIL("Expected ValidationError");
-    } catch(const CLI::ValidationError &err) {
-        CHECK(std::string(err.what()).find("File name is missing.") != std::string::npos);
-    }
+    CHECK_THROWS_AS(run(), CLI::ValidationError);
 
     CHECK(filename == std::filesystem::path{"initial_value"});
 }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2045,8 +2045,7 @@ TEST_CASE_METHOD(TApp, "FileExists", "[app]") {
 TEST_CASE_METHOD(TApp, "ExistingFileEmptyDefaultValue", "[app]") {
     std::string filename = "";
 
-    app.add_option("--file", filename)
-        ->check(CLI::ExistingFile);
+    app.add_option("--file", filename)->check(CLI::ExistingFile);
 
     args = {};  // <-- key case: option not provided
 
@@ -2057,13 +2056,12 @@ TEST_CASE_METHOD(TApp, "ExistingFileEmptyDefaultValue", "[app]") {
 TEST_CASE_METHOD(TApp, "ExistingFileEmptyStringIsRejected", "[app]") {
     std::string filename = "initial_value";
 
-    app.add_option("--file", filename)
-        ->check(CLI::ExistingFile);
+    app.add_option("--file", filename)->check(CLI::ExistingFile);
 
     args = {"--file", ""};  // explicit empty string input
 
     CHECK_THROWS_AS(run(), CLI::ValidationError);
-    CHECK(filename == "initial_value"); // ensure no overwrite
+    CHECK(filename == "initial_value");  // ensure no overwrite
 }
 
 TEST_CASE_METHOD(TApp, "DefaultedResult", "[app]") {


### PR DESCRIPTION
**Summary**

`CLI::ExistingFile` did not explicitly handle empty string inputs, leading to inconsistent behavior when an empty filename was provided via the command line. This change makes the behavior explicit by rejecting empty filenames with a` "File name is missing."` validation error.

Fixes #1350

**Test Plan**

- [X] Added regression test coverage for explicit empty string file input
- [X] Verified default (unset option) still passes validation unchanged
- [X] Ran full CLI Test suite
- [X] All new and existing tests pass without modification 