### PR TITLE
Format long CheckedTransformer help mappings

### DIFF
--- a/include/CLI/ExtraValidators.hpp
+++ b/include/CLI/ExtraValidators.hpp
@@ -145,6 +145,27 @@ template <typename T> std::string generate_map(const T &map, bool key_only = fal
     return out;
 }
 
+/// Generate a multiline string representation of a map
+template <typename T> std::string generate_multiline_map(const T &map, bool key_only = false) {
+    using element_t = typename detail::element_type<T>::type;
+    using iteration_type_t = typename detail::pair_adaptor<element_t>::value_type;  // the type of the object pair
+    std::string out("{\n");
+    out.append(detail::join(
+        detail::smart_deref(map),
+        [key_only](const iteration_type_t &v) {
+            std::string res{detail::to_string(detail::pair_adaptor<element_t>::first(v))};
+
+            if(!key_only) {
+                res.append("->");
+                res += detail::to_string(detail::pair_adaptor<element_t>::second(v));
+            }
+            return res;
+        },
+        ",\n"));
+    out.append("\n}");
+    return out;
+}
+
 template <typename C, typename V> struct has_find {
     template <typename CC, typename VV>
     static auto test(int) -> decltype(std::declval<CC>().find(std::declval<VV>()), std::true_type());
@@ -354,8 +375,12 @@ class CheckedTransformer : public Validator {
         std::function<local_item_t(local_item_t)> filter_fn = filter_function;
 
         auto tfunc = [mapping]() {
+            auto map_description = detail::generate_map(detail::smart_deref(mapping));
+            if(map_description.size() > 60) {
+                map_description = detail::generate_multiline_map(detail::smart_deref(mapping));
+            }
             std::string out("value in ");
-            out += detail::generate_map(detail::smart_deref(mapping)) + " OR {";
+            out += map_description + " OR {";
             out += detail::join(
                 detail::smart_deref(mapping),
                 [](const iteration_type_t &v) {

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -120,6 +120,46 @@ TEST_CASE_METHOD(TApp, "EnumCheckedTransform", "[transform]") {
     CHECK_THROWS_AS(run(), CLI::ValidationError);
 }
 
+TEST_CASE_METHOD(TApp, "EnumCheckedTransformHelpFormatting", "[transform]") {
+    enum class FirmwareUpdateFlags : std::int16_t {
+        normal = 0,
+        allow_downgrade = 1,
+        force_update = 2,
+        no_check = 3,
+        normal_check_only = 4,
+        allow_downgrade_check_only = 5,
+        force_update_check_only = 6
+    };
+
+    FirmwareUpdateFlags flags{FirmwareUpdateFlags::normal};
+
+    const std::map<std::string, FirmwareUpdateFlags> flags_map{
+        {"normal", FirmwareUpdateFlags::normal},
+        {"allow_downgrade", FirmwareUpdateFlags::allow_downgrade},
+        {"force_update", FirmwareUpdateFlags::force_update},
+        {"no_check", FirmwareUpdateFlags::no_check},
+        {"normal_check_only", FirmwareUpdateFlags::normal_check_only},
+        {"allow_downgrade_check_only", FirmwareUpdateFlags::allow_downgrade_check_only},
+        {"force_update_check_only", FirmwareUpdateFlags::force_update_check_only}};
+
+    app.add_option("--flags", flags, "FW Update Flags")->transform(CLI::CheckedTransformer(flags_map));
+
+    const auto help = app.help();
+
+    CHECK(help.find("--flags") != std::string::npos);
+    CHECK(help.find("FW Update Flags") != std::string::npos);
+
+    const auto first_mapping = help.find("allow_downgrade->1");
+    const auto second_mapping = help.find("allow_downgrade_check_only->5");
+
+    REQUIRE(first_mapping != std::string::npos);
+    REQUIRE(second_mapping != std::string::npos);
+
+    const auto newline_after_first = help.find('\n', first_mapping);
+
+    CHECK(newline_after_first < second_mapping);
+}
+
 // from to-mas-kral Issue #1086
 TEST_CASE_METHOD(TApp, "EnumCheckedTransformUint8", "[transform]") {
     enum class FooType : std::uint8_t { A, B };


### PR DESCRIPTION
Fixes #554.

This formats long CheckedTransformer map descriptions across multiple lines while keeping short descriptions unchanged.

Tests:
- cmake --build build --config Debug --target TransformTest
- ctest --test-dir build -C Debug -R TransformTest --output-on-failure
- ctest --test-dir build -C Debug --output-on-failure