### PR TITLE
fix(encoding): bound non-codecvt narrow/widen by str_size

### DIFF
--- a/include/CLI/impl/Encoding_inl.hpp
+++ b/include/CLI/impl/Encoding_inl.hpp
@@ -69,9 +69,15 @@ CLI11_INLINE std::string narrow_impl(const wchar_t *str, std::size_t str_size) {
 
 #endif  // _WIN32
 #else   // CLI11_HAS_CODECVT
-    (void)str_size;
+    // Copy into a local, NUL-terminated buffer so the conversion is bounded by str_size: a view into the
+    // middle of a larger buffer or a non-NUL-terminated buffer must not be read past str_size. Note that an
+    // embedded NUL inside the first str_size characters will still terminate std::wcsrtombs early; this matches
+    // the behavior of C-style narrow conversion and is treated as a best-effort limitation.
+    std::wstring input(str, str_size);
+    const wchar_t *src = input.c_str();
+    const wchar_t *it = src;
+
     std::mbstate_t state = std::mbstate_t();
-    const wchar_t *it = str;
 
     std::string old_locale = std::setlocale(LC_ALL, nullptr);
     auto sg = scope_guard([&] { std::setlocale(LC_ALL, old_locale.c_str()); });
@@ -80,10 +86,10 @@ CLI11_INLINE std::string narrow_impl(const wchar_t *str, std::size_t str_size) {
     std::size_t new_size = std::wcsrtombs(nullptr, &it, 0, &state);
     if(new_size == static_cast<std::size_t>(-1)) {
         throw std::runtime_error("CLI::narrow: conversion error in std::wcsrtombs at offset " +
-                                 std::to_string(it - str));
+                                 std::to_string(it - src));
     }
     std::string result(new_size, '\0');
-    std::wcsrtombs(const_cast<char *>(result.data()), &str, new_size, &state);
+    std::wcsrtombs(const_cast<char *>(result.data()), &src, new_size, &state);
 
     return result;
 
@@ -100,9 +106,15 @@ CLI11_INLINE std::wstring widen_impl(const char *str, std::size_t str_size) {
 
 #endif  // _WIN32
 #else   // CLI11_HAS_CODECVT
-    (void)str_size;
+    // Copy into a local, NUL-terminated buffer so the conversion is bounded by str_size: a view into the
+    // middle of a larger buffer or a non-NUL-terminated buffer must not be read past str_size. Note that an
+    // embedded NUL inside the first str_size characters will still terminate std::mbsrtowcs early; this matches
+    // the behavior of C-style wide conversion and is treated as a best-effort limitation.
+    std::string input(str, str_size);
+    const char *src = input.c_str();
+    const char *it = src;
+
     std::mbstate_t state = std::mbstate_t();
-    const char *it = str;
 
     std::string old_locale = std::setlocale(LC_ALL, nullptr);
     auto sg = scope_guard([&] { std::setlocale(LC_ALL, old_locale.c_str()); });
@@ -111,10 +123,10 @@ CLI11_INLINE std::wstring widen_impl(const char *str, std::size_t str_size) {
     std::size_t new_size = std::mbsrtowcs(nullptr, &it, 0, &state);
     if(new_size == static_cast<std::size_t>(-1)) {
         throw std::runtime_error("CLI::widen: conversion error in std::mbsrtowcs at offset " +
-                                 std::to_string(it - str));
+                                 std::to_string(it - src));
     }
     std::wstring result(new_size, L'\0');
-    std::mbsrtowcs(const_cast<wchar_t *>(result.data()), &str, new_size, &state);
+    std::mbsrtowcs(const_cast<wchar_t *>(result.data()), &src, new_size, &state);
 
     return result;
 

--- a/tests/EncodingTest.cpp
+++ b/tests/EncodingTest.cpp
@@ -71,6 +71,26 @@ TEST_CASE("Encoding: Widen", "[unicode]") {
 #endif  // CLI11_CPP17
 }
 
+// str_size must bound the conversion; converting a prefix of a longer buffer must not read past str_size
+// (relevant for the non-codecvt path, which is the default under C++26).
+TEST_CASE("Encoding: WidenSize", "[unicode]") {
+    using CLI::widen;
+
+    // "Hello " is 6 leading ASCII bytes, mapping 1:1 to 6 wide characters.
+    const std::string longer = "Hello world";
+    const std::wstring expected = L"Hello ";
+
+    CHECK(expected == widen(longer.c_str(), 6));
+
+    // A buffer that is not NUL-terminated at str_size must only read the first str_size bytes.
+    const std::array<char, 5> not_terminated{{'a', 'b', 'c', 'd', 'e'}};
+    CHECK(std::wstring(L"abc") == widen(not_terminated.data(), 3));
+
+#ifdef CLI11_CPP17
+    CHECK(expected == widen(std::string_view{longer}.substr(0, 6)));
+#endif  // CLI11_CPP17
+}
+
 // #14
 TEST_CASE("Encoding: Narrow", "[unicode]") {
     using CLI::narrow;
@@ -84,6 +104,26 @@ TEST_CASE("Encoding: Narrow", "[unicode]") {
 
 #ifdef CLI11_CPP17
     CHECK(hello_str == narrow(std::wstring_view{hello_wstr}));
+#endif  // CLI11_CPP17
+}
+
+// str_size must bound the conversion; converting a prefix of a longer buffer must not read past str_size
+// (relevant for the non-codecvt path, which is the default under C++26).
+TEST_CASE("Encoding: NarrowSize", "[unicode]") {
+    using CLI::narrow;
+
+    // "Hello " is 6 leading ASCII wide characters, mapping 1:1 to 6 bytes.
+    const std::wstring longer = L"Hello world";
+    const std::string expected = "Hello ";
+
+    CHECK(expected == narrow(longer.c_str(), 6));
+
+    // A buffer that is not NUL-terminated at str_size must only read the first str_size characters.
+    const std::array<wchar_t, 5> not_terminated{{L'a', L'b', L'c', L'd', L'e'}};
+    CHECK(std::string("abc") == narrow(not_terminated.data(), 3));
+
+#ifdef CLI11_CPP17
+    CHECK(expected == narrow(std::wstring_view{longer}.substr(0, 6)));
 #endif  // CLI11_CPP17
 }
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

In `include/CLI/impl/Encoding_inl.hpp`, the non-codecvt branches of `narrow_impl`/`widen_impl` did `(void)str_size;` and relied on `std::wcsrtombs`/`std::mbsrtowcs` converting up to a NUL terminator. That is fine for the `std::wstring`/null-terminated overloads, but wrong for the size-taking overloads (`narrow(const wchar_t *, std::size_t)`, the C++17 `narrow(std::wstring_view)` / `widen(std::string_view)`, etc.):

- A view into the middle of a larger buffer converted the entire remainder instead of `str_size` characters.
- A view over a non-NUL-terminated buffer read out of bounds (UB).
- Embedded NULs truncated the result.

The codecvt path already handled all of this correctly via `to_bytes(str, str + str_size)`. This non-codecvt path becomes the **default under C++26** (`CLI11_HAS_CODECVT` is 0 when `CLI11_CPP26` is set, per `include/CLI/Macros.hpp`), so it matters increasingly.

## Fix

In the non-codecvt branches, copy the input into a local, NUL-terminated buffer of exactly `str_size` characters and convert from that, so the conversion is bounded by `str_size` and never reads past the buffer. The existing locale `scope_guard` behavior and error reporting are preserved (offsets now reported relative to the local copy). C++11-compatible. Embedded NULs within the first `str_size` characters still terminate the C-style conversion early; this is documented in a comment as a best-effort limitation.

## Testing (dual-path)

Added `Encoding: WidenSize` / `Encoding: NarrowSize` regression tests in `tests/EncodingTest.cpp` that:
- convert a prefix of a longer buffer (e.g. `widen(longer.c_str(), 6)` / `narrow(longer.c_str(), 6)`) and assert only the prefix is converted;
- convert a non-NUL-terminated buffer of exactly `str_size` chars (would read OOB under the old code).

Both the default (codecvt) build and a `-DCMAKE_CXX_FLAGS=-DCLI11_HAS_CODECVT=0` build were configured and run; `EncodingTest` passes in both. The macro override was confirmed to select the non-codecvt branch (preprocessed output uses `wcsrtombs`/`mbsrtowcs` rather than `to_bytes`).

Part of #1357