### PR TITLE
fix: clear proc_results_ in Option::clear() to avoid stale processed values

### DIFF
--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -397,6 +397,7 @@ class Option : public OptionBase<Option> {
     /// Clear the parsed results (mostly for testing)
     void clear() {
         results_.clear();
+        proc_results_.clear();
         current_option_state_ = option_state::parsing;
     }
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -969,7 +969,7 @@ TEST_CASE_METHOD(TApp, "SumOptClearResetsProc", "[app]") {
 
     opt->clear();
     opt->add_result("7");
-    opt->as<int>();  // triggers reduction into proc_results_
+    (void)opt->as<int>();  // triggers reduction into proc_results_
     CHECK(7 == opt->as<int>());
 }
 

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -957,6 +957,22 @@ TEST_CASE_METHOD(TApp, "SumOptString", "[app]") {
     CHECK("i2" == val);
 }
 
+TEST_CASE_METHOD(TApp, "SumOptClearResetsProc", "[app]") {
+    // Regression test: Option::clear() must also clear proc_results_ so that
+    // a subsequent parse is not contaminated by a previous run's processed values.
+    int val = 0;
+    auto *opt = app.add_option("--val", val)->multi_option_policy(CLI::MultiOptionPolicy::Sum);
+
+    args = {"--val=2", "--val=3"};
+    run();
+    CHECK(5 == val);
+
+    opt->clear();
+    opt->add_result("7");
+    opt->as<int>();  // triggers reduction into proc_results_
+    CHECK(7 == opt->as<int>());
+}
+
 TEST_CASE_METHOD(TApp, "ReverseOpt", "[app]") {
 
     std::vector<std::string> val;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- **Bug**: `Option::clear()` reset `results_` and `current_option_state_` but not `proc_results_`. The fast path in `results(T&)` (`include/CLI/Option.hpp` ~line 726) returns `proc_results_` whenever it is non-empty, so any `as<T>()` call after `clear()` returned the old processed value instead of the newly added one.
- **Scenario**: Parse `--x 2 --x 3` with `MultiOptionPolicy::Sum` (fills `proc_results_ = {"5"}`), then `opt->clear(); opt->add_result("7"); opt->as<int>()` returned `5` instead of `7`.
- **Fix**: Add `proc_results_.clear();` inside `Option::clear()` (`include/CLI/Option.hpp`).
- **Test**: Added `SumOptClearResetsProc` to `tests/AppTest.cpp` to reproduce the exact scenario and assert the post-clear value is correct.

Part of #1357