### PR TITLE
fix(config): correct multiline string value extraction for indented keys

### DIFF
--- a/include/CLI/impl/Config_inl.hpp
+++ b/include/CLI/impl/Config_inl.hpp
@@ -346,7 +346,8 @@ inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) cons
             if(mlquote) {
                 // multiline string
                 auto keyChar = item.front();
-                item = buffer.substr(delimiter_pos + 1, std::string::npos);
+                auto offset = buffer.find_first_not_of(" \t");
+                item = buffer.substr((offset == std::string::npos ? 0 : offset) + delimiter_pos + 1, std::string::npos);
                 detail::ltrim(item);
                 item.erase(0, 3);
                 inMLineValue = true;

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -368,6 +368,33 @@ TEST_CASE("StringBased: TomlMultiLineStringError", "[config]") {
     CHECK_THROWS(CLI::ConfigINI().from_config(ofile));
 }
 
+TEST_CASE("StringBased: TomlMultiLineStringIndented", "[config]") {
+    // Regression: indented key with multiline value must not corrupt the value
+    // by applying the trimmed delimiter_pos to the untrimmed buffer.
+    std::stringstream ofile;
+
+    ofile << "one = [three]\n";
+    ofile << "  two = '''\n";
+    ofile << "multiline content\n";
+    ofile << "'''\n";
+    ofile << "three=7    \n";
+
+    ofile.seekg(0, std::ios::beg);
+
+    std::vector<CLI::ConfigItem> output = CLI::ConfigINI().from_config(ofile);
+
+    CHECK(output.size() == 3u);
+    CHECK(output.at(0).name == "one");
+    CHECK(output.at(0).inputs.size() == 1u);
+    CHECK(output.at(0).inputs.at(0) == "three");
+    CHECK(output.at(1).name == "two");
+    CHECK(output.at(1).inputs.size() == 1u);
+    CHECK(output.at(1).inputs.at(0) == "multiline content");
+    CHECK(output.at(2).name == "three");
+    CHECK(output.at(2).inputs.size() == 1u);
+    CHECK(output.at(2).inputs.at(0) == "7");
+}
+
 TEST_CASE("StringBased: Spaces", "[config]") {
     std::stringstream ofile;
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- **Bug**: In `ConfigBase::from_config` (`include/CLI/impl/Config_inl.hpp`), `delimiter_pos` is computed on `line` (the whitespace-trimmed copy of the input), but the multiline-value branch re-extracts the value using `buffer.substr(delimiter_pos + 1)` where `buffer` is the untrimmed original. Any leading whitespace (e.g. indentation) shifts the offset, yielding a corrupted value — e.g. `  key='''` + multiline content produces `''\nmultiline content` instead of `multiline content`.
- **Fix**: Compute the leading-whitespace offset of `buffer` with `buffer.find_first_not_of(" \t")` and add it to `delimiter_pos` when indexing into `buffer`. The flush-left case (offset == 0) is unchanged.
- **Test**: Added `TomlMultiLineStringIndented` regression test in `tests/ConfigFileTest.cpp` that parses a two-space-indented key with a `'''` literal multiline value and asserts the exact content.

Part of #1357

## Test plan

- [x] `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCLI11_BUILD_EXAMPLES=OFF && cmake --build build -j4 --target ConfigFileTest && ./build/tests/ConfigFileTest` — **701 assertions in 191 test cases, all passed**
- [x] `prek -a --quiet` — all hooks pass (clang-format auto-fix applied)