### PR TITLE
fix: type-conversion edge cases in TypeTools and Option reduce

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -944,7 +944,13 @@ inline std::string type_name() {
 /// Convert to an unsigned integral
 template <typename T, enable_if_t<std::is_unsigned<T>::value, detail::enabler> = detail::dummy>
 bool integral_conversion(const std::string &input, T &output) noexcept {
-    if(input.empty() || input.front() == '-') {
+    if(input.empty()) {
+        return false;
+    }
+    // strtoull skips leading whitespace and silently wraps a negative value, so reject any input whose
+    // first non-whitespace character is a minus sign before it reaches strtoull
+    auto first_non_ws = input.find_first_not_of(" \t\n\v\f\r");
+    if(first_non_ws != std::string::npos && input[first_non_ws] == '-') {
         return false;
     }
     char *val{nullptr};
@@ -1167,6 +1173,11 @@ bool lexical_cast(const std::string &input, T &output) {
     }
     char *val = nullptr;
     auto output_ld = std::strtold(input.c_str(), &val);
+    // strtold performs no conversion (and leaves val == start) for inputs like whitespace-only strings;
+    // treat that as a failure rather than reporting a successful conversion to 0
+    if(val == input.c_str()) {
+        return false;
+    }
     output = static_cast<T>(output_ld);
     if(val == (input.c_str() + input.size())) {
         return true;
@@ -1750,11 +1761,14 @@ bool lexical_conversion(std::vector<std::string> strings, AssignTo &output) {
     output.clear();
     while(!strings.empty()) {
 
-        typename std::remove_const<typename std::tuple_element<0, typename ConvertTo::value_type>::type>::type v1;
-        typename std::tuple_element<1, typename ConvertTo::value_type>::type v2;
+        typename std::remove_const<typename std::tuple_element<0, typename ConvertTo::value_type>::type>::type v1{};
+        typename std::tuple_element<1, typename ConvertTo::value_type>::type v2{};
         bool retval = tuple_type_conversion<decltype(v1), decltype(v1)>(strings, v1);
         if(!strings.empty()) {
             retval = retval && tuple_type_conversion<decltype(v2), decltype(v2)>(strings, v2);
+        } else {
+            // an odd number of elements means the second value is missing; never insert a default-constructed v2
+            retval = false;
         }
         if(retval) {
             output.insert(output.end(), typename AssignTo::value_type{v1, v2});
@@ -1858,6 +1872,28 @@ bool lexical_conversion(const std::vector<std::string> &strings, AssignTo &outpu
 
 /// Sum a vector of strings
 inline std::string sum_string_vector(const std::vector<std::string> &values) {
+    // First try a pure integer sum so that large integral totals (>= 1e16, or beyond the 2^53 mantissa of
+    // double) are preserved exactly and rendered as a plain integer rather than scientific notation
+    std::int64_t ival{0};
+    bool int_sum{true};
+    for(const auto &arg : values) {
+        std::int64_t tv{0};
+        if(!integral_conversion(arg, tv)) {
+            int_sum = false;
+            break;
+        }
+        // detect signed overflow before performing the addition since signed overflow is undefined behavior
+        if((tv > 0 && ival > (std::numeric_limits<std::int64_t>::max)() - tv) ||
+           (tv < 0 && ival < (std::numeric_limits<std::int64_t>::min)() - tv)) {
+            int_sum = false;
+            break;
+        }
+        ival += tv;
+    }
+    if(int_sum) {
+        return std::to_string(ival);
+    }
+
     double val{0.0};
     bool fail{false};
     std::string output;

--- a/include/CLI/impl/Option_inl.hpp
+++ b/include/CLI/impl/Option_inl.hpp
@@ -634,7 +634,7 @@ CLI11_INLINE void Option::_reduce_results(results_t &out, const results_t &origi
         }
     } break;
     case MultiOptionPolicy::Join:
-        if(results_.size() > 1) {
+        if(original.size() > 1) {
             out.push_back(detail::join(original, std::string(1, (delimiter_ == '\0') ? '\n' : delimiter_)));
         }
         break;

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1376,6 +1376,18 @@ TEST_CASE("Types: LexicalCastInt", "[helpers]") {
     CHECK_FALSE(CLI::detail::lexical_cast(empty_input, y_signed));
 }
 
+TEST_CASE("Types: LexicalCastUnsignedLeadingWhitespaceNegative", "[helpers]") {
+    // strtoull skips leading whitespace and silently wraps a negative value; " -1" must not become UINT64_MAX
+    std::uint64_t x_unsigned = 0;
+    CHECK_FALSE(CLI::detail::lexical_cast(" -1", x_unsigned));
+    CHECK_FALSE(CLI::detail::lexical_cast("\t-5", x_unsigned));
+    CHECK_FALSE(CLI::detail::lexical_cast("-1", x_unsigned));
+
+    // a leading-whitespace positive value should still convert correctly
+    CHECK(CLI::detail::lexical_cast(" 7", x_unsigned));
+    CHECK(x_unsigned == static_cast<std::uint64_t>(7));
+}
+
 TEST_CASE("Types: LexicalCastDouble", "[helpers]") {
     std::string input = "9.12";
     long double x = NAN;
@@ -1394,6 +1406,12 @@ TEST_CASE("Types: LexicalCastDouble", "[helpers]") {
 
     std::string empty_input{};
     CHECK_FALSE(CLI::detail::lexical_cast(empty_input, x));
+
+    // whitespace-only strings perform no conversion in strtold and must fail rather than report 0.0
+    double d = 7.5;
+    CHECK_FALSE(CLI::detail::lexical_cast(" ", d));
+    CHECK_FALSE(CLI::detail::lexical_cast("   ", d));
+    CHECK_FALSE(CLI::detail::lexical_cast("\t\n", d));
 }
 
 TEST_CASE("Types: LexicalCastBool", "[helpers]") {
@@ -1498,6 +1516,47 @@ TEST_CASE("Types: LexicalConversionEmptyVectorDouble", "[helpers]") {
     bool res = CLI::detail::lexical_conversion<std::vector<double>, std::vector<double>>(input, x);
     CHECK(res);
     CHECK(x.empty());
+}
+
+TEST_CASE("Types: LexicalConversionPairContainerOddCount", "[helpers]") {
+    // an odd element count must fail rather than insert a pair with an uninitialized/defaulted second value
+    using map_t = std::vector<std::pair<std::string, int>>;
+    CLI::results_t input = {"onlykey"};
+    map_t x;
+    bool res = CLI::detail::lexical_conversion<map_t, map_t>(input, x);
+    CHECK_FALSE(res);
+
+    // a complete set of pairs should still convert successfully
+    input = {"a", "1", "b", "2"};
+    res = CLI::detail::lexical_conversion<map_t, map_t>(input, x);
+    CHECK(res);
+    REQUIRE(x.size() == static_cast<std::size_t>(2));
+    CHECK(x[0].first == "a");
+    CHECK(x[0].second == 1);
+    CHECK(x[1].first == "b");
+    CHECK(x[1].second == 2);
+}
+
+TEST_CASE("Types: SumStringVector", "[helpers]") {
+    // large integer sums must stay exact and render as plain integers, not scientific notation
+    std::vector<std::string> big = {"5000000000000000", "5000000000000000"};
+    CHECK(CLI::detail::sum_string_vector(big) == "10000000000000000");
+
+    // values above 2^53 must not lose precision through a double accumulation
+    std::vector<std::string> precise = {"9007199254740993", "0"};
+    CHECK(CLI::detail::sum_string_vector(precise) == "9007199254740993");
+
+    // simple integer sums
+    std::vector<std::string> small = {"3", "4", "5"};
+    CHECK(CLI::detail::sum_string_vector(small) == "12");
+
+    // floating point sums fall back to the double path
+    std::vector<std::string> floats = {"1.5", "2.5"};
+    CHECK(CLI::detail::sum_string_vector(floats) == "4");
+
+    // non-numeric values fall back to string concatenation
+    std::vector<std::string> strings = {"a", "b"};
+    CHECK(CLI::detail::sum_string_vector(strings) == "ab");
 }
 
 static_assert(!CLI::detail::is_tuple_like<std::vector<double>>::value, "vector should not be like a tuple");

--- a/tests/OptionTypeTest.cpp
+++ b/tests/OptionTypeTest.cpp
@@ -1123,3 +1123,34 @@ TEST_CASE_METHOD(TApp, "force_callback3", "[optiontype]") {
     run();
     CHECK(0 == cnt);
 }
+
+TEST_CASE_METHOD(TApp, "JoinDefaultStrResults", "[optiontype]") {
+    // _reduce_results must apply the Join policy to the default-derived results (not the empty results_)
+    std::vector<std::string> strs;
+    auto *opt = app.add_option("--str", strs)
+                    ->multi_option_policy(CLI::MultiOptionPolicy::Join)
+                    ->expected(2)
+                    ->default_str("[a,b]");
+
+    args = {};
+    run();
+
+    std::string out;
+    opt->results(out);
+    CHECK("a\nb" == out);
+}
+
+TEST_CASE_METHOD(TApp, "SumLargeInteger", "[optiontype]") {
+    // a Sum-policy int64 option must accumulate large integral values exactly without scientific notation
+    std::int64_t val{0};
+    app.add_option("--s", val)->multi_option_policy(CLI::MultiOptionPolicy::Sum);
+
+    args = {"--s", "5000000000000000", "--s", "5000000000000000"};
+    run();
+    CHECK(val == static_cast<std::int64_t>(10000000000000000LL));
+
+    // values above 2^53 must not lose precision through a double accumulation
+    args = {"--s", "9007199254740993", "--s", "0"};
+    run();
+    CHECK(val == static_cast<std::int64_t>(9007199254740993LL));
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes five verified type-conversion bugs in `TypeTools.hpp` and `Option_inl.hpp`, each with a regression test.

1. **Unsigned `integral_conversion` accepted `" -1"` as `UINT64_MAX`.** The old guard only checked `input.front() == '-'`, but `strtoull` skips leading whitespace and silently wraps negatives. Now the input is rejected when its first non-whitespace character is `'-'`. (`include/CLI/TypeTools.hpp`)

2. **Float `lexical_cast` converted whitespace-only strings to `0.0` successfully.** When `strtold` performs no conversion the end pointer equals the start; the trailing-whitespace skip loop then walked to the end and returned `true`. Now we return `false` when nothing was consumed (`val == input.c_str()`). (`include/CLI/TypeTools.hpp`)

3. **Uninitialized `v2` could be inserted into a container-of-pairs (UB).** With an odd element count the second conversion was skipped while `retval` stayed `true`, inserting `{v1, v2}` with `v2` never assigned. Both values are now value-initialized and a missing second element sets `retval = false`, so it raises a `ConversionError` instead of silently inserting `{key, 0}`. Reachable via `add_result("onlykey"); results(map);`. (`include/CLI/TypeTools.hpp`)

4. **`sum_string_vector` broke for integer sums >= 1e16 and lost precision above 2^53.** Sums accumulated as `double` and printed at precision 16, rendering large totals in scientific notation that `integral_conversion` could not parse. An `int64_t` accumulation (with overflow check) is now tried first, falling back to the existing `double` path for floats/flags/non-numeric input. (`include/CLI/TypeTools.hpp`)

5. **`Join` policy in `_reduce_results` tested `results_.size()` instead of `original.size()`.** `Option::results(T&)` reduces results synthesized from `default_str_` while `results_` is empty, so the join was skipped (yielding `"a"` instead of `"a\nb"`). Now tests `original.size() > 1` like every other policy branch. (`include/CLI/impl/Option_inl.hpp`)

No false positives — all five reproduced against the code before the fix.

Tests added in `tests/HelpersTest.cpp` (unsigned leading-whitespace negative, whitespace-only float, odd-count pair container, `sum_string_vector`) and `tests/OptionTypeTest.cpp` (Join + `default_str` via `results()`, large-integer Sum policy).

Part of #1357