### PR TITLE
fix: config reader/writer, formatter, and ExtrasError bugs

### DIFF
--- a/include/CLI/Error.hpp
+++ b/include/CLI/Error.hpp
@@ -313,9 +313,9 @@ class ExtrasError : public ParseError {
                           detail::join(args, " "),
                       ExitCodes::ExtrasError) {}
     ExtrasError(const std::string &name, std::vector<std::string> args)
-        : ExtrasError(name,
-                      (args.size() > 1 ? "The following arguments were not expected: "
-                                       : "The following argument was not expected: ") +
+        : ExtrasError((name.empty() ? std::string{} : name + ": ") +
+                          (args.size() > 1 ? "The following arguments were not expected: "
+                                           : "The following argument was not expected: ") +
                           detail::join(args, " "),
                       ExitCodes::ExtrasError) {}
 };

--- a/include/CLI/impl/Config_inl.hpp
+++ b/include/CLI/impl/Config_inl.hpp
@@ -235,6 +235,22 @@ inline auto find_matching_config(std::vector<ConfigItem> &items,
     } while(fullSearch);
     return items.end();
 }
+
+CLI11_INLINE void clean_name_string(std::string &name, const std::string &keyChars) {
+    if(name.find_first_of(keyChars) != std::string::npos || (name.front() == '[' && name.back() == ']') ||
+       (name.find_first_of("'`\"\\") != std::string::npos)) {
+        if(name.find_first_of('\'') == std::string::npos) {
+            name.insert(0, 1, '\'');
+            name.push_back('\'');
+        } else {
+            if(detail::has_escapable_character(name)) {
+                name = detail::add_escaped_characters(name);
+            }
+            name.insert(0, 1, '\"');
+            name.push_back('\"');
+        }
+    }
+}
 }  // namespace detail
 
 inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) const {
@@ -265,6 +281,11 @@ inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) cons
             continue;
         }
         if(line.compare(0, 3, multiline_string_quote) == 0 || line.compare(0, 3, multiline_literal_quote) == 0) {
+            // check if the multiline comment opens and closes on the same line; the opening quotes
+            // themselves must not be counted as the closer hence the length requirement
+            if(len >= 6 && detail::hasMLString(line, line.front())) {
+                continue;
+            }
             inMLineComment = true;
             auto cchar = line.front();
             while(inMLineComment) {
@@ -278,6 +299,29 @@ inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) cons
                 }
             }
             continue;
+        }
+        // strip a trailing comment (quote aware) for section headers so that "[section] # comment"
+        // is recognized as a section; value lines handle their own trailing comments later
+        if(line.front() == '[' && line.back() != ']' && line.find_first_of(commentChar) != std::string::npos) {
+            std::size_t comment_search = 0;
+            while(comment_search < line.size()) {
+                auto test_char = line[comment_search];
+                if(test_char == '\"' || test_char == '\'' || test_char == '`') {
+                    comment_search = detail::close_sequence(line, comment_search, line[comment_search]);
+                    ++comment_search;
+                } else if(test_char == commentChar) {
+                    break;
+                } else {
+                    ++comment_search;
+                }
+            }
+            if(comment_search < line.size() && line[comment_search] == commentChar) {
+                line = detail::trim_copy(line.substr(0, comment_search));
+                len = line.length();
+                if(len < 3) {
+                    continue;
+                }
+            }
         }
         if(line.front() == '[' && line.back() == ']') {
             if(currentSection != "default") {
@@ -492,23 +536,6 @@ inline std::vector<ConfigItem> ConfigBase::from_config(std::istream &input) cons
     return output;
 }
 
-CLI11_INLINE std::string &clean_name_string(std::string &name, const std::string &keyChars) {
-    if(name.find_first_of(keyChars) != std::string::npos || (name.front() == '[' && name.back() == ']') ||
-       (name.find_first_of("'`\"\\") != std::string::npos)) {
-        if(name.find_first_of('\'') == std::string::npos) {
-            name.insert(0, 1, '\'');
-            name.push_back('\'');
-        } else {
-            if(detail::has_escapable_character(name)) {
-                name = detail::add_escaped_characters(name);
-            }
-            name.insert(0, 1, '\"');
-            name.push_back('\"');
-        }
-    }
-    return name;
-}
-
 CLI11_INLINE std::string
 ConfigBase::to_config(const App *app, bool default_also, bool write_description, std::string prefix) const {
     return to_config(app,
@@ -587,7 +614,7 @@ ConfigBase::to_config(const App *app, ConfigOutputMode mode, bool write_descript
                         // strings which would be interpreted incorrectly
                         auto delim_count = std::count(results[0].begin(), results[0].end(), delim);
                         if(results[0].back() == delim ||
-                           static_cast<decltype(delim_count)>(opt->count()) < delim_count - 1 ||
+                           static_cast<decltype(delim_count)>(opt->count()) < delim_count + 1 ||
                            results[0].find(std::string(2, delim)) != std::string::npos) {
                             results = opt->results();
                         }
@@ -648,7 +675,7 @@ ConfigBase::to_config(const App *app, ConfigOutputMode mode, bool write_descript
                         }
                         out << commentLead << detail::fix_newlines(commentLead, opt->get_description()) << '\n';
                     }
-                    clean_name_string(single_name, keyChars);
+                    detail::clean_name_string(single_name, keyChars);
 
                     std::string name = prefix + single_name;
                     if(commentDefaultsBool && isDefault) {
@@ -667,7 +694,7 @@ ConfigBase::to_config(const App *app, ConfigOutputMode mode, bool write_descript
                 continue;
             }
             if(write_description && !subcom->get_group().empty()) {
-                out << '\n' << commentLead << subcom->get_group() << " Options\n";
+                out << '\n' << commentChar << commentLead << subcom->get_group() << " Options\n";
             }
             /*if (!prefix.empty() || app->get_parent() == nullptr) {
                 out << '[' << prefix << "___"<< subcom->get_group() << "]\n";
@@ -692,7 +719,7 @@ ConfigBase::to_config(const App *app, ConfigOutputMode mode, bool write_descript
                 continue;
             }
             std::string subname = subcom->get_name();
-            clean_name_string(subname, keyChars);
+            detail::clean_name_string(subname, keyChars);
 
             if(subcom->get_configurable() && (app->got_subcommand(subcom) || (mode == ConfigOutputMode::AllDefaults))) {
                 if(!prefix.empty() || app->get_parent() == nullptr) {
@@ -700,12 +727,12 @@ ConfigBase::to_config(const App *app, ConfigOutputMode mode, bool write_descript
                     out << '[' << prefix << subname << "]\n";
                 } else {
                     std::string appname = app->get_name();
-                    clean_name_string(appname, keyChars);
+                    detail::clean_name_string(appname, keyChars);
                     subname = appname + parentSeparatorChar + subname;
                     const auto *p = app->get_parent();
                     while(p->get_parent() != nullptr) {
                         std::string pname = p->get_name();
-                        clean_name_string(pname, keyChars);
+                        detail::clean_name_string(pname, keyChars);
                         subname = pname + parentSeparatorChar + subname;
                         p = p->get_parent();
                     }

--- a/include/CLI/impl/Config_inl.hpp
+++ b/include/CLI/impl/Config_inl.hpp
@@ -614,7 +614,7 @@ ConfigBase::to_config(const App *app, ConfigOutputMode mode, bool write_descript
                         // strings which would be interpreted incorrectly
                         auto delim_count = std::count(results[0].begin(), results[0].end(), delim);
                         if(results[0].back() == delim ||
-                           static_cast<decltype(delim_count)>(opt->count()) < delim_count + 1 ||
+                           static_cast<decltype(delim_count)>(opt->count()) <= delim_count ||
                            results[0].find(std::string(2, delim)) != std::string::npos) {
                             results = opt->results();
                         }

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -116,7 +116,8 @@ CLI11_INLINE std::string Formatter::make_usage(const App *app, std::string name)
         out << " [" << get_label("OPTIONS") << "]";
 
     // Positionals need to be listed here
-    std::vector<const Option *> positionals = app->get_options([](const Option *opt) { return opt->get_positional(); });
+    std::vector<const Option *> positionals =
+        app->get_options([](const Option *opt) { return !opt->get_group().empty() && opt->get_positional(); });
 
     // Print out positionals if any are left
     if(!positionals.empty()) {
@@ -168,7 +169,7 @@ CLI11_INLINE std::string Formatter::make_help(const App *app, std::string name, 
         detail::streamOutAsParagraph(
             out, make_description(app), description_paragraph_width_, "");  // Format description as paragraph
     } else {
-        out << make_description(app) << '\n';
+        out << make_description(app);
     }
     out << make_usage(app, name);
     out << make_positionals(app);
@@ -232,8 +233,17 @@ CLI11_INLINE std::string Formatter::make_subcommand(const App *sub) const {
     std::string name = "  " + sub->get_display_name(true) + (sub->get_required() ? " " + get_label("REQUIRED") : "");
 
     out << std::setw(static_cast<int>(column_width_)) << std::left << name;
-    detail::streamOutAsParagraph(
-        out, sub->get_description(), right_column_width_, std::string(column_width_, ' '), true);
+
+    const std::string desc = sub->get_description();
+    if(!desc.empty()) {
+        bool skipFirstLinePrefix = true;
+        if(name.length() >= column_width_) {
+            out << '\n';
+            skipFirstLinePrefix = false;
+        }
+        detail::streamOutAsParagraph(
+            out, desc, right_column_width_, std::string(column_width_, ' '), skipFirstLinePrefix);
+    }
     out << '\n';
     return out.str();
 }

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -2603,6 +2603,23 @@ TEST_CASE_METHOD(TApp, "ExtrasErrorRvalueParse", "[app]") {
     CHECK_THROWS_AS(app.parse(std::vector<std::string>({"-x", "45", "-f", "27"})), CLI::ExtrasError);
 }
 
+// the two-argument ExtrasError(name, args) must still report its class name through get_name(),
+// like every other error class, while preserving the message content
+TEST_CASE_METHOD(TApp, "ExtrasErrorName", "[app]") {
+    app.name("myprog");
+    args = {"extra1", "extra2"};
+    try {
+        run();
+        CHECK(false);
+    } catch(const CLI::ExtrasError &err) {
+        CHECK(err.get_name() == "ExtrasError");
+        std::string message = err.what();
+        CHECK_THAT(message, Contains("extra1"));
+        CHECK_THAT(message, Contains("extra2"));
+        CHECK_THAT(message, Contains("myprog"));
+    }
+}
+
 TEST_CASE_METHOD(TApp, "AllowExtrasCascadeDirect", "[app]") {
 
     app.allow_extras();

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1424,6 +1424,78 @@ TEST_CASE_METHOD(TApp, "TomlDocStringComment3", "[config]") {
     CHECK(3 == three);
 }
 
+TEST_CASE_METHOD(TApp, "TomlSectionTrailingComment", "[config]") {
+    // a trailing comment on a section header should be stripped and the section recognized
+    TempFile tmpini{"TestIniTmp.ini"};
+
+    app.set_config("--config", tmpini);
+
+    {
+        std::ofstream out{tmpini};
+        out << "[default]" << '\n';
+        out << "val=1" << '\n';
+        out << "[subcom] # a comment about the subcommand" << '\n';
+        out << "val=2" << '\n';
+    }
+
+    int one{0}, two{0};
+    app.add_option("--val", one);
+    auto *subcom = app.add_subcommand("subcom");
+    subcom->add_option("--val", two);
+
+    run();
+
+    CHECK(one == 1);
+    CHECK(two == 2);
+}
+
+TEST_CASE_METHOD(TApp, "TomlDocStringCommentOneLine", "[config]") {
+    // a multiline comment that opens and closes on the same line must not swallow the rest of the file
+    TempFile tmpini{"TestIniTmp.ini"};
+
+    app.set_config("--config", tmpini, "", true);
+
+    {
+        std::ofstream out{tmpini};
+        out << "'''comment on one line'''" << '\n';
+        out << "[default]" << '\n';
+        out << "one=35" << '\n';
+        out << R"("""another one line comment""")" << '\n';
+        out << "two=42" << '\n';
+    }
+
+    int one{0}, two{0};
+    app.add_option("--one", one);
+    app.add_option("--two", two);
+
+    CHECK_NOTHROW(run());
+    CHECK(35 == one);
+    CHECK(42 == two);
+}
+
+TEST_CASE_METHOD(TApp, "IniJoinEmbeddedDelimiterRoundTrip", "[config]") {
+    // a Join-policy option whose stored elements contain the join delimiter must fall back to the
+    // array form when written so that the value round-trips with the correct element count.  The
+    // detection compares opt->count() against the embedded-delimiter count (off-by-two fix).
+    TempFile tmpini{"TestIniTmp.ini"};
+
+    std::vector<std::string> vals;
+    auto *opt = app.add_option("--vals", vals)->delimiter(',')->multi_option_policy(CLI::MultiOptionPolicy::Join);
+
+    app.set_config("--config", tmpini);
+
+    // two separate elements, the second containing the delimiter through the [[ ]] vector escape
+    opt->add_result("c");
+    opt->add_result("[[aa,,bb]]");  // -> a single element literally equal to "[a,b]"
+    REQUIRE(opt->count() == 2u);
+
+    std::string str = app.config_to_str();
+    // because an element embeds the delimiter the writer must emit the array form (vals=[...]) rather
+    // than a bare quoted join (the buggy off-by-two produced vals="c,[a,b]")
+    CHECK_THAT(str, Contains("vals=["));
+    CHECK_THAT(str, !Contains("vals=\"c,[a,b]\""));
+}
+
 TEST_CASE_METHOD(TApp, "ConfigModifiers", "[config]") {
 
     app.set_config("--config", "test.ini", "", true);

--- a/tests/FormatterTest.cpp
+++ b/tests/FormatterTest.cpp
@@ -356,3 +356,39 @@ TEST_CASE("Formatter: LongOptionAlignment", "[formatter]") {
     CHECK_THAT(help, Contains("\n  -h, --help                  Print"));
     CHECK_THAT(help, Contains("\n      --opt INT               Something"));
 }
+
+TEST_CASE("Formatter: HiddenPositionalUsage", "[formatter]") {
+    // a positional in an empty (hidden) group must not render as an empty "[]" in the usage line
+    CLI::App app{"My prog"};
+    int v{0};
+    app.add_option("pos", v, "a hidden positional")->group("");
+
+    std::string help = app.help();
+    CHECK_THAT(help, Contains("Usage:"));
+    CHECK_THAT(help, !Contains("[]"));
+    // the hidden positional should not appear in the usage line at all
+    CHECK_THAT(help, !Contains("pos"));
+}
+
+TEST_CASE("Formatter: LongSubcommandName", "[formatter]") {
+    // a subcommand name that fills the name column must wrap so its description does not glue onto it
+    CLI::App app{"My prog"};
+    app.add_subcommand("a-really-really-long-subcommand-name", "subcommand description text");
+
+    std::string help = app.help();
+    // name and description must be separated, not concatenated
+    CHECK_THAT(help, !Contains("a-really-really-long-subcommand-namesubcommand"));
+    CHECK_THAT(help, Contains("a-really-really-long-subcommand-name\n"));
+    CHECK_THAT(help, Contains("subcommand description text"));
+}
+
+TEST_CASE("Formatter: DescriptionNoFormattingSpacing", "[formatter]") {
+    // toggling description formatting off must not introduce an extra blank line before the usage
+    CLI::App app{"My prog"};
+    app.description("Short desc");
+
+    app.get_formatter()->enable_description_formatting(false);
+    std::string help = app.help();
+    CHECK_THAT(help, Contains("Short desc\n\n\nUsage"));
+    CHECK_THAT(help, !Contains("Short desc\n\n\n\nUsage"));
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1357

Fixes a batch of verified Config/Formatter/Error bugs. Each was reproduced before changing; regression tests accompany the behavioral fixes.

## `include/CLI/impl/Config_inl.hpp`

1. **Section header with a trailing comment is now recognized.** `[section] # a comment` (legal TOML) previously fell through the `front()=='[' && back()==']'` check (because `back()` was `'t'`, not `']'`), producing a bogus flag item named `[section]` and mis-attributing following keys. The reader now strips a quote-aware trailing comment for lines that open with `[` but do not end with `]`, before the section check. Value lines are untouched (they still handle their own trailing comments downstream).
2. **A one-line multiline comment no longer swallows the rest of the file.** `'''comment on one line'''` followed by real config now parses correctly. After detecting the `'''`/`"""` opener the same line is checked for a closer, guarded by a length `>= 6` requirement so the opening quotes themselves are not counted as the closer.
3. **Off-by-two in Join-policy embedded-delimiter detection.** A joined string of N elements has `N-1+e` delimiters; the array fallback should trigger when `e > 0`, i.e. `opt->count() < delim_count + 1`. The code tested `< delim_count - 1`, so embedded-delimiter cases slipped through and wrote a bare join (e.g. `vals="c,[a,b]"`) instead of the array form (`vals=['c', "[a,b]"]`). Fixed the comparison (signedness preserved via the existing cast). A round-trip test exercises the array-fallback path via the `[[ ]]` vector escape, which is the reachable way an element retains an embedded delimiter (normal delimiter-splitting options never produce `e > 0`).
4. **`clean_name_string` namespace/signature mismatch.** `Config.hpp` declared `void detail::clean_name_string(std::string&, const std::string&)`, but the definition lived in the public `CLI::` namespace and returned `std::string&`, so the `detail` declaration was never defined and the real function polluted `CLI::`. The definition is moved into `namespace detail`, the return type reconciled to `void` (matching the declaration; no caller used the return value), and the four call sites in `to_config` qualified as `detail::clean_name_string`.
5. **Consistent comment lead on group headers.** The unnamed-subcommand group header wrote only `commentLead` (`# Group Options`); it now matches the main option-group header style `commentChar << commentLead` (`## Group Options`).

## `include/CLI/impl/Formatter_inl.hpp`

6. **Hidden positionals no longer render as `[]` in the usage line.** `make_usage` now filters positionals with `!opt->get_group().empty()`, matching `make_positionals`.
7. **Long subcommand names no longer glue onto the description.** `make_subcommand` now mirrors `make_option`'s long-name branch: when the name fills the column it emits a newline and disables the skip-first-line-prefix, so the description starts on its own indented line.
8. **Non-paragraph description path no longer emits an extra blank line.** `make_description` already returns `desc + "\n\n"`; the `enable_description_formatting(false)` branch in `make_help` dropped its extra `'\n'` so toggling the flag no longer changes spacing. (Scope limited to `make_help` per the report; `make_expanded` left as-is.)

## `include/CLI/Error.hpp`

9. **`ExtrasError(name, args)` reports the right error name.** The two-argument constructor previously delegated to the protected 3-arg form, making `get_name()` return the app/subcommand name instead of `"ExtrasError"` (every other error class returns its class name, and `App::exit`/user code dispatch on `get_name()`). It now folds the app name into the message and constructs via the public single-arg path so `get_name() == "ExtrasError"`, while preserving (and slightly enriching) the message content.

## Tests
- `tests/ConfigFileTest.cpp`: `TomlSectionTrailingComment` (1), `TomlDocStringCommentOneLine` (2), `IniJoinEmbeddedDelimiterRoundTrip` (3, verified to fail on the pre-fix comparison).
- `tests/FormatterTest.cpp`: `HiddenPositionalUsage` (6), `LongSubcommandName` (7), `DescriptionNoFormattingSpacing` (8) — all verified to fail without their fix.
- `tests/AppTest.cpp`: `ExtrasErrorName` (9).
- Items 4 and 5 are covered by existing config round-trip tests, which continue to pass.

No false positives were found; all nine issues reproduced.

## Verification
`ctest` over the full suite: 24/24 passed. The five primary binaries (ConfigFileTest, HelpTest, FormatterTest, AppTest, SubcommandTest) all pass; no existing tests required changes. `prek -a --quiet` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)