### PR TITLE
chore: ignore a CLAUDE.md symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ a.out*
 
 /subprojects/Catch2-*
 /subprojects/packagecache
+
+# Symlink to AGENTS.md
+CLAUDE.md
+/claude


### PR DESCRIPTION
Ignore a symlink to AGENTS.md (Claude Code is the only harness that doesn't read it automatically).
