### PR TITLE
fix: double indentation in help message

### DIFF
--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -629,15 +629,20 @@ CLI11_INLINE std::ostream &streamOutAsParagraph(std::ostream &out,
                                                 std::size_t paragraphWidth,
                                                 const std::string &linePrefix,
                                                 bool skipPrefixOnFirstLine) {
-    if(!skipPrefixOnFirstLine)
-        out << linePrefix;  // First line prefix
-
     std::istringstream lss(text);
     std::string line = "";
+    bool first_iter = true;
     while(std::getline(lss, line)) {
         std::istringstream iss(line);
         std::string word = "";
         std::size_t charsWritten = 0;
+
+        if(!first_iter || !skipPrefixOnFirstLine) {
+            out << linePrefix;
+        }
+
+        if(first_iter)
+            first_iter = false;
 
         while(iss >> word) {
             if(charsWritten > 0 && (word.length() + 1 + charsWritten > paragraphWidth)) {
@@ -654,7 +659,7 @@ CLI11_INLINE std::ostream &streamOutAsParagraph(std::ostream &out,
         }
 
         if(!lss.eof())
-            out << '\n' << linePrefix;
+            out << '\n';
     }
     return out;
 }

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -631,18 +631,14 @@ CLI11_INLINE std::ostream &streamOutAsParagraph(std::ostream &out,
                                                 bool skipPrefixOnFirstLine) {
     std::istringstream lss(text);
     std::string line = "";
-    bool first_iter = true;
     while(std::getline(lss, line)) {
         std::istringstream iss(line);
         std::string word = "";
         std::size_t charsWritten = 0;
 
-        if(!first_iter || !skipPrefixOnFirstLine) {
+        if(!skipPrefixOnFirstLine)
             out << linePrefix;
-        }
-
-        if(first_iter)
-            first_iter = false;
+        skipPrefixOnFirstLine = false;  // subsequent lines always get the prefix
 
         while(iss >> word) {
             if(charsWritten > 0 && (word.length() + 1 + charsWritten > paragraphWidth)) {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -218,21 +218,21 @@ TEST_CASE("StringTools: Modify3", "[helpers]") {
 }
 
 TEST_CASE("StringTools: streamOutAsParagraph", "[helpers]") {
-    auto paragraph = [](const std::string &text, const std::string &prefix, bool skipFirst = false) {
+    auto paragraph = [](const std::string &text, const std::string &prefix, bool skipFirst) {
         std::ostringstream out;
         CLI::detail::streamOutAsParagraph(out, text, 80, prefix, skipFirst);
         return out.str();
     };
 
-    CHECK(paragraph("hello world", ">>") == ">>hello world");
+    CHECK(paragraph("hello world", ">>", false) == ">>hello world");
     CHECK(paragraph("hello world", ">>", true) == "hello world");
-    CHECK(paragraph("", ">>").empty());
+    CHECK(paragraph("", ">>", false).empty());
 
     // A trailing newline must not leave a dangling prefix on a phantom last line (regression: #1379).
-    CHECK(paragraph("hello", ">>") == ">>hello");
-    CHECK(paragraph("hello\n", ">>") == ">>hello\n");
-    CHECK(paragraph("line1\nline2", ">>") == ">>line1\n>>line2");
-    CHECK(paragraph("line1\nline2\n", ">>") == ">>line1\n>>line2\n");
+    CHECK(paragraph("hello", ">>", false) == ">>hello");
+    CHECK(paragraph("hello\n", ">>", false) == ">>hello\n");
+    CHECK(paragraph("line1\nline2", ">>", false) == ">>line1\n>>line2");
+    CHECK(paragraph("line1\nline2\n", ">>", false) == ">>line1\n>>line2\n");
 }
 
 TEST_CASE("StringTools: escape_detect", "[helpers]") {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <limits>
 #include <map>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -214,6 +215,24 @@ TEST_CASE("StringTools: Modify3", "[helpers]") {
         return 0u;
     });
     CHECK("aba" == newString);
+}
+
+TEST_CASE("StringTools: streamOutAsParagraph", "[helpers]") {
+    auto paragraph = [](const std::string &text, const std::string &prefix, bool skipFirst = false) {
+        std::ostringstream out;
+        CLI::detail::streamOutAsParagraph(out, text, 80, prefix, skipFirst);
+        return out.str();
+    };
+
+    CHECK(paragraph("hello world", ">>") == ">>hello world");
+    CHECK(paragraph("hello world", ">>", true) == "hello world");
+    CHECK(paragraph("", ">>").empty());
+
+    // A trailing newline must not leave a dangling prefix on a phantom last line (regression: #1379).
+    CHECK(paragraph("hello", ">>") == ">>hello");
+    CHECK(paragraph("hello\n", ">>") == ">>hello\n");
+    CHECK(paragraph("line1\nline2", ">>") == ">>line1\n>>line2");
+    CHECK(paragraph("line1\nline2\n", ">>") == ">>line1\n>>line2\n");
 }
 
 TEST_CASE("StringTools: escape_detect", "[helpers]") {


### PR DESCRIPTION
In some cases using `indent_block` after `streamOutAsParagraph` results in double indentation
due to the addition of one more prefix after the last line in function `streamOutAsParagraph`

to solve this, i moved prefix addition to the beginning of the loop iteration

``` c++
#include "CLI11.hpp"

int main(int argc, char** argv) {
    CLI::App app("test description");

    auto g = app.add_option_group("group", "common group");

    auto g1 = g->add_option_group("subgroup 1", "subgroup 1 description");
    g1->add_option("-a", "option a");

    auto g2 = g->add_option_group("subgroup 2", "subgroup 2 description");

    CLI11_PARSE(app, argc, argv);
}
```
this code produces double indentation before `[Option Group: subgroup 1]`
```
$ ./test-old -h
test description


./test-old [OPTIONS]


OPTIONS:
  -h,     --help              Print this help message and exit
[Option Group: group]
  common group

    [Option Group: subgroup 1]
    subgroup 1 description


    OPTIONS:
      -a                          option a
  [Option Group: subgroup 2]
    subgroup 2 description

    $
```

after fix
```
$ ./test -h
test description


./test [OPTIONS]


OPTIONS:
  -h,     --help              Print this help message and exit
[Option Group: group]
  common group

  [Option Group: subgroup 1]
    subgroup 1 description


    OPTIONS:
      -a                          option a
  [Option Group: subgroup 2]
    subgroup 2 description

$
```