### PR TITLE
fix: enforce require_subcommand maximum for dot notation

### DIFF
--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -2138,6 +2138,12 @@ App::_parse_arg(std::vector<std::string> &args, detail::Classifier current_type,
         if(dotloc != std::string::npos && dotloc < arg_name.size() - 1) {
             // using dot notation is equivalent to single argument subcommand
             auto *sub = _find_subcommand(arg_name.substr(0, dotloc), true, false);
+            if(sub != nullptr && require_subcommand_max_ != 0 &&
+               parsed_subcommands_.size() >= require_subcommand_max_ &&
+               std::find(parsed_subcommands_.begin(), parsed_subcommands_.end(), sub) == parsed_subcommands_.end()) {
+                // the maximum number of subcommands is reached, so a new one cannot be started
+                sub = nullptr;
+            }
             if(sub != nullptr) {
                 std::string v = args.back();
                 args.pop_back();

--- a/tests/SubcommandTest.cpp
+++ b/tests/SubcommandTest.cpp
@@ -2287,6 +2287,25 @@ TEST_CASE_METHOD(TApp, "DotNotationSubcommand", "[subcom]") {
     CHECK(subs.front()->get_name() == "sub2");
 }
 
+TEST_CASE_METHOD(TApp, "DotNotationSubcommandMax", "[subcom]") {
+    std::string v1, v2, other;
+
+    app.require_subcommand(0, 1);
+    auto *sub1 = app.add_subcommand("sub1");
+    sub1->add_option("--value", v1);
+    sub1->add_option("--other", other);
+    app.add_subcommand("sub2")->add_option("--value", v2);
+
+    // more than one option on the same subcommand is still a single subcommand
+    args = {"--sub1.value=a", "--sub1.other=b"};
+    run();
+    CHECK(v1 == "a");
+    CHECK(other == "b");
+
+    args = {"--sub1.value=a", "--sub2.value=b"};
+    CHECK_THROWS_AS(run(), CLI::ExtrasError);
+}
+
 TEST_CASE_METHOD(TApp, "DotNotationSubcommandSingleChar", "[subcom]") {
     std::string v1, v2, vbase;
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The dot-notation path in `App::_parse_arg` called `_find_subcommand` directly, which skipped the `require_subcommand` maximum check that `_valid_subcommand` does for the usual path. `--sub1.value=a --sub2.value=b` thus parsed two subcommands when the maximum was 1.

The dot-notation branch now rejects the match when the maximum is reached and the subcommand is not already parsed. Repeated options on one already-parsed subcommand still work. Silent subcommands are not affected, because they do not count toward the maximum in either path.

Fixes #1383