### PR TITLE
ci: pass CODECOV_TOKEN on coverage upload

### DIFF
--- a/.github/workflows/coverage-tests.yml
+++ b/.github/workflows/coverage-tests.yml
@@ -63,3 +63,5 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: build/coverage.info
+          # Protected branches reject tokenless uploads; fork PRs still work without it.
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Coverage uploads from `main` have failed since the branch became protected:

```
error -- Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

Codecov permits tokenless uploads for public repos only on unprotected branches. Fork PRs get a colon-prefixed branch name (`fork:main`) and upload correctly, but pushes to `main` are rejected. As a result Codecov holds no report for any recent `main` commit and falls back to `e4ee3af`, which is 228 commits old. Every PR then shows a coverage loss that does not exist — see #1379, where Codecov reports "All modified and coverable lines are covered by tests" but `codecov/project` still fails.

This adds the token input. The repository secret `CODECOV_TOKEN` must be set for the fix to operate.