### PR TITLE
test: cover remaining uncovered lines

### DIFF
--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -263,6 +263,9 @@ CLI11_INLINE bool is_binary_escaped_string(const std::string &escaped_string);
 /// extract an escaped binary_string
 CLI11_INLINE std::string extract_binary_string(const std::string &escaped_string);
 
+/// escape an array-like string so it cannot be interpreted as a secondary array
+CLI11_INLINE void handle_secondary_array(std::string &str);
+
 /// process a quoted string, remove the quotes and if appropriate handle escaped characters
 CLI11_INLINE bool process_quoted_string(std::string &str,
                                         char string_char = '\"',

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1598,7 +1598,7 @@ CLI11_INLINE void App::_parse(std::vector<std::string> &&args) {
 
     while(!args.empty()) {
         if(!_parse_single(args, positional_only)) {
-            break;
+            break;  // LCOV_EXCL_LINE  _parse_single cannot return false at the top level
         }
     }
     _process();

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1501,6 +1501,32 @@ TEST_CASE_METHOD(TApp, "TomlSectionTrailingComment", "[config]") {
     CHECK(two == 2);
 }
 
+TEST_CASE_METHOD(TApp, "TomlQuotedSectionTrailingComment", "[config]") {
+    // stripping a trailing comment from a section header must skip comment characters inside quotes,
+    // and a header that is too short after the strip is ignored
+    TempFile tmpini{"TestIniTmp.ini"};
+
+    app.set_config("--config", tmpini);
+
+    {
+        std::ofstream out{tmpini};
+        out << "val=1" << '\n';
+        out << "[ # not a section" << '\n';
+        out << "[\"subcom\"] # a 'quoted' comment" << '\n';
+        out << "val=2" << '\n';
+    }
+
+    int one{0}, two{0};
+    app.add_option("--val", one);
+    auto *subcom = app.add_subcommand("subcom");
+    subcom->add_option("--val", two);
+
+    run();
+
+    CHECK(one == 1);
+    CHECK(two == 2);
+}
+
 TEST_CASE_METHOD(TApp, "TomlDocStringCommentOneLine", "[config]") {
     // a multiline comment that opens and closes on the same line must not swallow the rest of the file
     TempFile tmpini{"TestIniTmp.ini"};

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -478,6 +478,11 @@ TEST_CASE_METHOD(TApp, "GetNameCheck", "[creation]") {
     CHECK("-o,--other" == d->get_name(false, true));
     CHECK("one,-o,--other" == d->get_name(true, true));
     CHECK("one" == d->get_name(true, false));
+
+    // an option with an empty group is hidden and has no name
+    auto *e = app.add_flag("--hidden")->group("");
+    CHECK(e->get_name().empty());
+    CHECK(e->get_name(true, true).empty());
 }
 
 TEST_CASE_METHOD(TApp, "SubcommandDefaults", "[creation]") {

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -503,6 +503,24 @@ TEST_CASE("StringTools: unicode_literals", "[helpers]") {
     CHECK(CLI::detail::remove_escaped_characters("test\\U0010FFFF") == from_u8string(u8"test\U0010FFFF"));
 }
 
+TEST_CASE("StringTools: handleSecondaryArray", "[helpers]") {
+    // a quoted string that decodes to an array-like value gets its characters doubled so it
+    // cannot be misinterpreted as a secondary array by later processing
+    std::string s1 = "[1,2]";
+    CLI::detail::handle_secondary_array(s1);
+    CHECK(s1 == "[[11,,22]]");
+
+    // non array-like strings pass through untouched
+    std::string s2 = "[1,2";
+    CLI::detail::handle_secondary_array(s2);
+    CHECK(s2 == "[1,2");
+
+    // the escaping also triggers through quote processing
+    std::string q1 = "\"[1,2]\"";
+    CHECK(CLI::detail::process_quoted_string(q1));
+    CHECK(q1 == "[[11,,22]]");
+}
+
 TEST_CASE("StringTools: close_sequence", "[helpers]") {
     CHECK(CLI::detail::close_sequence("[test]", 0, ']') == 5U);
     CHECK(CLI::detail::close_sequence("[\"test]\"]", 0, ']') == 8U);
@@ -1614,6 +1632,13 @@ TEST_CASE("Types: SumStringVector", "[helpers]") {
     // non-numeric values fall back to string concatenation
     std::vector<std::string> strings = {"a", "b"};
     CHECK(CLI::detail::sum_string_vector(strings) == "ab");
+
+    // sums that would overflow int64 fall back to the double path
+    std::vector<std::string> overflow = {"9223372036854775807", "1"};
+    CHECK(CLI::detail::sum_string_vector(overflow) == "9.223372036854776e+18");
+
+    std::vector<std::string> underflow = {"-9223372036854775807", "-2"};
+    CHECK(CLI::detail::sum_string_vector(underflow) == "-9.223372036854776e+18");
 }
 
 static_assert(!CLI::detail::is_tuple_like<std::vector<double>>::value, "vector should not be like a tuple");


### PR DESCRIPTION
Followup to #1385.

:robot: _AI text below_ :robot:

Codecov reports main at 99.76% with 12 missed lines in 5 spots. This fills them:

- `sum_string_vector`: int64 overflow/underflow fall-back to the double path (`TypeTools.hpp`)
- `handle_secondary_array`: array-escaping from #1110, direct and via `process_quoted_string` (`StringTools_inl.hpp`)
- Config parsing: quoted section name with a trailing comment, and a too-short header after comment strip (`Config_inl.hpp`)
- `Option::get_name` on a hidden (empty-group) option (`Option_inl.hpp`)

The last line, the `break` in the rvalue `App::_parse` overload (`App_inl.hpp:1601`), is unreachable: `_parse_single` can only return false when a parent app exists, and this overload only runs at the top level. It is now marked `LCOV_EXCL_LINE` as defensive code.