### PR TITLE
ci: make codecov wait for all coverage uploads

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,8 @@
+# Wait for all coverage jobs before computing status
+codecov:
+  notify:
+    after_n_builds: 8
+
 ignore:
   - "tests"
   - "examples"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,0 @@
-codecov:
-  notify:
-    after_n_builds: 8
-coverage:
-  status:
-    project:
-      informational: true


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `codecov/project` status can report a spurious drop (e.g. 99.96% on #1389, a docs-only PR) because codecov computes it as soon as the first coverage report arrives, while the base commit has 8 merged sessions.

`.github/codecov.yml` already set `after_n_builds: 8`, but it never applied: codecov reads only the first config it finds, and the root `.codecov.yml` shadows `.github/`. This merges the setting into the root file and removes the shadowed one. The shadowed file's `informational: true` for the project status is intentionally not carried over, since it never took effect and would keep the check from ever failing.

The merged config passes `codecov.io/validate`.