### PR TITLE
docs: fix errors found in a documentation review

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -26,6 +24,11 @@ jobs:
         run: |
           curl -fsSL https://github.com/doxygen/doxygen/releases/download/Release_1_17_0/doxygen-1.17.0.linux.bin.tar.gz | tar -xz -C "$RUNNER_TEMP"
           echo "$RUNNER_TEMP/doxygen-1.17.0/bin" >> "$GITHUB_PATH"
+
+      - name: Get version from Version.hpp
+        run: |
+          version=$(sed -n 's/#define CLI11_VERSION[ \t]*"\(.*\)"/\1/p' include/CLI/Version.hpp)
+          echo "CLI11_VERSION=$version" >> "$GITHUB_ENV"
 
       - name: Build API docs
         run: doxygen docs/Doxyfile
@@ -50,6 +53,9 @@ jobs:
   pages:
     runs-on: ubuntu-latest
     needs: [apidocs]
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Latest release][repology-badge]][repology]
 [![Conan.io][conan-badge]][conan-link]
 [![Conda Version][conda-badge]][conda-link]
-[![Try CLI11 2.4 online][wandbox-badge]][wandbox-link]
+[![Try CLI11 online][wandbox-badge]][wandbox-link]
 
 [What's new](./CHANGELOG.md) • [Documentation][gitbook] • [API
 Reference][api-docs]
@@ -166,8 +166,8 @@ this library:
   incomplete arguments. It's better not to guess. Most third party command line
   parsers for python actually reimplement command line parsing rather than using
   argparse because of this perceived design flaw (recent versions do have an
-  option to disable it). Recent releases of CLI11 do include partial option
-  matching for option prefixes 🆕. This is enabled by
+  option to disable it). Recent releases of CLI11 include optional unambiguous
+  prefix matching for subcommand names 🆕, enabled by
   `.allow_subcommand_prefix_matching()`, along with an example that generates
   suggested close matches.
 - Autocomplete: This might eventually be added to both Plumbum and CLI11, but it
@@ -216,7 +216,7 @@ int main(int argc, char** argv) {
 When adding options the names should not conflict with each other, if an option
 is added, or a modifier changed that would cause naming conflicts a run time
 error will be thrown in the add_option method. This includes default options for
-help `-h, --help`. For more information about `ensure_utf8` the section on
+help `-h, --help`. For more information about `ensure_utf8` see the section on
 [Unicode support](#unicode-support) below.
 
 <details><summary>Note: If you don't like macros, this is what that macro expands to: (click to expand)</summary><p>
@@ -311,7 +311,7 @@ The two parameter template overload can be used in cases where you want to
 restrict the input such as
 
 ```cpp
-double val
+double val;
 app.add_option<double,unsigned int>("-v",val);
 ```
 
@@ -336,9 +336,9 @@ template to directly specify the conversion type.
 
 Types such as (std or boost) `optional<int>`, `optional<double>`, and
 `optional<string>` and any other wrapper types are supported directly. For
-purposes of CLI11 wrapper types are those which `value_type` definition. See
-[CLI11 Advanced Topics/Custom Converters][] for information on how you can add
-your own converters for additional types.
+purposes of CLI11 wrapper types are those which have a `value_type` definition.
+See [CLI11 Advanced Topics/Custom Converters][] for information on how you can
+add your own converters for additional types.
 
 Vector types can also be used in the two parameter template overload
 
@@ -460,17 +460,17 @@ Before parsing, you can set the following options:
   flags (which do not inherit their default but always start with a specific
   policy). `->join(delim)` can also be used to join with a specific delimiter.
   This equivalent to calling `->delimiter(delim)` and `->join()`. Valid values
-  are `CLI::MultiOptionPolicy::Throw`, `CLI::MultiOptionPolicy::Throw`,
-  `CLI::MultiOptionPolicy::TakeLast`, `CLI::MultiOptionPolicy::TakeFirst`,
-  `CLI::MultiOptionPolicy::Join`, `CLI::MultiOptionPolicy::TakeAll`,
-  `CLI::MultiOptionPolicy::Sum`, and `CLI::MultiOptionPolicy::Reverse`.
+  are `CLI::MultiOptionPolicy::Throw`, `CLI::MultiOptionPolicy::TakeLast`,
+  `CLI::MultiOptionPolicy::TakeFirst`, `CLI::MultiOptionPolicy::Join`,
+  `CLI::MultiOptionPolicy::TakeAll`, `CLI::MultiOptionPolicy::Sum`, and
+  `CLI::MultiOptionPolicy::Reverse`.
 - `->check(std::string(const std::string &), validator_name="",validator_description="")`:
   Define a check function. The function should return a non empty string with
   the error message if the check fails
 - `->check(Validator)`: Use a Validator object to do the check see
   [Validators](#validators) for a description of available Validators and how to
   create new ones.
-- `->transform(std::string(std::string &), validator_name="",validator_description=")`:
+- `->transform(std::string(std::string &), validator_name="",validator_description="")`:
   Converts the input string into the output string, in-place in the parsed
   options.
 - `->transform(Validator)`: Uses a Validator object to do the transformation see
@@ -624,7 +624,6 @@ of flags.
   sure to use floating point if needed). Min defaults to 0.
 - `CLI::PositiveNumber`: Requires the number be greater than 0
 - `CLI::NonNegativeNumber`: Requires the number be greater or equal to 0
-- `CLI::Number`: Requires the input be a number.
 
 #### Validators that may be disabled 🆕
 
@@ -650,10 +649,11 @@ computation time that may not be valuable for some use cases.
   `11 Mib` to absolute values. `KB` can be configured to be interpreted as 10^3
   or 2^10.
 
-- `CLI::Bounded(min,max)`: Modify the input such that it is always between min
-  and max (make sure to use floating point if needed). Min defaults to 0. Will
+- `CLI::Bound(min,max)`: Modify the input such that it is always between min and
+  max (make sure to use floating point if needed). Min defaults to 0. Will
   produce an error if conversion is not possible.
 
+- `CLI::Number`: Requires the input be a number.
 - `CLI::ValidIPV4`: Requires that the option be a valid IPv4 string e.g.
   `'255.255.255.255'`, `'10.1.1.7'`.
 - `CLI::TypeValidator<TYPE>`:Requires that the option be convertible to the
@@ -703,9 +703,9 @@ There are a few built in Validators that let you transform values if used with
 the `transform` function. If they also do some checks then they can be used
 `check` but some may do nothing in that case.
 
-- `CLI::Bounded(min,max)` will bound values between min and max and values
-  outside of that range are limited to min or max, it will fail if the value
-  cannot be converted and produce a `ValidationError`
+- `CLI::Bound(min,max)` will bound values between min and max and values outside
+  of that range are limited to min or max, it will fail if the value cannot be
+  converted and produce a `ValidationError`
 - The `IsMember` Validator lets you specify a set of predefined options. You can
   pass any container or copyable pointer (including `std::shared_ptr`) to a
   container to this Validator; the container just needs to be iterable and have
@@ -731,7 +731,7 @@ functions that work on other types. Here are some examples of `IsMember`:
   can use maps; in `->transform()` these replace the matched value with the
   matched key. The value member of the map is not used in `IsMember`, so it can
   be any type.
-- `auto p = std::make_shared<std::vector<std::string>>(std::initializer_list<std::string>("one", "two")); CLI::IsMember(p)`:
+- `auto p = std::make_shared<std::vector<std::string>>(std::initializer_list<std::string>{"one", "two"}); CLI::IsMember(p)`:
   You can modify `p` later.
 - The `Transformer` and `CheckedTransformer` Validators transform one value into
   another. Any container or copyable pointer (including `std::shared_ptr`) to a
@@ -753,16 +753,16 @@ are interchangeable in the examples) of `Transformer`:
 
 - `CLI::Transformer({{"key1", "map1"},{"key2","map2"}})`: Select from key values
   and produce map values.
-- `CLI::Transformer(std::map<std::string,int>({"two",2},{"three",3},{"four",4}}))`:
+- `CLI::Transformer(std::map<std::string,int>({{"two",2},{"three",3},{"four",4}}))`:
   most maplike containers work, the `::value_type` needs to produce a pair of
   some kind.
 - `CLI::CheckedTransformer(std::map<std::string, int>({{"one", 1}, {"two", 2}}))`:
   You can use maps; in `->transform()` these replace the matched key with the
   value. `CheckedTransformer` also requires that the value either match one of
   the keys or match one of known outputs.
-- `auto p = std::make_shared<CLI::TransformPairs<std::string>>(std::initializer_list<std::pair<std::string,std::string>>({"key1", "map1"},{"key2","map2"})); CLI::Transformer(p)`:
+- `auto p = std::make_shared<CLI::TransformPairs<std::string>>(std::initializer_list<std::pair<std::string,std::string>>{{"key1", "map1"},{"key2","map2"}}); CLI::Transformer(p)`:
   You can modify `p` later. `TransformPairs<T>` is an alias for
-  `std::vector<std::pair<<std::string,T>>`
+  `std::vector<std::pair<std::string,T>>`
 
 NOTES: If the container used in `IsMember`, `Transformer`, or
 `CheckedTransformer` has a `find` function like `std::unordered_map` or
@@ -900,7 +900,7 @@ not used in performance critical code:
   specified type if possible, can be vector to return all results, and a
   non-vector to get the result according to the MultiOptionPolicy in place. If
   it is expected that the results will be needed as a vector, it is suggested
-  that `->expected(CLI::details::expected_max_vector_size)` or
+  that `->expected(CLI::detail::expected_max_vector_size)` or
   `allow_extra_args()` be used on the option to inform CLI11 that vector args
   are expected and allowed.
 
@@ -1003,7 +1003,7 @@ option_groups. These are:
   character as a single dash long form name; for example, `-s` and `-single` are
   not allowed in the same application.
 - `.allow_subcommand_prefix_matching()`:🆕 If this modifier is enabled,
-  unambiguious prefix portions of a subcommand will match. For example
+  unambiguous prefix portions of a subcommand will match. For example
   `upgrade_package` would match on `upgrade_`, `upg`, `u` as long as no other
   subcommand would also match. It also disallows subcommand names that are full
   prefixes of another subcommand.
@@ -1086,7 +1086,7 @@ option_groups. These are:
   fallthrough (and is not nameless 🚧).
 - `.parse_order()`: Get the list of option pointers in the order they were
   parsed (including duplicates).
-- `.formatter(std::shared_ptr<formatterBase> fmt)`: Set a custom formatter for
+- `.formatter(std::shared_ptr<FormatterBase> fmt)`: Set a custom formatter for
   help.
 - `.formatter_fn(fmt)`, with signature
   `std::string(const App*, std::string, AppFormatMode)`. See [formatting][] for
@@ -1162,9 +1162,9 @@ option_groups. These are:
   `PrefixCommandMode::SeparatorOnly` will only trigger prefix command mode with
   the subcommand separator `--`; other unrecognized arguments are considered an
   error unless `allow_extras` is enabled. Calling with
-  `PrefixCommandMode::PositionalOnly` will only trigger prefix command mode at
-  the first positional argument or the separator `--`; unrecognized options do
-  not stop processing and are collected in the remaining_arg list.
+  `PrefixCommandMode::PositionalOnly` 🚧 will only trigger prefix command mode
+  at the first positional argument or the separator `--`; unrecognized options
+  do not stop processing and are collected in the remaining_arg list.
 - `.usage(message)`: Replace text to appear at the start of the help string
   after description.
 - `.usage(std::string())`: Set a callback to generate a string that will appear
@@ -1445,7 +1445,7 @@ following overloads:
   active values, or include defaulted arguments if `default_also` is `true`.
   This overload will likely be deprecated in a future release in favor of the
   `CLI::ConfigOutputMode` overload.
-- `.config_to_str(CLI::ConfigOutputMode, bool write_description = false)`: 🆕
+- `.config_to_str(CLI::ConfigOutputMode, bool write_description = false)`: 🚧
   Specify how configuration output should be generated.
   - `CLI::ConfigOutputMode::Active`: print active values only. Same as
     `.config_to_str()`.
@@ -1530,7 +1530,7 @@ signature. see [formatting][] for more details.
 The App class was designed allow toolkits to subclass it, to provide preset
 default options (see above) and setup/teardown code. Subcommands remain an
 unsubclassed `App`, since those are not expected to need setup and teardown. The
-default `App` only adds a help flag, `-h,--help`, than can removed/replaced
+default `App` only adds a help flag, `-h,--help`, that can be removed/replaced
 using `.set_help_flag(name, help_string)`. You can also set a help-all flag with
 `.set_help_all_flag(name, help_string)`; this will expand the subcommands (one
 level only). You can remove options if you have pointers to them using
@@ -2017,7 +2017,7 @@ try! Feedback is always welcome.
 [github pull requests]: https://github.com/CLIUtils/CLI11/pulls
 [goofit]: https://GooFit.github.io
 [plumbum]: https://plumbum.readthedocs.io/en/latest/
-[click]: http://click.pocoo.org
+[click]: https://click.palletsprojects.com
 [api-docs]: https://CLIUtils.github.io/CLI11/index.html
 [rang]: https://github.com/agauniyal/rang
 [boost program options]:
@@ -2033,7 +2033,7 @@ try! Feedback is always welcome.
 [university of cincinnati]: http://www.uc.edu
 [gitbook]: https://cliutils.github.io/CLI11/book.html
 [cli11 advanced topics/custom converters]:
-  https://cliutils.gitlab.io/CLI11Tutorial/chapters/advanced-topics.html#custom-converters
+  https://cliutils.github.io/CLI11/book-advanced-topics.html
 [programoptions.hxx]: https://github.com/Fytch/ProgramOptions.hxx
 [argument aggregator]: https://github.com/vietjtnguyen/argagg
 [args]: https://github.com/Taywee/args
@@ -2045,7 +2045,7 @@ try! Feedback is always welcome.
 [version 1.3 post]: https://iscinumpy.gitlab.io/post/announcing-cli11-13/
 [version 1.6 post]: https://iscinumpy.gitlab.io/post/announcing-cli11-16/
 [version 2.0 post]: https://iscinumpy.gitlab.io/post/announcing-cli11-20/
-[wandbox-badge]: https://img.shields.io/badge/try_2.1-online-blue.svg
+[wandbox-badge]: https://img.shields.io/badge/try-online-blue.svg
 [wandbox-link]: https://wandbox.org/permlink/9eQyaD1DchlzukRv
 [releases-badge]: https://img.shields.io/github/release/CLIUtils/CLI11.svg
 [cli11-po-compare]:

--- a/book/README.md
+++ b/book/README.md
@@ -9,7 +9,7 @@ header file (`CLI11.hpp` available in [releases][]) to use CLI11 in your own
 application. Other ways to integrate it into a build system are listed in the
 [README][].
 
-The library was inspired the Python libraries [Plumbum][] and [Click][], and
+The library was inspired by the Python libraries [Plumbum][] and [Click][], and
 incorporates many of their user friendly features. The library is extensively
 documented, with a [friendly introduction][readme], this tutorial book, and more
 technical [API docs][].
@@ -22,13 +22,13 @@ analysis with multiple models and many parameters and switches. For example,
 this is a simple program that has an optional parameter that defaults to 0:
 
 ```text
-gitbook $ ./a.out
+$ ./a.out
 Parameter value: 0
 
-gitbook $ ./a.out -p 4
+$ ./a.out -p 4
 Parameter value: 4
 
-gitbook $ ./a.out --help
+$ ./a.out --help
 App description
 Usage: ./a.out [OPTIONS]
 
@@ -38,7 +38,7 @@ Options:
 ```
 
 Like any good command line application, help is provided. This program can be
-implemented in 10 lines:
+implemented in only a few lines:
 
 \include intro.cpp
 
@@ -49,7 +49,7 @@ help is requested or if incorrect arguments are passed. You can try this example
 out for yourself. To compile with GCC:
 
 ```text
-gitbook:examples $ c++ -std=c++11 intro.cpp
+c++ -std=c++11 intro.cpp
 ```
 
 Much more complicated options are handled elegantly:

--- a/book/chapters/advanced-topics.md
+++ b/book/chapters/advanced-topics.md
@@ -49,7 +49,8 @@ add_option(CLI::App &app, std::string name, cx &variable, std::string descriptio
     };
 
     CLI::Option *opt = app.add_option(name, fun, description, defaulted);
-    opt->set_custom_option("COMPLEX", 2);
+    opt->type_name("COMPLEX");
+    opt->type_size(2);
     if(defaulted) {
         std::stringstream out;
         out << variable;
@@ -71,38 +72,11 @@ add_option(app, "-c,--complex", comp);
 You can add your own converters to allow CLI11 to accept more option types in
 the standard calls. These can only be used for "single" size options (so
 complex, vector, etc. are a separate topic). If you set up a custom
-`istringstream& operator <<` overload before include CLI11, you can support
+`istringstream& operator>>` overload before include CLI11, you can support
 different conversions. If you place this in the CLI namespace, you can even keep
-this from affecting the rest of your code. Here's how you could add
-`boost::optional` for a compiler that does not have `__has_include`:
-
-```cpp
-// CLI11 already does this if __has_include is defined
-#ifndef __has_include
-
-#include <boost/optional.hpp>
-
-// Use CLI namespace to avoid the conversion leaking into your other code
-namespace CLI {
-
-template <typename T> std::istringstream &operator>>(std::istringstream &in, boost::optional<T> &val) {
-    T v;
-    in >> v;
-    val = v;
-    return in;
-}
-
-}
-
-#endif
-
-#include <CLI11.hpp>
-```
-
-This is an example of how to use the system only; if you are just looking for a
-way to activate `boost::optional` support on older compilers, you should define
-`CLI11_BOOST_OPTIONAL` before including a CLI11 file, you'll get the
-`boost::optional` support.
+this from affecting the rest of your code. Note that `std::optional` is
+supported natively and does not need a custom converter. The next section shows
+a complete example.
 
 ## Custom converters and type names: std::chrono example
 

--- a/book/chapters/an-advanced-example.md
+++ b/book/chapters/an-advanced-example.md
@@ -24,7 +24,7 @@ code runs, and then return:
 If you compile and run:
 
 ```text
-gitbook:examples $ c++ -std=c++11 geet.cpp -o geet
+c++ -std=c++11 geet.cpp -o geet
 ```
 
 You'll see it behaves pretty much like `git`.

--- a/book/chapters/basics.md
+++ b/book/chapters/basics.md
@@ -4,8 +4,9 @@ The simplest CLI11 program looks like this:
 
 \include simplest.cpp
 
-The first line includes the library; this explicitly uses the single file
-edition (see [Selecting an edition](@ref book-installation)).
+The first line includes the library; this uses the normal headers of the full
+edition (see [Selecting an edition](@ref book-installation)). With the single
+file edition you would include `CLI11.hpp` instead.
 
 After entering the main function, you'll see that a `CLI::App` object is
 created. This is the basis for all interactions with the library. You could
@@ -24,14 +25,15 @@ If you just use `app.parse` directly, your application will still work, but the
 stack will not be correctly unwound since you have an uncaught exception, and
 the command line output will be cluttered, especially for help.
 
-For this (and most of the examples in this book) we will assume that we have the
-`CLI11.hpp` file in the current directory and that we are creating an output
-executable `a.out` on a macOS or Linux system. The commands to compile and test
-this example would be:
+For this (and most of the examples in this book) we will assume that the CLI11
+`include` directory is on the compiler include path and that we are creating an
+output executable `a.out` on a macOS or Linux system. (With the single file
+edition, you could instead place `CLI11.hpp` next to your source code and skip
+the include path.) The commands to compile and test this example would be:
 
 ```text
-gitbook:examples $ g++ -std=c++11 simplest.cpp
-gitbook:examples $ ./a.out -h
+$ g++ -std=c++11 simplest.cpp -I/path/to/CLI11/include
+$ ./a.out -h
 Usage: ./a.out [OPTIONS]
 
 Options:

--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -3,9 +3,9 @@
 ## Reading a configure file
 
 You can tell your app to allow configure files with `set_config("--config")`.
-There are arguments: the first is the option name. If empty, it will clear the
-config flag. The second item is the default file name. If that is specified, the
-config will try to read that file. The third item is the help string, with a
+There are four arguments: the first is the option name. If empty, it will clear
+the config flag. The second item is the default file name. If that is specified,
+the config will try to read that file. The third item is the help string, with a
 reasonable default, and the final argument is a boolean (default: false) that
 indicates that the configuration file is required and an error will be thrown if
 the file is not found and this is set to true. The option pointer returned by
@@ -132,7 +132,7 @@ vector = [1,2,3]
 
 # Section map to subcommands
 [subcommand]
-in_subcommand = Wow
+in_subcommand = "Wow"
 [subcommand.sub]
 subcommand = true # could also be give as sub.subcommand=true
 ```
@@ -388,7 +388,7 @@ bool commentDefaultsBool = false;
 /// specify the config reader should collapse repeated field names to a single vector
 bool allowMultipleDuplicateFields{false};
 /// Specify the configuration index to use for arrayed sections
-uint16_t configIndex{-1};
+int16_t configIndex{-1};
 /// Specify the configuration section that should be used
 std::string configSection;
 ```
@@ -415,7 +415,7 @@ These can be modified via setter functions
   parent layers from options
 - `ConfigBase *section(const std::string &sectionName)` : specify the section
   name to use to get the option values, only this section will be processed
-- `ConfigBase *index(uint16_t sectionIndex)` : specify an index section to use
+- `ConfigBase *index(int16_t sectionIndex)` : specify an index section to use
   for processing if multiple TOML sections of the same name are present
   `[[section]]`
 

--- a/book/chapters/flags.md
+++ b/book/chapters/flags.md
@@ -15,14 +15,16 @@ app.add_flag("-f", my_flag, "Optional description");
 
 This will bind the flag `-f` to the boolean `my_flag`. After the parsing step,
 `my_flag` will be `false` if the flag was not found on the command line, or
-`true` if it was. By default, it will be allowed any number of times, but if you
-explicitly\[^1\] request `->take_last(false)`, it will only be allowed once;
-passing something like `./my_app -f -f` or `./my_app -ff` will throw a
-`ParseError` with a nice help description. A flag name may start with any
-character except ('-', ' ', '\n', and '!'). For long flags, after the first
-character all characters are allowed except ('=',':','{',' ', '\n'). Names are
-given as a comma separated string, with the dash or dashes. A flag can have as
-many names as you want, and afterward, using `count`, you can use any of the
+`true` if it was. The flag is allowed any number of times, and the last value
+given wins; bool flags always use `CLI::MultiOptionPolicy::TakeLast` (this is
+not inherited from the parent defaults, since allowing repeats is often useful
+even if you don't want other options to allow multiple values). If you want
+passing something like `./my_app -f -f` or `./my_app -ff` to be an error, use
+`->multi_option_policy(CLI::MultiOptionPolicy::Throw)`. A flag name may start
+with any character except ('-', ' ', '\n', and '!'). For long flags, after the
+first character all characters are allowed except ('=',':','{',' ', '\n'). Names
+are given as a comma separated string, with the dash or dashes. A flag can have
+as many names as you want, and afterward, using `count`, you can use any of the
 names, with dashes as needed.
 
 ## Integer flags
@@ -98,11 +100,11 @@ was found. You can also directly use the value (`*my_flag`) as a bool.
 
 If you want to define a callback that runs when you make a flag, you can use
 `add_flag_function` (C++11 or newer) or `add_flag` (C++14 or newer only) to add
-a callback function. The function should have the signature `void(std::size_t)`.
-This could be useful for a version printout, etc.
+a callback function. The function should have the signature
+`void(std::int64_t)`. This could be useful for a version printout, etc.
 
 ```cpp
-auto callback = [](int count){std::cout << "This was called " << count << " times";};
+auto callback = [](std::int64_t count){std::cout << "This was called " << count << " times";};
 app.add_flag_function("-c", callback, "Optional description");
 ```
 
@@ -127,7 +129,7 @@ app.add_flag("--flag", flag)
 would allow the following to count as passing the flag:
 
 ```text
-gitbook $ ./my_app --fLaG
+./my_app --fLaG
 ```
 
 ## Example
@@ -145,8 +147,8 @@ The values would be used like this:
 If you compile and run:
 
 ```text
-gitbook:examples $ g++ -std=c++11 flags.cpp
-gitbook:examples $ ./a.out -h
+$ g++ -std=c++11 flags.cpp
+$ ./a.out -h
 Flag example program
 Usage: ./a.out [OPTIONS]
 
@@ -156,12 +158,9 @@ Options:
   -i,--int                    This is an int flag
   -p,--plain                  This is a plain flag
 
-gitbook:examples $ ./a.out -bii --plain -i
+$ ./a.out -bii --plain -i
 The flags program
 Bool flag passed
 Flag int: 3
 Flag plain: 1
 ```
-
-\[^1\]: It will not inherit this from the parent defaults, since this is often
-useful even if you don't want all options to allow multiple passed options.

--- a/book/chapters/formatting.md
+++ b/book/chapters/formatting.md
@@ -15,8 +15,8 @@ There are several configuration options that you can set:
 | `label(key, value)`                        | Set a label to a different value                                     | Both         |
 | `long_option_alignment_ratio(float)`       | Set the alignment ratio for long options within the left column(1/3) | Both         |
 | `right_column_width(std::size_t)`          | Set the right column width(65)                                       | Both         |
-| `description_paragraph_width(std::size_t)` | Set the description paragraph width at the top of help(88)           | Both         |
-| `footer_paragraph_width(std::size_t)`      | Set the footer paragraph width (88)                                  | Both         |
+| `description_paragraph_width(std::size_t)` | Set the description paragraph width at the top of help(80)           | Both         |
+| `footer_paragraph_width(std::size_t)`      | Set the footer paragraph width (80)                                  | Both         |
 | `enable_description_formatting(bool)`      | enable/disable description paragraph formatting (true)               | Both         |
 | `enable_footer_formatting(bool)`           | enable/disable footer paragraph formatting (true)                    | Both         |
 | `enable_option_defaults(bool)`             | enable/disable printing of option defaults (true)                    | Both         |
@@ -49,7 +49,7 @@ column widths and ratios of the different sections of the help
 The long option alignment ratio controls the relative proportion of short to
 long option names. It must be a number between 0 and 1. values entered outside
 this range are converted into the range by absolute value or inversion. It
-defines where in the left column long optiosn are aligned. It is a ratio of the
+defines where in the left column long options are aligned. It is a ratio of the
 column width property.
 
 ### formatting options
@@ -99,8 +99,8 @@ app.formatter(std::make_shared<MyFormatter>());
 ```
 
 Look at the class definitions in `FormatterFwd.hpp` or the method definitions in
-`Formatter.hpp` to see what methods you have access to and how they are put
-together.
+`impl/Formatter_inl.hpp` to see what methods you have access to and how they are
+put together.
 
 ## Anatomy of a help message
 
@@ -109,16 +109,16 @@ line.
 
 ```text
 <make_description(app)>
-<make_usage(app)>
+<make_usage(app, name)>
 <make_positionals(app)>
-  <make_group(app, "Positionals", true, filter>
+  <make_group("POSITIONALS", true, opts)>
 <make_groups(app, mode)>
-  <make_group(app, "Option Group 1"), false, filter>
-  <make_group(app, "Option Group 2"), false, filter>
+  <make_group("Option Group 1", false, opts)>
+  <make_group("Option Group 2", false, opts)>
   ...
-<make_subcommands(app)>
-  <make_subcommand(sub1, Mode::Normal)>
-  <make_subcommand(sub2, Mode::Normal)>
+<make_subcommands(app, mode)>
+  <make_subcommand(sub1)>
+  <make_subcommand(sub2)>
 <make_footer(app)>
 ```
 
@@ -138,8 +138,6 @@ make_option_name(o,p)        make_option_desc(o)
 
 Notes:
 
-- `*1`: This signature depends on whether the call is from a positional or
-  optional.
 - `o` is opt pointer, `p` is true if positional.
 
 ## formatting callback

--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -25,9 +25,9 @@ include shown above.
 
 ### CMake support for the full edition
 
-If you use CMake 3.5+ for your project (highly recommended), CLI11 comes with a
+If you use CMake 3.14+ for your project (highly recommended), CLI11 comes with a
 powerful CMakeLists.txt file that was designed to also be used with
-`add_subproject`. You can add the repository to your code (preferably as a git
+`add_subdirectory`. You can add the repository to your code (preferably as a git
 submodule), then add the following line to your project (assuming your folder is
 called CLI11):
 
@@ -89,10 +89,10 @@ really need.)
 
 #### Modules
 
-When using modules, you must be using C++20 or later. CMake currently supports
-only Ninja as the build system for modules (for example, Makefiles won't work).
-When enabling `CLI11_MODULES`, you will have a target `CLI11::Modules` for
-linking.
+When using modules, you must be using C++20 or later. CMake supports modules
+with the Ninja generator, and with the Visual Studio generator in CMake 3.28+
+(Makefiles won't work). When enabling `CLI11_MODULES`, you will have a target
+`CLI11::Modules` for linking.
 
 ```cpp
 import cli11;
@@ -152,49 +152,22 @@ without internet access, or where TLS connections to GitHub releases are
 blocked, install Catch2 separately or configure with `CLI11_BUILD_TESTS=OFF`
 until the dependency is available.
 
-As an example of the build system, the following code will download and test
-CLI11 in a simple Alpine Linux docker container [^1]:
+As an example of the build system, the following commands will download and test
+CLI11 in a simple Alpine Linux docker container. (Docker is being used to create
+a pristine disposable environment; there is nothing special about this
+container. Alpine is being used because it is small, modern, and fast. Commands
+are similar on any other platform.)
 
-```text
-gitbook:~ $ docker run -it alpine
-root:/ # apk add --no-cache g++ cmake make git
-fetch ...
-root:/ # git clone https://github.com/CLIUtils/CLI11.git
-Cloning into 'CLI11' ...
-root:/ # cd CLI11
-root:CLI11 # mkdir build
-root:CLI11 # cd build
-root:build # cmake ..
--- The CXX compiler identification is GNU 6.3.0 ...
-root:build # make
-Scanning dependencies ...
-root:build # make test
-[warning]Running tests...
-Test project /CLI11/build
-      Start  1: HelpersTest
- 1/10 Test  #1: HelpersTest ......................   Passed    0.01 sec
-      Start  2: IniTest
- 2/10 Test  #2: IniTest ..........................   Passed    0.01 sec
-      Start  3: SimpleTest
- 3/10 Test  #3: SimpleTest .......................   Passed    0.01 sec
-      Start  4: AppTest
- 4/10 Test  #4: AppTest ..........................   Passed    0.02 sec
-      Start  5: CreationTest
- 5/10 Test  #5: CreationTest .....................   Passed    0.01 sec
-      Start  6: SubcommandTest
- 6/10 Test  #6: SubcommandTest ...................   Passed    0.01 sec
-      Start  7: HelpTest
- 7/10 Test  #7: HelpTest .........................   Passed    0.01 sec
-      Start  8: NewParseTest
- 8/10 Test  #8: NewParseTest .....................   Passed    0.01 sec
-      Start  9: TimerTest
- 9/10 Test  #9: TimerTest ........................   Passed    0.24 sec
-      Start 10: link_test_2
-10/10 Test #10: link_test_2 ......................   Passed    0.00 sec
-
-100% tests passed, 0 tests failed out of 10
-
-Total Test time (real) =   0.34 sec
+```bash
+docker run -it alpine
+apk add --no-cache g++ cmake make git
+git clone https://github.com/CLIUtils/CLI11.git
+cd CLI11
+mkdir build
+cd build
+cmake ..
+make
+make test
 ```
 
 For the curious, the CMake options and defaults are listed below. Most options
@@ -202,7 +175,7 @@ default to off if CLI11 is used as a subdirectory in another project.
 
 | Option                               | Description                                                      |
 | ------------------------------------ | ---------------------------------------------------------------- |
-| `CLI11_SINGLE_FILE=ON`               | Build the `CLI11.hpp` file from the sources. Requires Python.    |
+| `CLI11_SINGLE_FILE=OFF`              | Build the `CLI11.hpp` file from the sources. Requires Python.    |
 | `CLI11_PRECOMPILED=OFF`              | Generate a precompiled library instead of header-only            |
 | `CLI11_MODULES=OFF`                  | Build CLI11 as a module (requires C++20 or later)                |
 | `CLI11_INSTALL_PACKAGE_TESTS=OFF`    | Run tests checking the installation                              |
@@ -212,16 +185,11 @@ default to off if CLI11 is used as a subdirectory in another project.
 | `CLI11_BUILD_EXAMPLES=ON`            | Build the example programs.                                      |
 | `CLI11_BUILD_EXAMPLES_JSON=ON`       | Build some additional example using json libraries               |
 | `CLI11_INSTALL=ON`                   | Install CLI11 to the install folder during the install process   |
-| `CLI11_FULL_INSTALL=ON`              | Install all CLI11 headers/libraries regardless of other settings |
+| `CLI11_FULL_INSTALL=OFF`             | Install all CLI11 headers/libraries regardless of other settings |
 | `CLI11_FORCE_LIBCXX=OFF`             | Use libc++ instead of libstdc++ if building with clang on linux  |
 | `CLI11_DISABLE_IMPL_HEADERS_INSTALL` | Don't install the impl headers if the CLI11_PRECOMPILED is ON    |
 | `CLI11_CUDA_TESTS=OFF`               | Build the tests with NVCC                                        |
 | `CLI11_BUILD_TESTS=ON`               | Build the tests.                                                 |
-
-[^1]:
-    Docker is being used to create a pristine disposable environment; there is
-    nothing special about this container. Alpine is being used because it is
-    small, modern, and fast. Commands are similar on any other platform.
 
 ## Meson support
 

--- a/book/chapters/internals.md
+++ b/book/chapters/internals.md
@@ -15,9 +15,11 @@ Option* add_option(string name, T &item) {
 }
 ```
 
-Obviously, you can't access `T` after the `add_` method is over, so it stores
-the string representation of the default value if it receives the special `true`
-value as the final argument (not shown above).
+Obviously, you can't access `T` after the `add_` method is over. To store the
+string representation of the default value, call `capture_default_str()` on the
+option (or use `always_capture_default()` to do this for every option). Only the
+low-level `add_option` overload taking a raw `callback_t` still accepts a
+`defaulted` bool argument.
 
 ## Parsing
 
@@ -33,7 +35,7 @@ The parsing phase is the most interesting:
 1. `_parse_single`: Run on each entry on the command line and fill the
    options/subcommands.
 2. `_process`: Run the procedure listed below.
-3. `_process_extra`: This throws an error if needed on extra arguments that
+3. `_process_extras`: This throws an error if needed on extra arguments that
    didn't fit in the parse.
 
 The `_process` procedure runs the following steps; each step is recursive and

--- a/book/chapters/options.md
+++ b/book/chapters/options.md
@@ -57,7 +57,7 @@ option. Positional options are accepted in the same order they are defined. So,
 for example:
 
 ```text
-gitbook:examples $ ./a.out one --two three four
+./a.out one --two three four
 ```
 
 The string `one` would have to be the first positional option. If `--two` is a
@@ -106,7 +106,7 @@ command line.
 
 A definition of a container for purposes of CLI11 is a type with a `end()`,
 `insert(...)`, `clear()` and `value_type` definitions. This includes `vector`,
-`set`, `deque`, `list`, `forward_iist`, `map`, `unordered_map` and a few others
+`set`, `deque`, `list`, `forward_list`, `map`, `unordered_map` and a few others
 from the standard library, and many other containers from the boost library.
 
 ### Empty containers
@@ -162,7 +162,7 @@ the defaults. To insert of a separator from the command line add a `%%` where
 the separation should occur.
 
 ```bash
-cmd --vec_of_vec 1 2 3 4 %% 1 2
+cmd --vec 1 2 3 4 %% 1 2
 ```
 
 would then result in a container of size 2 with the first element containing 4
@@ -228,8 +228,8 @@ that to add option modifiers. A full listing of the option modifiers:
 | `->take_all()`                                          | sets `->multi_option_policy(CLI::MultiOptionPolicy::TakeAll)`                                                                                                                                                                                                                                                                                                                                                                                             |
 | `->join()`                                              | sets `->multi_option_policy(CLI::MultiOptionPolicy::Join)`, which uses newlines or the specified delimiter to join all arguments into a single string output.                                                                                                                                                                                                                                                                                             |
 | `->join(delim)`                                         | sets `->multi_option_policy(CLI::MultiOptionPolicy::Join)`, which uses `delim` to join all arguments into a single string output. this also sets the delimiter                                                                                                                                                                                                                                                                                            |
-| `->check(Validator)`                                    | perform a check on the returned results to verify they meet some criteria. See [Validators](./validators.md) for more info                                                                                                                                                                                                                                                                                                                                |
-| `->transform(Validator)`                                | Run a transforming validator on each value passed. See [Validators](./validators.md) for more info                                                                                                                                                                                                                                                                                                                                                        |
+| `->check(Validator)`                                    | perform a check on the returned results to verify they meet some criteria. See [Validators](@ref book-validators) for more info                                                                                                                                                                                                                                                                                                                           |
+| `->transform(Validator)`                                | Run a transforming validator on each value passed. See [Validators](@ref book-validators) for more info                                                                                                                                                                                                                                                                                                                                                   |
 | `->each(void(std::string))`                             | Run a function on each parsed value, _in order_.                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `->default_str(string)`                                 | set a default string for use in the help and as a default value if no arguments are passed and a value is requested                                                                                                                                                                                                                                                                                                                                       |
 | `->default_function(std::string())`                     | Advanced: Change the function that `capture_default_str()` uses.                                                                                                                                                                                                                                                                                                                                                                                          |
@@ -242,9 +242,10 @@ that to add option modifiers. A full listing of the option modifiers:
 | `->option_text(string)`                                 | Sets the text between the option name and description.                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 The `->check(...)` and `->transform(...)` modifiers can also take a callback
-function of the form `bool function(std::string)` that runs on every value that
-the option receives, and returns a value that tells CLI11 whether the check
-passed or failed.
+function that runs on every value that the option receives and returns an error
+message as a `std::string`; an empty string means the value passed. A `check`
+function receives the value by `const` reference, while a `transform` function
+may modify it.
 
 ### Multi Option policy
 
@@ -280,7 +281,7 @@ them.
 ```cpp
 CLI::Option* opt = app.add_flag("--opt");
 
-CLI11_PARSE(app, argv, argc);
+CLI11_PARSE(app, argc, argv);
 
 if(* opt)
     std::cout << "Flag received " << opt->count() << " times." << '\n';
@@ -321,8 +322,8 @@ An example of usage:
 ```cpp
 app.option_defaults()->ignore_case()->group("Required");
 
-app.add_flag("--CaSeLeSs");
-app.get_group() // is "Required"
+CLI::Option* opt = app.add_flag("--CaSeLeSs");
+opt->get_group() // is "Required"
 ```
 
 Groups are mostly for visual organization, but an empty string for a group name

--- a/book/chapters/subcommands.md
+++ b/book/chapters/subcommands.md
@@ -17,7 +17,7 @@ can do with an `App`, however.
 You are given a lot of control the help output. You can set a footer with
 `app.footer("My Footer")`. You can replace the default help print when a
 `ParseError` is thrown with `app.failure_message(CLI::FailureMessage::help)`.
-The default is `CLI:::FailureMessage::simple`, and you can easily define a new
+The default is `CLI::FailureMessage::simple`, and you can easily define a new
 one. Just make a (lambda) function that takes an App pointer and a reference to
 an error code (even if you don't use them), and returns a string.
 
@@ -95,10 +95,15 @@ at the point the subcommand is created:
 
 - The name and description for the help flag
 - The footer
+- The usage
 - The failure message printer function
+- The formatter
+- The config formatter
 - Option defaults
 - Allow extras
+- Allow config extras
 - Prefix command
+- Immediate callback
 - Ignore case
 - Ignore underscore
 - Allow Windows style options
@@ -106,6 +111,7 @@ at the point the subcommand is created:
 - Group name
 - Max required subcommands
 - prefix_matching
+- Configurable
 - validate positional arguments
 - validate optional arguments
 
@@ -129,7 +135,7 @@ through" to the parent command; if that parent allows that option, it matches
 there instead. This was added to allow CLI11 to represent models:
 
 ```text
-gitbook:code $ ./my_program my_model_1 --model_flag --shared_flag
+./my_program my_model_1 --model_flag --shared_flag
 ```
 
 Here, `--shared_flag` was set on the main app, and on the command line it "falls
@@ -163,7 +169,7 @@ calls another command called "`git-thing`" with the remaining options intact.
 ### prefix matching
 
 A modifier is available for subcommand matching,
-`->allow_subcommand_prefix_matching()`. if this is enabled unambiguious prefix
+`->allow_subcommand_prefix_matching()`. if this is enabled unambiguous prefix
 portions of a subcommand will match. For Example `upgrade_package` would match
 on `upgrade_`, `upg`, `u` as long as no other subcommand would also match. It
 also disallows subcommand names that are full prefixes of another subcommand.
@@ -189,12 +195,12 @@ This would allow calling help such as:
 ### Positional Validation
 
 Some arguments supplied on the command line may be legitimately applied to more
-than 1 positional argument. In this context enabling `positional_validation` on
+than 1 positional argument. In this context calling `validate_positionals()` on
 the application or subcommand will check any validators before applying the
 command line argument to the positional option. It is not an error to fail
 validation in this context, positional arguments not matching any validators
-will go into the `extra_args` field which may generate an error depending on
-settings.
+will be treated as extra arguments (retrievable via `app.remaining()`) which may
+generate an error depending on settings.
 
 ### Optional Argument Validation
 

--- a/book/chapters/toolkits.md
+++ b/book/chapters/toolkits.md
@@ -15,9 +15,9 @@ You may also want to make your own copy of the `CLI11_PARSE` macro. Something
 like:
 
 ```cpp
- #define MYPACKAGE_PARSE(app, argv, argc)    \
+ #define MYPACKAGE_PARSE(app, argc, argv)    \
      try {                                   \
-         app.parse(argv, argc);              \
+         app.parse(argc, argv);              \
      } catch(const CLI::ParseError &e) {     \
          return app.exit(e);                 \
      }
@@ -27,7 +27,7 @@ like:
 
 If you subclass `App`, you'll just need to do a few things. You'll need a
 constructor; calling the base `App` constructor is a good idea, but not
-necessary (it just sets a description and adds a help flag.
+necessary (it just sets a description and adds a help flag).
 
 You can call anything you would like to configure in the constructor, like
 `option_defaults()->take_last()` or `fallthrough()`, and it will be set on all

--- a/book/chapters/validators.md
+++ b/book/chapters/validators.md
@@ -8,9 +8,10 @@ There are two forms of validators:
 
 A transform validator comes in one form, a function with the signature
 `std::string(std::string&)`. The function will take a string and return an error
-message, or an empty string if input is valid. If there is an error, the
-function should throw a `CLI::ValidationError` with the appropriate reason as a
-message.
+message, or an empty string if input is valid. Alternatively, the function may
+throw a `CLI::ValidationError` with the appropriate reason as a message; either
+returning a non-empty string or throwing signals a failure, so throwing is not
+required.
 
 An example of a mutating validator:
 
@@ -45,7 +46,7 @@ constructor also.
 An example of a custom validator:
 
 ```cpp
-struct LowerCaseValidator : public Validator {
+struct LowerCaseValidator : public CLI::Validator {
     LowerCaseValidator() {
         name_ = "LOWER";
         func_ = [](const std::string &str) {
@@ -72,7 +73,7 @@ The built-in validators for CLI11 are:
 | `NonexistentPath`   | Check for an non-existing path                                         |
 | `Range(min=0, max)` | Produce a range (factory). Min and max are inclusive.                  |
 | `NonNegativeNumber` | Range(0,max<double>)                                                   |
-| `PositiveNumber`    | Range(epsilon,max<double>)                                             |
+| `PositiveNumber`    | Range(denorm_min<double>,max<double>), i.e. any positive number        |
 
 A few built-in transformers are also available
 
@@ -86,7 +87,7 @@ And, the protected members that you can set when you make your own are:
 | Type                                        | Member               | Description                                                            |
 | ------------------------------------------- | -------------------- | ---------------------------------------------------------------------- |
 | `std::function<std::string(std::string &)>` | `func_`              | Core validation function - modifies input and returns "" if successful |
-| `std::function<std::string()>`              | `desc_function`      | Optional description function (uses `description_` instead if not set) |
+| `std::function<std::string()>`              | `desc_function_`     | Optional description function (returns an empty string if not set)     |
 | `std::string`                               | `name_`              | The name for search purposes                                           |
 | `int` (`-1`)                                | `application_index_` | The element this validator applies to (-1 for all)                     |
 | `bool` (`true`)                             | `active_`            | This can be disabled                                                   |
@@ -110,15 +111,16 @@ compilation time is a concern they can be disabled.
 | `AsNumberWithUnit`   | checks for numbers with a unit as part of a specified set of units |
 | `AsSizeValue`        | As Number with Unit with support for SI prefixes                   |
 
-| Transformer            | Description                                         |
-| ---------------------- | --------------------------------------------------- |
-| `Bound<T>(min=0, max)` | Force a range (factory). Min and max are inclusive. |
-| `Transformer`          | Modify values in a set to the matching pair value   |
+| Transformer                       | Description                                                            |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| `Bound(min, max)` or `Bound(max)` | Force a range (factory). Min and max are inclusive; min defaults to 0. |
+| `Transformer`                     | Modify values in a set to the matching pair value                      |
 
 ## New Extra Validators
 
 Some additional validators can be enabled by using CLI11_ENABLE_EXTRA_VALIDATORS
-to 1. These validators are disabled by default.
+to 1. These validators are disabled by default. They also require `<filesystem>`
+support (C++17, `CLI11_HAS_FILESYSTEM`).
 
 | Validator           | Description                                                 |
 | ------------------- | ----------------------------------------------------------- |

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,11 +1,11 @@
-set(DOXYGEN_EXTRACT_ALL YES)
-set(DOXYGEN_BUILTIN_STL_SUPPORT YES)
-set(PROJECT_BRIEF "C++11 Command Line Interface Parser")
-
-file(
-  GLOB DOC_LIST
-  RELATIVE "${PROJECT_SOURCE_DIR}/include"
-  "${PROJECT_SOURCE_DIR}/include/CLI/*.hpp")
-
-doxygen_add_docs(docs ${DOC_LIST} "${CMAKE_CURRENT_SOURCE_DIR}/mainpage.md"
-                 WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/include")
+# Run the real Doxyfile (same config as the published docs: impl/ headers,
+# book chapters, doxygen-awesome styling). All paths in the Doxyfile are
+# relative to the repo root, and OUTPUT_DIRECTORY is empty, so the output
+# lands in html/ at the repo root (gitignored).
+add_custom_target(
+  docs
+  COMMAND ${CMAKE_COMMAND} -E env CLI11_VERSION=${CLI11_VERSION} $<TARGET_FILE:Doxygen::doxygen>
+          "${PROJECT_SOURCE_DIR}/docs/Doxyfile"
+  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+  COMMENT "Generating API documentation with Doxygen (output: ${PROJECT_SOURCE_DIR}/html)"
+  VERBATIM)

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CLI11
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = $(TRAVIS_TAG)
+PROJECT_NUMBER         = $(CLI11_VERSION)
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewers a
@@ -382,7 +382,7 @@ MARKDOWN_STRICT        = YES
 # Minimum value: 0, maximum value: 99, default value: 6.
 # This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
 
-TOC_INCLUDE_HEADINGS   = 0
+TOC_INCLUDE_HEADINGS   = 3
 
 # The MARKDOWN_ID_STYLE tag can be used to specify the algorithm used to
 # generate identifiers for the Markdown headings. Note: Every identifier is
@@ -393,7 +393,7 @@ TOC_INCLUDE_HEADINGS   = 0
 # The default value is: DOXYGEN.
 # This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
 
-MARKDOWN_ID_STYLE      = DOXYGEN
+MARKDOWN_ID_STYLE      = GITHUB
 
 # When enabled Doxygen tries to link words that correspond to documented
 # classes, or namespaces to their corresponding documentation. Such a link can

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -226,11 +226,12 @@ template <typename Callable> inline std::string find_and_modify(std::string str,
 }
 
 /// close a sequence of characters indicated by a closure character.  Brackets allows sub sequences
-/// recognized bracket sequences include "'`[(<{  other closure characters are assumed to be literal strings
+/// recognized bracket sequences include double quote, single quote, backquote, [, (, <, and {; other closure
+/// characters are assumed to be literal strings
 CLI11_INLINE std::size_t close_sequence(const std::string &str, std::size_t start, char closure_char);
 
 /// Split a string '"one two" "three"' into 'one two', 'three'
-/// Quote characters can be ` ' or " or bracket characters [{(< with matching to the matching bracket
+/// Quote characters can be backquote, ' or " or bracket characters [{(< with matching to the matching bracket
 CLI11_INLINE std::vector<std::string> split_up(std::string str, char delimiter = '\0');
 
 /// get the value of an environmental variable or empty string if empty

--- a/include/CLI/impl/Validators_inl.hpp
+++ b/include/CLI/impl/Validators_inl.hpp
@@ -309,7 +309,6 @@ CLI11_INLINE std::pair<std::string, std::string> split_program_name(std::string 
 }
 
 }  // namespace detail
-/// @}
 
 // [CLI11:validators_inl_hpp:end]
 }  // namespace CLI


### PR DESCRIPTION
:robot: _AI text below_ :robot:

A review of the README, the tutorial book, and the Doxygen setup against the current headers found a number of errors. This PR fixes them.

## Documentation content

- Fix API references that do not compile or do not exist: `CLI::Bound` (was `Bounded`), `CLI11_PARSE(app, argc, argv)` argument order (book and toolkits macro example), `type_name`/`type_size` (was the removed `set_custom_option`), `validate_positionals()`, and the bool-flag repeat behavior (the `->take_last(false)` passage described an API that never existed).
- Remove the stale `boost::optional` section; support was dropped long ago.
- Correct namespaces, option-table defaults, callback signatures, formatter widths and signatures, `int16_t configIndex`, and the subcommand inheritance list.
- Mark main-only features with 🚧 and fix the last link to the retired GitBook/mdbook tutorial site.
- Remove GitBook-era footnote syntax and shell prompts that Doxygen renders literally, plus assorted typos and broken code snippets.

## Docs build

- The CMake `docs` target now runs the real `docs/Doxyfile`, so local builds match the published site (the old `doxygen_add_docs` config missed `impl/`, the book, and the styling).
- `PROJECT_NUMBER` uses `CLI11_VERSION` (was the dead `TRAVIS_TAG`), set from `Version.hpp` in the workflow, so the site shows a version again.
- `TOC_INCLUDE_HEADINGS = 3` with GitHub-style IDs makes book subheadings deep-linkable.
- Fix two doc comments (stray `/// @}`, unbalanced backticks) that produced Doxygen warnings.
- Scope `pages: write` and `id-token: write` to the deploy job only.

Beyond CI, this was verified with a local Doxygen 1.17.0 build (the two real warnings are gone; anchors and version confirmed in the HTML) and the new CMake `docs` target was run end to end.