### PR TITLE
chore: prepare 2.7.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,3 +124,15 @@ prek -a
 
 The version string is read from `include/CLI/Version.hpp` at configure time. Do
 not edit project version in `CMakeLists.txt`.
+
+## Release Checklist
+
+When preparing a release (`chore: prepare X.Y.Z release`):
+
+- Add the changelog entry and bump `include/CLI/Version.hpp`.
+- Update the feature markers in `README.md`: remove the old 🆕 markers (the
+  previous release's features) and change 🚧 markers (main-only features) to 🆕.
+  Removing an emoji from a heading also changes its TOC anchor — drop the
+  trailing `-` from the matching TOC links.
+- Check the copyright year in `LICENSE` and the version in
+  `book/chapters/installation.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@ that remove unnecessary copies in hot paths.
 - Added C++26 CI coverage (GCC, and clang with modules), and made codecov wait
   for all coverage uploads. [#1388][], [#1391][]
 - Tidied the configuration files in the root directory. [#1393][]
+- Attached the source packages to tagged releases, wrote the release notes from
+  the changelog, and added a CI check for a changelog entry on every build.
+  [#1401][], [#1402][], [#1403][]
 
 [#1305]: https://github.com/CLIUtils/CLI11/pull/1305
 [#1382]: https://github.com/CLIUtils/CLI11/pull/1382
@@ -159,6 +162,9 @@ that remove unnecessary copies in hot paths.
 [#1397]: https://github.com/CLIUtils/CLI11/pull/1397
 [#1398]: https://github.com/CLIUtils/CLI11/pull/1398
 [#1400]: https://github.com/CLIUtils/CLI11/pull/1400
+[#1401]: https://github.com/CLIUtils/CLI11/pull/1401
+[#1402]: https://github.com/CLIUtils/CLI11/pull/1402
+[#1403]: https://github.com/CLIUtils/CLI11/pull/1403
 
 ## Version 2.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ that remove unnecessary copies in hot paths.
   output with doxygen-awesome-css, and reorganized the sidebar navigation.
   [#1390][], [#1392][], [#1397][], [#1398][]
 - Corrected errors found in a documentation review. [#1394][]
+- Split the documentation into Guide and Examples sections and filled gaps in
+  the guide. [#1400][]
 
 ### Internal
 
@@ -156,6 +158,7 @@ that remove unnecessary copies in hot paths.
 [#1396]: https://github.com/CLIUtils/CLI11/pull/1396
 [#1397]: https://github.com/CLIUtils/CLI11/pull/1397
 [#1398]: https://github.com/CLIUtils/CLI11/pull/1398
+[#1400]: https://github.com/CLIUtils/CLI11/pull/1400
 
 ## Version 2.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,161 @@
 # Changelog
 
-## Unreleased
+## Version 2.7.0
+
+This version adds a `FileSize` validator, a `PositionalOnly` prefix command
+mode, and more control over config file generation. It also contains a large set
+of bug fixes from a systematic audit of the parsing, config, help formatting,
+string handling, and type conversion code, along with performance improvements
+that remove unnecessary copies in hot paths.
+
+### Added
+
+- Added a `FileSize` validator to check minimum and maximum file sizes.
+  [#1305][]
+- Added `PrefixCommandMode::PositionalOnly`, which restores the pre-2.6.2 prefix
+  command behavior as an opt-in mode: only a positional argument or the `--`
+  separator triggers prefix mode, and unrecognized options are collected as
+  extras. [#1382][]
+- Added an option to write only the active subcommand defaults when generating a
+  config file. [#1314][]
+
+### Changed
+
+- Improved performance by removing unnecessary string and container copies in
+  parsing and validator hot paths. [#1368][]
+- Improved the performance of string splitting by replacing a `stringstream`
+  with a find-based loop. [#1396][]
+- Sorted the `excludes` and `needs` sets by name for stable help output.
+  [#1308][]
+- Removed `en_US.UTF-8` from the unicode locale fallback list. [#1312][]
+- Modernization and portability fixes: added missing standard includes, exported
+  `CLI::Number` from the C++20 module, and cleaned up the warning lists.
+  [#1367][]
+- Aligned the Meson build with wrapdb policy by removing `disable_auto_if` for
+  subprojects. [#1349][]
+
+### Fixed
+
+- Fixed `require_subcommand` maximum enforcement for dot notation and for
+  disabled fallthrough, dot-notation subcommands with Windows-style prefixes,
+  `get_options` const/non-const consistency, and a crash when parsing with
+  `argc == 0`. [#1363][], [#1384][]
+- Fixed missing symbol export from the precompiled shared library on macOS.
+  [#1387][]
+- Fixed double indentation of nested option groups in help output. [#1371][],
+  [#1379][]
+- Fixed config reading and writing bugs: section headers with trailing comments,
+  one-line multiline comments, embedded delimiters with the `Join` policy, and
+  multiline values for indented keys. [#1369][], [#1361][]
+- Fixed help formatting issues: hidden positionals appearing in the usage line,
+  long subcommand names running into their descriptions, and `ExtrasError`
+  reporting the wrong error name. [#1369][]
+- Fixed `ignore_case` and `ignore_underscore` so both apply when used together.
+  [#1358][]
+- Fixed string handling edge cases in `split_up`, `remove_quotes`,
+  `append_codepoint`, and `escape_detect`. [#1364][]
+- Fixed type conversion edge cases: negative input to unsigned types,
+  whitespace-only floating point input, containers of pairs with an odd element
+  count, large integer sums, and the `Join` policy with default values.
+  [#1362][]
+- Fixed stale processed values being returned after `Option::clear()`. [#1360][]
+- Fixed out-of-bounds reads in the non-codecvt narrow/widen conversion paths
+  used under C++26. [#1359][]
+- Fixed infinite recursion on subcommand option groups with fallthrough enabled.
+  [#1316][]
+- Fixed empty strings given to wrapper types such as `std::optional` to
+  consistently produce a default-constructed value. [#1340][]
+- Fixed `CLI::ExistingFile` to reject an empty filename with a clear error.
+  [#1351][]
+- Fixed an empty description on a modified `Transformer`. [#1345][]
+- Fixed unsigned wraparound in `split_program_name` for command lines without
+  spaces. [#1339][]
+- Fixed `FileOnDefaultPath` with an empty default path, and `PositiveNumber`
+  rejecting subnormal values. [#1366][]
+- Fixed compilation with libc++/clang in C++26 mode. [#1326][]
+- Fixed the case of the `shell32` library name in CMake. [#1347][]
+- Removed the `static` keyword from the precompiled library definition in CMake.
+  [#1304][]
+
+### Documentation
+
+- Clarified the behavior of the `prefix_command` overloads. [#1310][]
+- Documented the Catch2 dependency for the test build. [#1342][]
+- Corrected documentation errors, including the `AsSizeValue` example, the
+  `App::required()` doc, and validator comments. [#1304][], [#1366][]
+- Modernized some documentation. [#1336][]
+- Moved the tutorial book into the Doxygen documentation, modernized the HTML
+  output with doxygen-awesome-css, and reorganized the sidebar navigation.
+  [#1390][], [#1392][], [#1397][], [#1398][]
+- Corrected errors found in a documentation review. [#1394][]
+
+### Internal
+
+- Added a `dev` CMake preset and workflow for faster local iteration using the
+  precompiled library and ccache. [#1387][]
+- Added a CUDA test for the single-header build. [#1381][]
+- Refactored the duplicated parse-completion pipeline and removed dead code.
+  [#1365][]
+- Moved static `std::string` reference initializers to helper functions.
+  [#1335][]
+- Routed formatter label fallback through an internal helper as a step toward
+  internationalization support. [#1320][]
+- Cleaned up the CMake logic for finding Catch2 and Boost, and corrected the
+  example test regular expressions. [#1325][], [#1322][]
+- Reorganized the GitHub workflows and reduced CI build times. [#1323][],
+  [#1387][]
+- Added C++26 CI coverage (GCC, and clang with modules), and made codecov wait
+  for all coverage uploads. [#1388][], [#1391][]
+- Tidied the configuration files in the root directory. [#1393][]
+
+[#1305]: https://github.com/CLIUtils/CLI11/pull/1305
+[#1382]: https://github.com/CLIUtils/CLI11/pull/1382
+[#1314]: https://github.com/CLIUtils/CLI11/pull/1314
+[#1387]: https://github.com/CLIUtils/CLI11/pull/1387
+[#1381]: https://github.com/CLIUtils/CLI11/pull/1381
+[#1368]: https://github.com/CLIUtils/CLI11/pull/1368
+[#1308]: https://github.com/CLIUtils/CLI11/pull/1308
+[#1312]: https://github.com/CLIUtils/CLI11/pull/1312
+[#1365]: https://github.com/CLIUtils/CLI11/pull/1365
+[#1335]: https://github.com/CLIUtils/CLI11/pull/1335
+[#1367]: https://github.com/CLIUtils/CLI11/pull/1367
+[#1320]: https://github.com/CLIUtils/CLI11/pull/1320
+[#1325]: https://github.com/CLIUtils/CLI11/pull/1325
+[#1322]: https://github.com/CLIUtils/CLI11/pull/1322
+[#1349]: https://github.com/CLIUtils/CLI11/pull/1349
+[#1323]: https://github.com/CLIUtils/CLI11/pull/1323
+[#1310]: https://github.com/CLIUtils/CLI11/pull/1310
+[#1342]: https://github.com/CLIUtils/CLI11/pull/1342
+[#1336]: https://github.com/CLIUtils/CLI11/pull/1336
+[#1304]: https://github.com/CLIUtils/CLI11/pull/1304
+[#1363]: https://github.com/CLIUtils/CLI11/pull/1363
+[#1384]: https://github.com/CLIUtils/CLI11/pull/1384
+[#1371]: https://github.com/CLIUtils/CLI11/pull/1371
+[#1379]: https://github.com/CLIUtils/CLI11/pull/1379
+[#1369]: https://github.com/CLIUtils/CLI11/pull/1369
+[#1361]: https://github.com/CLIUtils/CLI11/pull/1361
+[#1358]: https://github.com/CLIUtils/CLI11/pull/1358
+[#1364]: https://github.com/CLIUtils/CLI11/pull/1364
+[#1362]: https://github.com/CLIUtils/CLI11/pull/1362
+[#1360]: https://github.com/CLIUtils/CLI11/pull/1360
+[#1359]: https://github.com/CLIUtils/CLI11/pull/1359
+[#1316]: https://github.com/CLIUtils/CLI11/pull/1316
+[#1340]: https://github.com/CLIUtils/CLI11/pull/1340
+[#1351]: https://github.com/CLIUtils/CLI11/pull/1351
+[#1345]: https://github.com/CLIUtils/CLI11/pull/1345
+[#1339]: https://github.com/CLIUtils/CLI11/pull/1339
+[#1366]: https://github.com/CLIUtils/CLI11/pull/1366
+[#1326]: https://github.com/CLIUtils/CLI11/pull/1326
+[#1347]: https://github.com/CLIUtils/CLI11/pull/1347
+[#1388]: https://github.com/CLIUtils/CLI11/pull/1388
+[#1390]: https://github.com/CLIUtils/CLI11/pull/1390
+[#1391]: https://github.com/CLIUtils/CLI11/pull/1391
+[#1392]: https://github.com/CLIUtils/CLI11/pull/1392
+[#1393]: https://github.com/CLIUtils/CLI11/pull/1393
+[#1394]: https://github.com/CLIUtils/CLI11/pull/1394
+[#1396]: https://github.com/CLIUtils/CLI11/pull/1396
+[#1397]: https://github.com/CLIUtils/CLI11/pull/1397
+[#1398]: https://github.com/CLIUtils/CLI11/pull/1398
 
 ## Version 2.6.2
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-CLI11 2.6.2 Copyright (c) 2017-2026 University of Cincinnati, developed by Henry
+CLI11 2.7.0 Copyright (c) 2017-2026 University of Cincinnati, developed by Henry
 Schreiner under NSF AWARD 1414736. All rights reserved.
 
 Redistribution and use in source and binary forms of CLI11, with or without

--- a/README.md
+++ b/README.md
@@ -666,12 +666,17 @@ computation time that may not be valuable for some use cases.
 New validators will go into code sections that must be explicitly enabled by
 setting `CLI11_ENABLE_EXTRA_VALIDATORS` to 1
 
-- `CLI::ReadPermission`: Requires that the file or folder given exist and have
+- `CLI::ReadPermissions`: Requires that the file or folder given exist and have
   read permission. Requires C++17.
-- `CLI::WritePermission`: Requires that the file or folder given exist and have
+- `CLI::WritePermissions`: Requires that the file or folder given exist and have
   write permission. Requires C++17.
-- `CLI::ExecPermission`: Requires that the file given exist and have execution
+- `CLI::ExecPermissions`: Requires that the file given exist and have execution
   permission. Requires C++17.
+- `CLI::FileSizeValidator(min_size, max_size = 0)`: 🆕 Requires that the file
+  exist and that its size in bytes be at least `min_size`. If `max_size` is
+  greater than 0, the size must also not exceed it. Requires C++17.
+- `CLI::NonEmptyFile`: 🆕 Requires that the file exist and not be empty. Same as
+  `CLI::FileSizeValidator(1)`. Requires C++17.
 
 #### Validator Usage
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ set with a simple and intuitive interface.
       - [Option options](#option-options)
       - [Validators](#validators)
       - [Default Validators](#default-validators)
-      - [Validators that may be disabled 🆕](#validators-that-may-be-disabled-)
-      - [Extra Validators 🆕](#extra-validators-)
+      - [Validators that may be disabled](#validators-that-may-be-disabled)
+      - [Extra Validators](#extra-validators)
       - [Validator Usage](#validator-usage)
         - [Transforming Validators](#transforming-validators)
         - [Validator operations](#validator-operations)
@@ -167,7 +167,7 @@ this library:
   parsers for python actually reimplement command line parsing rather than using
   argparse because of this perceived design flaw (recent versions do have an
   option to disable it). Recent releases of CLI11 include optional unambiguous
-  prefix matching for subcommand names 🆕, enabled by
+  prefix matching for subcommand names, enabled by
   `.allow_subcommand_prefix_matching()`, along with an example that generates
   suggested close matches.
 - Autocomplete: This might eventually be added to both Plumbum and CLI11, but it
@@ -506,8 +506,8 @@ Before parsing, you can set the following options:
   validation checks for the option to be executed when the option value is
   parsed vs. at the end of all parsing. This could cause the callback to be
   executed multiple times. Also works with positional options.
-- `->callback_priority(CallbackPriority priority)`: 🆕 changes the order in
-  which the option callback is executed. Four principal callback call-points are
+- `->callback_priority(CallbackPriority priority)`: changes the order in which
+  the option callback is executed. Four principal callback call-points are
   available. `CallbackPriority::First` executes at the very beginning of
   processing, before configuration files are read and environment variables are
   interpreted. `CallbackPriority::PreRequirementsCheck` executes after
@@ -600,8 +600,8 @@ the two function are that checks do not modify the input whereas transforms can
 and are executed before any Validators added through `check`.
 
 CLI11 has several Validators included that perform some common checks. By
-default the most commonly used ones are available. 🆕 If some are not needed
-they can be disabled by using
+default the most commonly used ones are available. If some are not needed they
+can be disabled by using
 
 ```c++
 #define CLI11_DISABLE_EXTRA_VALIDATORS 1
@@ -625,7 +625,7 @@ of flags.
 - `CLI::PositiveNumber`: Requires the number be greater than 0
 - `CLI::NonNegativeNumber`: Requires the number be greater or equal to 0
 
-#### Validators that may be disabled 🆕
+#### Validators that may be disabled
 
 Validators that may be disabled by setting `CLI11_DISABLE_EXTRA_VALIDATORS` to 1
 or enabled by setting `CLI11_ENABLE_EXTRA_VALIDATORS` to 1. By default they are
@@ -661,7 +661,7 @@ computation time that may not be valuable for some use cases.
   the input be convertible to an `unsigned int` regardless of the end
   conversion.
 
-#### Extra Validators 🆕
+#### Extra Validators
 
 New validators will go into code sections that must be explicitly enabled by
 setting `CLI11_ENABLE_EXTRA_VALIDATORS` to 1
@@ -843,8 +843,8 @@ It is also possible to create a subclass of `CLI::Validator`, in which case it
 can also set a custom description function, and operation function. One example
 of this is in the
 [custom validator example](https://github.com/CLIUtils/CLI11/blob/main/examples/custom_validator.cpp).
-example. The `check` and `transform` operations can also take a shared_ptr 🆕 to
-a validator if you wish to reuse the validator in multiple locations or it is
+example. The `check` and `transform` operations can also take a shared_ptr to a
+validator if you wish to reuse the validator in multiple locations or it is
 mutating and the check is dependent on other operations or is variable. Note
 that in this case it is not recommended to use the same object for both check
 and transform operations, the check will modify some internal flags on the
@@ -1002,7 +1002,7 @@ option_groups. These are:
   is not allowed to have a single character short option starting with the same
   character as a single dash long form name; for example, `-s` and `-single` are
   not allowed in the same application.
-- `.allow_subcommand_prefix_matching()`:🆕 If this modifier is enabled,
+- `.allow_subcommand_prefix_matching()`: If this modifier is enabled,
   unambiguous prefix portions of a subcommand will match. For example
   `upgrade_package` would match on `upgrade_`, `upg`, `u` as long as no other
   subcommand would also match. It also disallows subcommand names that are full
@@ -1078,12 +1078,12 @@ option_groups. These are:
 - `.get_option_no_throw(name)`: Get an option pointer by option name. This
   function will return a `nullptr` instead of throwing if the option is not
   available. This method will not search parents of option_options or nameless
-  subcommands regardless of fallthrough status 🚧, this behavior is slightly
+  subcommands regardless of fallthrough status 🆕, this behavior is slightly
   different from `get_option`.
 - `.get_options(filter)`: Get the list of all defined option pointers (useful
   for processing the app for custom output formats). If used on a subcommand
   will also get options that are in the parent app if the subcommand has
-  fallthrough (and is not nameless 🚧).
+  fallthrough (and is not nameless 🆕).
 - `.parse_order()`: Get the list of option pointers in the order they were
   parsed (including duplicates).
 - `.formatter(std::shared_ptr<FormatterBase> fmt)`: Set a custom formatter for
@@ -1128,8 +1128,8 @@ option_groups. These are:
   executes after the first argument of an application is processed. See
   [Subcommand callbacks](#callbacks) for some additional details.
 - `.allow_extras()`: Do not throw an error if extra arguments are left over.
-- `.allow_extras(CLI::ExtrasMode)`: 🆕 Specify the method of handling
-  unrecognized arguments.
+- `.allow_extras(CLI::ExtrasMode)`: Specify the method of handling unrecognized
+  arguments.
   - `CLI::ExtrasMode::Error`: generate an error on unrecognized argument. Same
     as `.allow_extras(false)`.
   - `CLI::ExtrasMode::ErrorImmediately`: generate an error immediately on
@@ -1162,7 +1162,7 @@ option_groups. These are:
   `PrefixCommandMode::SeparatorOnly` will only trigger prefix command mode with
   the subcommand separator `--`; other unrecognized arguments are considered an
   error unless `allow_extras` is enabled. Calling with
-  `PrefixCommandMode::PositionalOnly` 🚧 will only trigger prefix command mode
+  `PrefixCommandMode::PositionalOnly` 🆕 will only trigger prefix command mode
   at the first positional argument or the separator `--`; unrecognized options
   do not stop processing and are collected in the remaining_arg list.
 - `.usage(message)`: Replace text to appear at the start of the help string
@@ -1445,7 +1445,7 @@ following overloads:
   active values, or include defaulted arguments if `default_also` is `true`.
   This overload will likely be deprecated in a future release in favor of the
   `CLI::ConfigOutputMode` overload.
-- `.config_to_str(CLI::ConfigOutputMode, bool write_description = false)`: 🚧
+- `.config_to_str(CLI::ConfigOutputMode, bool write_description = false)`: 🆕
   Specify how configuration output should be generated.
   - `CLI::ConfigOutputMode::Active`: print active values only. Same as
     `.config_to_str()`.

--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -169,7 +169,7 @@ FetchContent_Declare(
     cli11_proj
     QUIET
     GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
-    GIT_TAG v2.6.2
+    GIT_TAG v2.7.0
 )
 
 FetchContent_MakeAvailable(cli11_proj)

--- a/include/CLI/Version.hpp
+++ b/include/CLI/Version.hpp
@@ -11,8 +11,8 @@
 // [CLI11:version_hpp:verbatim]
 
 #define CLI11_VERSION_MAJOR 2
-#define CLI11_VERSION_MINOR 6
-#define CLI11_VERSION_PATCH 2
-#define CLI11_VERSION "2.6.2"
+#define CLI11_VERSION_MINOR 7
+#define CLI11_VERSION_PATCH 0
+#define CLI11_VERSION "2.7.0"
 
 // [CLI11:version_hpp:end]


### PR DESCRIPTION
Edit: okay, I think this (and we) are ready. @phlptp, are we okay to release?

🤖 _AI text below_ :robot:

Add the 2.7.0 changelog entry and bump the version to 2.7.0. Also update the copyright years in the license and the version in the installation docs.