### PR TITLE
ci: attach the source packages to tagged releases

### DIFF
--- a/.github/workflows/artifact-generation.yml
+++ b/.github/workflows/artifact-generation.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           mkdir -p CLI11-Source
           cp build/CLI11-*-Source.* CLI11-Source
-          cp build/CLI11-*-Source.* .
 
       - name: Make header
         run: cmake --build build --target CLI11-generate-single-file
@@ -54,3 +53,5 @@ jobs:
         with:
           files: |
             build/single-include/CLI11.hpp
+            CLI11-Source/CLI11-*-Source.tar.gz
+            CLI11-Source/CLI11-*-Source.zip


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The Build workflow already makes the source `tar.gz` and `zip` with CPack, but the release step only attached `CLI11.hpp`, so past releases have a single asset. Attach the source packages as well.

Also removes the copy of those packages into the repository root, which nothing used.