### PR TITLE
ci: write release notes from the changelog

### DIFF
--- a/.github/workflows/artifact-generation.yml
+++ b/.github/workflows/artifact-generation.yml
@@ -47,10 +47,17 @@ jobs:
           name: CLI11-Source
           path: CLI11-Source
 
+      - name: Make release notes
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          python3 scripts/ExtractReleaseNotes.py "${GITHUB_REF_NAME}" > release-notes.md
+          cat release-notes.md
+
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          body_path: release-notes.md
           files: |
             build/single-include/CLI11.hpp
             CLI11-Source/CLI11-*-Source.tar.gz

--- a/scripts/ExtractReleaseNotes.py
+++ b/scripts/ExtractReleaseNotes.py
@@ -2,19 +2,20 @@
 
 """Print the CHANGELOG.md section for a version, for use as release notes.
 
-Usage: ExtractReleaseNotes.py VERSION [CHANGELOG]
-
 VERSION accepts a tag name ("v2.7.0") or a plain version ("2.7.0"). Older
 sections are titled with two components and a name, such as
 "## Version 2.5: Help Formatter", so "2.5.0" also matches "## Version 2.5".
 Each section keeps its own link definitions, so the output needs no fixup.
 """
 
+from __future__ import annotations
+
+import argparse
 import re
-import sys
+from pathlib import Path
 
 
-def extract(text, version):
+def extract(text: str, version: str) -> str | None:
     heads = list(re.finditer(r"^## Version (\S+?):?(?:[ \t].*)?$", text, re.M))
     for candidate in (version, version.rsplit(".", 1)[0]):
         for i, head in enumerate(heads):
@@ -25,17 +26,18 @@ def extract(text, version):
     return None
 
 
-def main():
-    if not 2 <= len(sys.argv) <= 3:
-        sys.exit(__doc__)
-    version = sys.argv[1].lstrip("v")
-    changelog = sys.argv[2] if len(sys.argv) == 3 else "CHANGELOG.md"
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("version", help='tag ("v2.7.0") or version ("2.7.0")')
+    parser.add_argument("changelog", nargs="?", type=Path, default=Path("CHANGELOG.md"))
+    args = parser.parse_args()
 
-    with open(changelog, encoding="utf-8") as fp:
-        notes = extract(fp.read(), version)
-
+    version = args.version.lstrip("v")
+    notes = extract(args.changelog.read_text(encoding="utf-8"), version)
     if notes is None:
-        sys.exit(f"No '## Version {version}' section in {changelog}")
+        raise SystemExit(f"No '## Version {version}' section in {args.changelog}")
     print(notes)
 
 

--- a/scripts/ExtractReleaseNotes.py
+++ b/scripts/ExtractReleaseNotes.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+"""Print the CHANGELOG.md section for a version, for use as release notes.
+
+Usage: ExtractReleaseNotes.py VERSION [CHANGELOG]
+
+VERSION accepts a tag name ("v2.7.0") or a plain version ("2.7.0"). Older
+sections are titled with two components and a name, such as
+"## Version 2.5: Help Formatter", so "2.5.0" also matches "## Version 2.5".
+Each section keeps its own link definitions, so the output needs no fixup.
+"""
+
+import re
+import sys
+
+
+def extract(text, version):
+    heads = list(re.finditer(r"^## Version (\S+?):?(?:[ \t].*)?$", text, re.M))
+    for candidate in (version, version.rsplit(".", 1)[0]):
+        for i, head in enumerate(heads):
+            if head.group(1) != candidate:
+                continue
+            end = heads[i + 1].start() if i + 1 < len(heads) else len(text)
+            return text[head.end() : end].strip()
+    return None
+
+
+def main():
+    if not 2 <= len(sys.argv) <= 3:
+        sys.exit(__doc__)
+    version = sys.argv[1].lstrip("v")
+    changelog = sys.argv[2] if len(sys.argv) == 3 else "CHANGELOG.md"
+
+    with open(changelog, encoding="utf-8") as fp:
+        notes = extract(fp.read(), version)
+
+    if notes is None:
+        sys.exit(f"No '## Version {version}' section in {changelog}")
+    print(notes)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fill in the release body from `CHANGELOG.md`. The new `scripts/ExtractReleaseNotes.py` prints the section for a version, taken from the tag name, and the workflow passes it to the release as `body_path`.

Each changelog section holds its own link definitions, so the extracted text needs no fixup. The script also matches the older two-component headings such as `## Version 2.5: Help Formatter`.