### PR TITLE
ci: check the changelog entry on every build

### DIFF
--- a/.github/workflows/artifact-generation.yml
+++ b/.github/workflows/artifact-generation.yml
@@ -47,10 +47,16 @@ jobs:
           name: CLI11-Source
           path: CLI11-Source
 
+      # Runs on every build, so a version bump without a changelog entry fails
+      # here instead of at tag time.
       - name: Make release notes
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          python3 scripts/ExtractReleaseNotes.py "${GITHUB_REF_NAME}" > release-notes.md
+          if [ "$GITHUB_REF_TYPE" = tag ]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="$(python3 scripts/ExtractVersion.py)"
+          fi
+          python3 scripts/ExtractReleaseNotes.py "$version" > release-notes.md
           cat release-notes.md
 
       - name: Release


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Run the release notes extraction on every build, with the version from `scripts/ExtractVersion.py` when the run is not for a tag. A version bump that has no matching changelog section now fails the build, instead of making a release with empty notes.

This means the version bump and the changelog entry must land in the same PR, which matches how 2.6.2 and #1399 were done.