### PR TITLE
docs: add the changelog to the Doxygen site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changelog {#changelog}
 
 ## Version 2.7.0
 

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1029,7 +1029,8 @@ WARN_LOGFILE           =
 INPUT                  = include \
                          docs/mainpage.md \
                          docs/examples.md \
-                         book/chapters
+                         book/chapters \
+                         CHANGELOG.md
 
 # This tag can be used to specify the character encoding of the source files
 # that Doxygen parses. Internally Doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -37,6 +37,7 @@
         <tab type="classmembers" visible="yes" title="" intro=""/>
       </tab>
     </tab>
+    <tab type="user" url="changelog.html" title="Changelog"/>
   </navindex>
 
   <!-- Layout definition for a class page -->


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The changelog is now a page on the Doxygen site, with a top-level **Changelog** tab in the navigation.

- `CHANGELOG.md` — added the `{#changelog}` label to the top heading, so the page URL is `changelog.html` instead of a generated name. The `book/chapters/*.md` files already use this style.
- `docs/Doxyfile` — added `CHANGELOG.md` to `INPUT`.
- `docs/DoxygenLayout.xml` — added the nav tab after *API Reference*.

Ran Doxygen locally: the page builds, the tab shows, and all PR reference links resolve, because each version section carries its own link definitions. `scripts/ExtractReleaseNotes.py` only matches `## Version` headings, so the new label does not change the release notes.