### PR TITLE
docs: title the changelog entries and name releases from them

### DIFF
--- a/.github/workflows/artifact-generation.yml
+++ b/.github/workflows/artifact-generation.yml
@@ -50,6 +50,7 @@ jobs:
       # Runs on every build, so a version bump without a changelog entry fails
       # here instead of at tag time.
       - name: Make release notes
+        id: notes
         run: |
           if [ "$GITHUB_REF_TYPE" = tag ]; then
             version="$GITHUB_REF_NAME"
@@ -57,12 +58,16 @@ jobs:
             version="$(python3 scripts/ExtractVersion.py)"
           fi
           python3 scripts/ExtractReleaseNotes.py "$version" > release-notes.md
+          title="$(python3 scripts/ExtractReleaseNotes.py --title "$version")"
+          echo "title=$title" >> "$GITHUB_OUTPUT"
+          echo "$title"
           cat release-notes.md
 
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          name: ${{ steps.notes.outputs.title }}
           body_path: release-notes.md
           files: |
             build/single-include/CLI11.hpp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,9 @@ not edit project version in `CMakeLists.txt`.
 
 When preparing a release (`chore: prepare X.Y.Z release`):
 
-- Add the changelog entry and bump `include/CLI/Version.hpp`.
+- Add the changelog entry and bump `include/CLI/Version.hpp`. Give the changelog
+  heading a short title, such as `## Version 2.7.0: Audit and documentation`;
+  the heading is the name of the GitHub release.
 - Update the feature markers in `README.md`: remove the old 🆕 markers (the
   previous release's features) and change 🚧 markers (main-only features) to 🆕.
   Removing an emoji from a heading also changes its TOC anchor — drop the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog {#changelog}
 
-## Version 2.7.0
+## Version 2.7.0: Audit and documentation
 
 This version adds a `FileSize` validator, a `PositionalOnly` prefix command
 mode, and more control over config file generation. It also contains a large set
@@ -166,7 +166,7 @@ that remove unnecessary copies in hot paths.
 [#1402]: https://github.com/CLIUtils/CLI11/pull/1402
 [#1403]: https://github.com/CLIUtils/CLI11/pull/1403
 
-## Version 2.6.2
+## Version 2.6.2: C++20 modules
 
 This version adds C++20 modules support, additional controls for help output and
 finer grained control for extras handling and prefix command operation. Fixes
@@ -231,7 +231,7 @@ help output and specific combinations of options and conditions.
 [#1261]: https://github.com/CLIUtils/CLI11/pull/1261
 [#1244]: https://github.com/CLIUtils/CLI11/pull/1244
 
-## Version 2.6.1
+## Version 2.6.1: Compilation fixes
 
 Patch fixing some compile issues in specific situations in the recent release,
 and a potential segmentation fault from specially crafted config files
@@ -253,7 +253,7 @@ and a potential segmentation fault from specially crafted config files
 [#1238]: https://github.com/CLIUtils/CLI11/pull/1238
 [#1239]: https://github.com/CLIUtils/CLI11/pull/1239
 
-## Version 2.6.0
+## Version 2.6.0: Callback control
 
 This version adds finer grained control of when option callbacks are executed,
 and further refinements in the help formatting. It also fixes a number of bugs

--- a/scripts/ExtractReleaseNotes.py
+++ b/scripts/ExtractReleaseNotes.py
@@ -6,6 +6,9 @@ VERSION accepts a tag name ("v2.7.0") or a plain version ("2.7.0"). Older
 sections are titled with two components and a name, such as
 "## Version 2.5: Help Formatter", so "2.5.0" also matches "## Version 2.5".
 Each section keeps its own link definitions, so the output needs no fixup.
+
+With --title, print the section heading instead of the body; this is the name
+of the GitHub release.
 """
 
 from __future__ import annotations
@@ -15,14 +18,15 @@ import re
 from pathlib import Path
 
 
-def extract(text: str, version: str) -> str | None:
-    heads = list(re.finditer(r"^## Version (\S+?):?(?:[ \t].*)?$", text, re.M))
+def extract(text: str, version: str) -> tuple[str, str] | None:
+    """Return the heading and the body of the section for a version."""
+    heads = list(re.finditer(r"^## (Version (\S+?):?(?:[ \t].*)?)$", text, re.M))
     for candidate in (version, version.rsplit(".", 1)[0]):
         for i, head in enumerate(heads):
-            if head.group(1) != candidate:
+            if head.group(2) != candidate:
                 continue
             end = heads[i + 1].start() if i + 1 < len(heads) else len(text)
-            return text[head.end() : end].strip()
+            return head.group(1), text[head.end() : end].strip()
     return None
 
 
@@ -32,13 +36,17 @@ def main() -> None:
     )
     parser.add_argument("version", help='tag ("v2.7.0") or version ("2.7.0")')
     parser.add_argument("changelog", nargs="?", type=Path, default=Path("CHANGELOG.md"))
+    parser.add_argument(
+        "--title", action="store_true", help="print the heading, not the body"
+    )
     args = parser.parse_args()
 
     version = args.version.lstrip("v")
-    notes = extract(args.changelog.read_text(encoding="utf-8"), version)
-    if notes is None:
+    section = extract(args.changelog.read_text(encoding="utf-8"), version)
+    if section is None:
         raise SystemExit(f"No '## Version {version}' section in {args.changelog}")
-    print(notes)
+    heading, notes = section
+    print(heading if args.title else notes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Gives 2.6.0, 2.6.1, 2.6.2, and 2.7.0 short titles, to match the style used for 2.5 and earlier.

`ExtractReleaseNotes.py` gets a `--title` flag that prints the section heading, and the release workflow passes it as the release name. The GitHub releases were already renamed to match by hand. The release checklist in `AGENTS.md` now says to title the heading.