### PR TITLE
docs: move the release checklist to a prepare-release skill

### DIFF
--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: prepare-release
+description:
+  Prepare a CLI11 release — changelog entry, version bump, README feature
+  markers, and related version references.
+---
+
+# Prepare a CLI11 release
+
+When preparing a release (`chore: prepare X.Y.Z release`):
+
+## Collect the changes
+
+List the merged PRs since the last release with
+`git log --oneline --first-parent v<last>..main`. Every user-visible change gets
+a changelog line.
+
+## Changelog entry
+
+Add a `## Version X.Y.Z: <Short title>` section at the top of `CHANGELOG.md`.
+The heading becomes the name of the GitHub release, so give it a short title,
+such as `## Version 2.7.0: Audit and documentation`.
+
+- Start with a short prose paragraph that summarizes the release.
+- Group the entries under `### Added`, `### Changed`, `### Fixed`,
+  `### Documentation`, and `### Internal` (and `### Removed`/`### Deprecated` if
+  needed). `Documentation` covers docs-only changes; `Internal` covers CI,
+  tests, and tooling changes with no user-visible effect.
+- Reference PRs as `[#1305][]` and put the matching link definitions
+  (`[#1305]: https://github.com/CLIUtils/CLI11/pull/1305`) at the end of the
+  section — each section keeps its own definitions so an extracted section needs
+  no fixup.
+
+## Version bump
+
+Bump `include/CLI/Version.hpp`: the `CLI11_VERSION_MAJOR`/`MINOR`/`PATCH` macros
+and the `CLI11_VERSION` string.
+
+## Other files
+
+- Update the feature markers in `README.md`: remove the old 🆕 markers (the
+  previous release's features) and change 🚧 markers (main-only features) to 🆕.
+  Removing an emoji from a heading also changes its TOC anchor — drop the
+  trailing `-` from the matching TOC links.
+- Check the copyright year in `LICENSE` and the version in
+  `book/chapters/installation.md`.
+
+## Verify
+
+CI extracts the release notes from the changelog on every build, so a version
+bump without a matching changelog section fails. Check locally:
+
+```bash
+python3 scripts/ExtractReleaseNotes.py --title "$(python3 scripts/ExtractVersion.py)"
+python3 scripts/ExtractReleaseNotes.py "$(python3 scripts/ExtractVersion.py)"
+```
+
+## After the PR merges
+
+Tell the user to tag the merge commit as `vX.Y.Z` and push the tag. CI then
+creates the GitHub release: the name comes from the changelog heading, the body
+from the changelog section, and the single header plus source packages are
+attached automatically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,17 +124,3 @@ prek -a
 
 The version string is read from `include/CLI/Version.hpp` at configure time. Do
 not edit project version in `CMakeLists.txt`.
-
-## Release Checklist
-
-When preparing a release (`chore: prepare X.Y.Z release`):
-
-- Add the changelog entry and bump `include/CLI/Version.hpp`. Give the changelog
-  heading a short title, such as `## Version 2.7.0: Audit and documentation`;
-  the heading is the name of the GitHub release.
-- Update the feature markers in `README.md`: remove the old 🆕 markers (the
-  previous release's features) and change 🚧 markers (main-only features) to 🆕.
-  Removing an emoji from a heading also changes its TOC anchor — drop the
-  trailing `-` from the matching TOC links.
-- Check the copyright year in `LICENSE` and the version in
-  `book/chapters/installation.md`.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Move the release checklist from AGENTS.md to an agent skill at `.agents/skills/prepare-release/SKILL.md`, and expand it: collecting changes since the last tag, the changelog section format and PR link style, the full Version.hpp bump, local verification with `scripts/ExtractReleaseNotes.py`, and the tag-and-release flow.

`.claude/` is gitignored, so Claude Code users link it locally: `ln -s ../.agents/skills .claude/skills`.