### PR TITLE
fix: missing symbols in the precompiled library under LTO

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,11 @@ jobs:
             options: -DCMAKE_CXX_FLAGS="-std=c++23 -stdlib=libc++"
               -DCLI11_ENABLE_EXTRA_VALIDATORS=1 -DCMAKE_CXX_COMPILER=clang++
               -DCLI11_FORCE_LIBCXX=ON -DCMAKE_LINKER_TYPE=LLD
+          - name: gcc15 std17 precompiled shared lto
+            container: gcc:15
+            std: 17
+            precompile: ON
+            options: -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_FLAGS="-O2 -flto=auto"
           - name: clang20 std26
             container: silkeh/clang:20
             std: 26

--- a/src/Precompile.cpp
+++ b/src/Precompile.cpp
@@ -4,6 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+// Build the full validator set into the library by default so consumers that
+// define CLI11_ENABLE_EXTRA_VALIDATORS per-TU can still link. An explicit
+// CMake-level choice (passed as a PUBLIC definition) is respected.
+#if !defined(CLI11_ENABLE_EXTRA_VALIDATORS) && !defined(CLI11_DISABLE_EXTRA_VALIDATORS)
+#define CLI11_ENABLE_EXTRA_VALIDATORS 1
+#endif
+
 // IWYU pragma: begin_keep
 
 #include <CLI/impl/App_inl.hpp>
@@ -18,3 +25,12 @@
 #include <CLI/impl/Validators_inl.hpp>
 
 // IWYU pragma: end_keep
+
+namespace CLI {
+// Library consumers only see the declarations of these member templates, so
+// the compiled library must provide the instantiations. Implicit instantiation
+// emits only discardable weak symbols, which LTO can remove from a shared
+// library; instantiate explicitly so the symbols always survive.
+template Option *Option::ignore_case<App>(bool);
+template Option *Option::ignore_underscore<App>(bool);
+}  // namespace CLI


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #1408.

The precompiled shared library relied on implicit instantiation of `Option::ignore_case<App>` and `ignore_underscore<App>` inside `Precompile.cpp`. Implicit instantiations are discardable weak symbols, and GCC LTO removes them from a shared library, so consumers (including our own tests, which get `CLI11_COMPILE` and never see the definitions) fail to link. `Precompile.cpp` now instantiates both templates explicitly.

The same configuration exposed a second gap: `fuzzApp.cpp` defines `CLI11_ENABLE_EXTRA_VALIDATORS` per-TU, but the library did not contain `FileSizeValidator`/`PermissionValidator` unless CMake enabled them. The library now compiles the full validator set by default; an explicit CMake-level enable/disable is still respected.

A new CI job (gcc15, precompiled, shared, `-O2 -flto=auto`) reproduces the reported AUR configuration and fails without both fixes. Also verified locally with GCC 16: the LTO shared build (25/25 tests, including FuzzFailTest), the `dev` preset, and the header-only `default` workflow all pass.