### PR TITLE
chore: prepare 2.7.1 release

### DIFF
--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -28,8 +28,8 @@ such as `## Version 2.7.0: Audit and documentation`.
   tests, and tooling changes with no user-visible effect.
 - Reference PRs as `[#1305][]` and put the matching link definitions
   (`[#1305]: https://github.com/CLIUtils/CLI11/pull/1305`) at the end of the
-  section — each section keeps its own definitions so an extracted section needs
-  no fixup.
+  version section — each section keeps its own definitions so an extracted
+  section needs no fixup.
 
 ## Version bump
 
@@ -38,10 +38,10 @@ and the `CLI11_VERSION` string.
 
 ## Other files
 
-- Update the feature markers in `README.md`: remove the old 🆕 markers (the
-  previous release's features) and change 🚧 markers (main-only features) to 🆕.
-  Removing an emoji from a heading also changes its TOC anchor — drop the
-  trailing `-` from the matching TOC links.
+- Only if not a patch release: Update the feature markers in `README.md`:
+  remove the old 🆕 markers (the previous release's features) and change 🚧
+  markers (main-only features) to 🆕.  Removing an emoji from a heading also
+  changes its TOC anchor — drop the trailing `-` from the matching TOC links.
 - Check the copyright year in `LICENSE` and the version in
   `book/chapters/installation.md`.
 

--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -38,10 +38,10 @@ and the `CLI11_VERSION` string.
 
 ## Other files
 
-- Only if not a patch release: Update the feature markers in `README.md`:
-  remove the old 🆕 markers (the previous release's features) and change 🚧
-  markers (main-only features) to 🆕.  Removing an emoji from a heading also
-  changes its TOC anchor — drop the trailing `-` from the matching TOC links.
+- Only if not a patch release: Update the feature markers in `README.md`: remove
+  the old 🆕 markers (the previous release's features) and change 🚧 markers
+  (main-only features) to 🆕. Removing an emoji from a heading also changes its
+  TOC anchor — drop the trailing `-` from the matching TOC links.
 - Check the copyright year in `LICENSE` and the version in
   `book/chapters/installation.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog {#changelog}
 
+## Version 2.7.1: LTO link fix
+
+This patch release fixes linking against the precompiled shared library when it
+is built with link-time optimization.
+
+### Fixed
+
+- Fixed missing symbols in the precompiled library under LTO: `Precompile.cpp`
+  now explicitly instantiates `Option::ignore_case<App>` and
+  `ignore_underscore<App>`, and the library always compiles the full validator
+  set unless CMake disables it. [#1409][]
+
+### Documentation
+
+- Added the changelog to the Doxygen site. [#1405][]
+- Titled the changelog entries and named the releases from them. [#1406][]
+
+### Internal
+
+- Moved the release checklist to a `prepare-release` skill. [#1407][]
+
+[#1405]: https://github.com/CLIUtils/CLI11/pull/1405
+[#1406]: https://github.com/CLIUtils/CLI11/pull/1406
+[#1407]: https://github.com/CLIUtils/CLI11/pull/1407
+[#1409]: https://github.com/CLIUtils/CLI11/pull/1409
+
 ## Version 2.7.0: Audit and documentation
 
 This version adds a `FileSize` validator, a `PositionalOnly` prefix command

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-CLI11 2.7.0 Copyright (c) 2017-2026 University of Cincinnati, developed by Henry
+CLI11 2.7.1 Copyright (c) 2017-2026 University of Cincinnati, developed by Henry
 Schreiner under NSF AWARD 1414736. All rights reserved.
 
 Redistribution and use in source and binary forms of CLI11, with or without

--- a/book/chapters/installation.md
+++ b/book/chapters/installation.md
@@ -169,7 +169,7 @@ FetchContent_Declare(
     cli11_proj
     QUIET
     GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
-    GIT_TAG v2.7.0
+    GIT_TAG v2.7.1
 )
 
 FetchContent_MakeAvailable(cli11_proj)

--- a/include/CLI/Version.hpp
+++ b/include/CLI/Version.hpp
@@ -12,7 +12,7 @@
 
 #define CLI11_VERSION_MAJOR 2
 #define CLI11_VERSION_MINOR 7
-#define CLI11_VERSION_PATCH 0
-#define CLI11_VERSION "2.7.0"
+#define CLI11_VERSION_PATCH 1
+#define CLI11_VERSION "2.7.1"
 
 // [CLI11:version_hpp:end]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Add the 2.7.1 changelog entry and bump the version to 2.7.1. Also update the
version in the license and the installation docs.

This is a patch release for the LTO link fix (#1409), so the README feature
markers are unchanged. Includes small wording updates to the `prepare-release`
skill.
