### PR TITLE
refactor: trim heavy includes from the declaration headers

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -12,12 +12,11 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
-#include <iostream>
+#include <iosfwd>
 #include <iterator>
 #include <memory>
 #include <numeric>
 #include <set>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -964,7 +963,13 @@ class App {
     }
 
     /// Print a nice error message and return the exit code
-    int exit(const Error &e, std::ostream &out = std::cout, std::ostream &err = std::cerr) const;
+    int exit(const Error &e, std::ostream &out, std::ostream &err) const;
+
+    /// Print a nice error message to std::cout/std::cerr and return the exit code
+    int exit(const Error &e) const;
+
+    /// Print a nice error message and return the exit code; errors go to std::cerr
+    int exit(const Error &e, std::ostream &out) const;
 
     ///@}
     /// @name Post parsing

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -965,8 +965,9 @@ class App {
     /// Print a nice error message and return the exit code
     int exit(const Error &e, std::ostream &out, std::ostream &err) const;
 
-    /// Print a nice error message to std::cout/std::cerr and return the exit code
-    CLI11_NODISCARD int exit(const Error &e) const;
+    /// Print a nice error message to std::cout/std::cerr and return the exit code; the
+    /// result can be discarded when it is called only for the printing
+    int exit(const Error &e) const;  // NOLINT(modernize-use-nodiscard)
 
     /// Print a nice error message and return the exit code; errors go to std::cerr
     int exit(const Error &e, std::ostream &out) const;

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -966,7 +966,7 @@ class App {
     int exit(const Error &e, std::ostream &out, std::ostream &err) const;
 
     /// Print a nice error message to std::cout/std::cerr and return the exit code
-    int exit(const Error &e) const;
+    CLI11_NODISCARD int exit(const Error &e) const;
 
     /// Print a nice error message and return the exit code; errors go to std::cerr
     int exit(const Error &e, std::ostream &out) const;

--- a/include/CLI/Config.hpp
+++ b/include/CLI/Config.hpp
@@ -10,9 +10,6 @@
 
 // [CLI11:public_includes:set]
 #include <algorithm>
-#include <cctype>
-#include <fstream>
-#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -11,14 +11,12 @@
 // [CLI11:public_includes:set]
 #include <algorithm>
 #include <cstdint>
-#include <fstream>
-#include <iostream>
+#include <iosfwd>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 // [CLI11:public_includes:end]
-#include "Encoding.hpp"
 #include "Error.hpp"
 #include "StringTools.hpp"
 
@@ -80,18 +78,7 @@ class Config {
     }
 
     /// Parse a config file, throw an error (ParseError:ConfigParseError or FileError) on failure
-    CLI11_NODISCARD std::vector<ConfigItem> from_file(const std::string &name) const {
-#if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
-        std::ifstream input{to_path(name)};
-#else
-        std::ifstream input{name};
-#endif
-
-        if(!input.good())
-            throw FileError::Missing(name);
-
-        return from_config(input);
-    }
+    CLI11_NODISCARD std::vector<ConfigItem> from_file(const std::string &name) const;
 
     /// Virtual destructor
     virtual ~Config() = default;

--- a/include/CLI/ExtraValidators.hpp
+++ b/include/CLI/ExtraValidators.hpp
@@ -18,10 +18,11 @@
 #include <cmath>
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <limits>
+#include <locale>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/CLI/Macros.hpp
+++ b/include/CLI/Macros.hpp
@@ -104,21 +104,14 @@
 #endif
 #endif
 
-/** <codecvt> availability */
-#if !defined(CLI11_CPP26) && !defined(CLI11_HAS_CODECVT)
-#if defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER) && __GNUC__ < 5
+/** <codecvt> availability (the header is only included where it is used) */
+#ifndef CLI11_HAS_CODECVT
+#if defined(CLI11_CPP26)
+#define CLI11_HAS_CODECVT 0
+#elif defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER) && __GNUC__ < 5
 #define CLI11_HAS_CODECVT 0
 #else
 #define CLI11_HAS_CODECVT 1
-#include <codecvt>
-#endif
-#else
-#if defined(CLI11_HAS_CODECVT)
-#if CLI11_HAS_CODECVT > 0
-#include <codecvt>
-#endif
-#else
-#define CLI11_HAS_CODECVT 0
 #endif
 #endif
 

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -10,8 +10,6 @@
 
 // [CLI11:public_includes:set]
 #include <algorithm>
-#include <iomanip>
-#include <locale>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -177,17 +175,10 @@ inline bool is_separator(const std::string &str) {
 }
 
 /// Verify that str consists of letters only
-inline bool isalpha(const std::string &str) {
-    return std::all_of(str.begin(), str.end(), [](char c) { return std::isalpha(c, std::locale()); });
-}
+CLI11_INLINE bool isalpha(const std::string &str);
 
 /// Return a lower case version of a string
-inline std::string to_lower(std::string str) {
-    std::transform(std::begin(str), std::end(str), std::begin(str), [](const std::string::value_type &x) {
-        return std::tolower(x, std::locale());
-    });
-    return str;
-}
+CLI11_INLINE std::string to_lower(std::string str);
 
 /// remove underscores from a string
 inline std::string remove_underscore(std::string str) {

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -18,6 +18,7 @@
 #include <exception>
 #include <limits>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -17,9 +17,9 @@
 #include <cmath>
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <limits>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -726,6 +726,10 @@ CLI11_INLINE int App::exit(const Error &e, std::ostream &out, std::ostream &err)
     return e.get_exit_code();
 }
 
+CLI11_INLINE int App::exit(const Error &e) const { return exit(e, std::cout, std::cerr); }
+
+CLI11_INLINE int App::exit(const Error &e, std::ostream &out) const { return exit(e, out, std::cerr); }
+
 CLI11_INLINE std::vector<const App *> App::get_subcommands(const std::function<bool(const App *)> &filter) const {
     std::vector<const App *> subcomms(subcommands_.size());
     std::transform(

--- a/include/CLI/impl/Config_inl.hpp
+++ b/include/CLI/impl/Config_inl.hpp
@@ -11,8 +11,14 @@
 // This include is only needed for IDEs to discover symbols
 #include "../Config.hpp"
 
+#include "../Encoding.hpp"
+
 // [CLI11:public_includes:set]
 #include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <istream>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -20,6 +26,19 @@
 
 namespace CLI {
 // [CLI11:config_inl_hpp:verbatim]
+
+CLI11_INLINE std::vector<ConfigItem> Config::from_file(const std::string &name) const {
+#if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
+    std::ifstream input{to_path(name)};
+#else
+    std::ifstream input{name};
+#endif
+
+    if(!input.good())
+        throw FileError::Missing(name);
+
+    return from_config(input);
+}
 
 static constexpr auto multiline_literal_quote = R"(''')";
 static constexpr auto multiline_string_quote = R"(""")";

--- a/include/CLI/impl/Encoding_inl.hpp
+++ b/include/CLI/impl/Encoding_inl.hpp
@@ -25,6 +25,12 @@
 #include <utility>
 // [CLI11:public_includes:end]
 
+// [CLI11:encoding_inl_includes:verbatim]
+#if CLI11_HAS_CODECVT
+#include <codecvt>
+#endif
+// [CLI11:encoding_inl_includes:end]
+
 namespace CLI {
 // [CLI11:encoding_inl_hpp:verbatim]
 

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -13,7 +13,9 @@
 
 // [CLI11:public_includes:set]
 #include <algorithm>
+#include <iomanip>
 #include <set>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -12,7 +12,12 @@
 #include "../StringTools.hpp"
 
 // [CLI11:public_includes:set]
+#include <algorithm>
 #include <cstdint>
+#include <iomanip>
+#include <locale>
+#include <ostream>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -22,6 +27,18 @@ namespace CLI {
 // [CLI11:string_tools_inl_hpp:verbatim]
 
 namespace detail {
+
+CLI11_INLINE bool isalpha(const std::string &str) {
+    return std::all_of(str.begin(), str.end(), [](char c) { return std::isalpha(c, std::locale()); });
+}
+
+CLI11_INLINE std::string to_lower(std::string str) {
+    std::transform(std::begin(str), std::end(str), std::begin(str), [](const std::string::value_type &x) {
+        return std::tolower(x, std::locale());
+    });
+    return str;
+}
+
 CLI11_INLINE std::vector<std::string> split(const std::string &s, char delim) {
     std::vector<std::string> elems;
     if(s.empty()) {

--- a/single-include/CLI11.hpp.in
+++ b/single-include/CLI11.hpp.in
@@ -44,6 +44,8 @@
 
 {encoding_includes}
 
+{encoding_inl_includes}
+
 {argv_inl_includes}
 
 namespace {namespace} {{


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Progress on #194.

Remove `<iostream>`, `<codecvt>`, `<iomanip>`, `<fstream>`, and `<locale>` from the declaration headers, so precompiled-mode (`CLI11_PRECOMPILED`) clients do not parse them:

- `App::exit()` used `<iostream>` only for its `std::cout`/`std::cerr` default arguments; it is now three overloads, with the defaults supplied in `App_inl.hpp`. `App.hpp` uses `<iosfwd>`.
- The inline bodies of `Config::from_file`, `detail::isalpha`, and `detail::to_lower` move to the impl headers. This also removes `Encoding.hpp` (and with it `<filesystem>`) from the `App.hpp` include chain.
- `<codecvt>` (deprecated, removed in C++26) is now confined to `Encoding_inl.hpp`; the `CLI11_HAS_CODECVT` detection stays in `Macros.hpp` with the same semantics.
- `TypeTools.hpp` and several impl headers now include what they use (`<sstream>`, `<locale>`, `<iomanip>`) instead of relying on transitive includes.

Measured with a small 3-option app: the precompiled client drops from ~70.4k to ~68.2k preprocessed lines (0.45s to 0.42s with Apple clang at -O2). The gain is limited because `<sstream>`, which the public templates genuinely need, pulls in most of the stream and locale machinery on both libc++ and libstdc++. Header-only builds are unchanged, since the impl headers restore the includes. Clients on libstdc++ also no longer instantiate the `std::ios_base::Init` static from `<iostream>`.

Beyond CI: verified the generated single header compiles in both C++11 and C++2c mode (where `<codecvt>` does not exist), and built the precompiled library and a client with GCC 16.