### PR TITLE
refactor: move non-template bodies from declaration headers to _inl files

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -342,10 +342,7 @@ class App {
     ///@{
 
     /// Create a new program. Pass in the same arguments as main(), along with a help string.
-    explicit App(std::string app_description = "", std::string app_name = "")
-        : App(app_description, app_name, nullptr) {
-        set_help_flag("-h,--help", "Print this help message and exit");
-    }
+    explicit App(std::string app_description = "", std::string app_name = "");
 
     App(const App &) = delete;
     App &operator=(const App &) = delete;
@@ -362,14 +359,7 @@ class App {
     /// it is not possible to overload on std::function (fixed in c++14
     /// and backported to c++11 on newer compilers). Use capture by reference
     /// to get a pointer to App if needed.
-    App *callback(std::function<void()> app_callback) {
-        if(immediate_callback_) {
-            parse_complete_callback_ = std::move(app_callback);
-        } else {
-            final_callback_ = std::move(app_callback);
-        }
-        return this;
-    }
+    App *callback(std::function<void()> app_callback);
 
     /// Set a callback for execution when all parsing and processing has completed
     /// aliased as callback
@@ -440,26 +430,11 @@ class App {
         return this;
     }
     /// Set the subcommand to be disabled by default, so on clear(), at the start of each parse it is disabled
-    App *disabled_by_default(bool disable = true) {
-        if(disable) {
-            default_startup = startup_mode::disabled;
-        } else {
-            default_startup = (default_startup == startup_mode::enabled) ? startup_mode::enabled : startup_mode::stable;
-        }
-        return this;
-    }
+    App *disabled_by_default(bool disable = true);
 
     /// Set the subcommand to be enabled by default, so on clear(), at the start of each parse it is enabled (not
     /// disabled)
-    App *enabled_by_default(bool enable = true) {
-        if(enable) {
-            default_startup = startup_mode::enabled;
-        } else {
-            default_startup =
-                (default_startup == startup_mode::disabled) ? startup_mode::disabled : startup_mode::stable;
-        }
-        return this;
-    }
+    App *enabled_by_default(bool enable = true);
 
     /// Set the subcommand callback to be executed immediately on subcommand completion
     App *immediate_callback(bool immediate = true);
@@ -477,15 +452,7 @@ class App {
     }
 
     /// ignore extras in config files
-    App *allow_config_extras(bool allow = true) {
-        if(allow) {
-            allow_config_extras_ = ConfigExtrasMode::Capture;
-            allow_extras_ = ExtrasMode::Capture;
-        } else {
-            allow_config_extras_ = ConfigExtrasMode::Error;
-        }
-        return this;
-    }
+    App *allow_config_extras(bool allow = true);
 
     /// ignore extras in config files
     App *allow_config_extras(config_extras_mode mode) {
@@ -654,9 +621,7 @@ class App {
     }
 
     /// Add option with no description or variable assignment
-    Option *add_option(std::string option_name) {
-        return add_option(option_name, CLI::callback_t{}, std::string{}, false);
-    }
+    Option *add_option(std::string option_name);
 
     /// Add option with description but with no variable assignment or callback
     template <typename T,
@@ -688,7 +653,7 @@ class App {
 
   public:
     /// Add a flag with no description or variable assignment
-    Option *add_flag(std::string flag_name) { return _add_flag_internal(flag_name, CLI::callback_t(), std::string{}); }
+    Option *add_flag(std::string flag_name);
 
     /// Add flag with description but with no variable assignment or callback
     /// takes a constant string or a rvalue reference to a string,  if a variable string is passed that variable will be
@@ -851,16 +816,7 @@ class App {
     /// Require a subcommand to be given (does not affect help call)
     /// The number required can be given. Negative values indicate maximum
     /// number allowed (0 for any number). Max number inheritable.
-    App *require_subcommand(int value) {
-        if(value < 0) {
-            require_subcommand_min_ = 0;
-            require_subcommand_max_ = static_cast<std::size_t>(-value);
-        } else {
-            require_subcommand_min_ = static_cast<std::size_t>(value);
-            require_subcommand_max_ = static_cast<std::size_t>(value);
-        }
-        return this;
-    }
+    App *require_subcommand(int value);
 
     /// Explicitly control the number of subcommands required. Setting 0
     /// for the max means unlimited number allowed. Max number inheritable.
@@ -880,16 +836,7 @@ class App {
     /// Require an option to be given (does not affect help call)
     /// The number required can be given. Negative values indicate maximum
     /// number allowed (0 for any number).
-    App *require_option(int value) {
-        if(value < 0) {
-            require_option_min_ = 0;
-            require_option_max_ = static_cast<std::size_t>(-value);
-        } else {
-            require_option_min_ = static_cast<std::size_t>(value);
-            require_option_max_ = static_cast<std::size_t>(value);
-        }
-        return this;
-    }
+    App *require_option(int value);
 
     /// Explicitly control the number of options required. Setting 0
     /// for the max means unlimited number allowed. Max number inheritable.
@@ -992,60 +939,20 @@ class App {
     std::vector<App *> get_subcommands(const std::function<bool(App *)> &filter);
 
     /// Check to see if given subcommand was selected
-    bool got_subcommand(const App *subcom) const {
-        // get subcom needed to verify that this was a real subcommand
-        return get_subcommand(subcom)->parsed_ > 0;
-    }
+    bool got_subcommand(const App *subcom) const;
 
     /// Check with name instead of pointer to see if subcommand was selected
-    CLI11_NODISCARD bool got_subcommand(std::string subcommand_name) const noexcept {
-        App *sub = get_subcommand_no_throw(subcommand_name);
-        return (sub != nullptr) ? (sub->parsed_ > 0) : false;
-    }
+    CLI11_NODISCARD bool got_subcommand(std::string subcommand_name) const noexcept;
 
     /// Sets excluded options for the subcommand
-    App *excludes(Option *opt) {
-        if(opt == nullptr) {
-            throw OptionNotFound("nullptr passed");
-        }
-        exclude_options_.insert(opt);
-        return this;
-    }
+    App *excludes(Option *opt);
 
     /// Sets excluded subcommands for the subcommand
-    App *excludes(App *app) {
-        if(app == nullptr) {
-            throw OptionNotFound("nullptr passed");
-        }
-        if(app == this) {
-            throw OptionNotFound("cannot self reference in excludes");
-        }
-        auto res = exclude_subcommands_.insert(app);
-        // subcommand exclusion should be symmetric
-        if(res.second) {
-            app->exclude_subcommands_.insert(this);
-        }
-        return this;
-    }
+    App *excludes(App *app);
 
-    App *needs(Option *opt) {
-        if(opt == nullptr) {
-            throw OptionNotFound("nullptr passed");
-        }
-        need_options_.insert(opt);
-        return this;
-    }
+    App *needs(Option *opt);
 
-    App *needs(App *app) {
-        if(app == nullptr) {
-            throw OptionNotFound("nullptr passed");
-        }
-        if(app == this) {
-            throw OptionNotFound("cannot self reference in needs");
-        }
-        need_subcommands_.insert(app);
-        return this;
-    }
+    App *needs(App *app);
 
     /// Removes an option from the excludes list of this subcommand
     bool remove_excludes(Option *opt);
@@ -1084,20 +991,15 @@ class App {
     }
     /// Produce a string that could be read in as a config of the current values of the App. Set default_also to
     /// include default arguments. write_descriptions will print a description for the App and for each option.
-    CLI11_NODISCARD std::string config_to_str() const { return config_to_str(ConfigOutputMode::Active, false); }
+    CLI11_NODISCARD std::string config_to_str() const;
 
     /// Produce a string that could be read in as a config of the current values of the App.
-    CLI11_NODISCARD std::string config_to_str(ConfigOutputMode mode, bool write_description = false) const {
-        return config_formatter_->to_config(this, mode, write_description, "");
-    }
+    CLI11_NODISCARD std::string config_to_str(ConfigOutputMode mode, bool write_description = false) const;
 
     /// Produce a string that could be read in as a config of the current values of the App. Set default_also to
     /// include default arguments. write_descriptions will print a description for the App and for each option.
     /// This will be deprecated soon, use the version that takes a ConfigOutputMode instead.
-    CLI11_NODISCARD std::string config_to_str(bool default_also, bool write_description = false) const {
-        return config_to_str(default_also ? ConfigOutputMode::AllDefaults : ConfigOutputMode::Active,
-                             write_description);
-    }
+    CLI11_NODISCARD std::string config_to_str(bool default_also, bool write_description = false) const;
 
     /// Makes a help message, using the currently configured formatter
     /// Will only do one subcommand at a time
@@ -1183,14 +1085,10 @@ class App {
     CLI11_NODISCARD const std::string &get_group() const { return group_; }
 
     /// Generate and return the usage.
-    CLI11_NODISCARD std::string get_usage() const {
-        return (usage_callback_) ? usage_callback_() + '\n' + usage_ : usage_;
-    }
+    CLI11_NODISCARD std::string get_usage() const;
 
     /// Generate and return the footer.
-    CLI11_NODISCARD std::string get_footer() const {
-        return (footer_callback_) ? footer_callback_() + '\n' + footer_ : footer_;
-    }
+    CLI11_NODISCARD std::string get_footer() const;
 
     /// Get the required min subcommand value
     CLI11_NODISCARD std::size_t get_require_subcommand_min() const { return require_subcommand_min_; }
@@ -1458,27 +1356,12 @@ class App {
 /// Extension of App to better manage groups of options
 class Option_group : public App {
   public:
-    Option_group(std::string group_description, std::string group_name, App *parent)
-        : App(std::move(group_description), "", parent) {
-        group(group_name);
-        // option groups should have automatic fallthrough
-        if(group_name.empty() || group_name.front() == '+') {
-            // help will not be used by default in these contexts
-            set_help_flag("");
-            set_help_all_flag("");
-        }
-    }
+    Option_group(std::string group_description, std::string group_name, App *parent);
     using App::add_option;
     /// Add an existing option to the Option_group
-    Option *add_option(Option *opt) {
-        if(get_parent() == nullptr) {
-            throw OptionNotFound("Unable to locate the specified option");
-        }
-        get_parent()->_move_option(opt, this);
-        return opt;
-    }
+    Option *add_option(Option *opt);
     /// Add an existing option to the Option_group
-    void add_options(Option *opt) { add_option(opt); }
+    void add_options(Option *opt);
     /// Add a bunch of options to the group
     template <typename... Args> void add_options(Option *opt, Args... args) {
         add_option(opt);
@@ -1486,12 +1369,7 @@ class Option_group : public App {
     }
     using App::add_subcommand;
     /// Add an existing subcommand to be a member of an option_group
-    App *add_subcommand(App *subcom) {
-        App_p subc = subcom->get_parent()->get_subcommand_ptr(subcom);
-        subc->get_parent()->remove_subcommand(subcom);
-        add_subcommand(std::move(subc));
-        return subcom;
-    }
+    App *add_subcommand(App *subcom);
 };
 
 /// Helper function to enable one option group/subcommand when another is used
@@ -1510,16 +1388,10 @@ CLI11_INLINE void TriggerOff(App *trigger_app, std::vector<App *> apps_to_enable
 CLI11_INLINE void deprecate_option(Option *opt, const std::string &replacement = "");
 
 /// Helper function to mark an option as deprecated
-inline void deprecate_option(App *app, const std::string &option_name, const std::string &replacement = "") {
-    auto *opt = app->get_option(option_name);
-    deprecate_option(opt, replacement);
-}
+CLI11_INLINE void deprecate_option(App *app, const std::string &option_name, const std::string &replacement = "");
 
 /// Helper function to mark an option as deprecated
-inline void deprecate_option(App &app, const std::string &option_name, const std::string &replacement = "") {
-    auto *opt = app.get_option(option_name);
-    deprecate_option(opt, replacement);
-}
+CLI11_INLINE void deprecate_option(App &app, const std::string &option_name, const std::string &replacement = "");
 
 /// Helper function to mark an option as retired
 CLI11_INLINE void retire_option(App *app, Option *opt);

--- a/include/CLI/ExtraValidators.hpp
+++ b/include/CLI/ExtraValidators.hpp
@@ -619,16 +619,16 @@ class FileSizeValidator : public Validator {
 };
 
 /// Check that the file exist and available for read
-const detail::PermissionValidator ReadPermissions(detail::Permission::read);
+CLI11_MODULE_INLINE const detail::PermissionValidator ReadPermissions(detail::Permission::read);
 
 /// Check that the file exist and available for write
-const detail::PermissionValidator WritePermissions(detail::Permission::write);
+CLI11_MODULE_INLINE const detail::PermissionValidator WritePermissions(detail::Permission::write);
 
 /// Check that the file exist and available for execute
-const detail::PermissionValidator ExecPermissions(detail::Permission::exec);
+CLI11_MODULE_INLINE const detail::PermissionValidator ExecPermissions(detail::Permission::exec);
 
 /// Check that the file exists and is not empty
-const FileSizeValidator NonEmptyFile(1, 0);
+CLI11_MODULE_INLINE const FileSizeValidator NonEmptyFile(1, 0);
 #endif
 
 #endif

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -373,10 +373,7 @@ class Option : public OptionBase<Option> {
            std::string option_description,
            callback_t callback,
            App *parent,
-           bool allow_non_standard = false)
-        : description_(std::move(option_description)), parent_(parent), callback_(std::move(callback)) {
-        std::tie(snames_, lnames_, pname_) = detail::get_names(detail::split_names(option_name), allow_non_standard);
-    }
+           bool allow_non_standard = false);
 
   public:
     /// @name Basic
@@ -395,11 +392,7 @@ class Option : public OptionBase<Option> {
     explicit operator bool() const { return !empty() || force_callback_; }
 
     /// Clear the parsed results (mostly for testing)
-    void clear() {
-        results_.clear();
-        proc_results_.clear();
-        current_option_state_ = option_state::parsing;
-    }
+    void clear();
 
     ///@}
     /// @name Setting options
@@ -486,12 +479,7 @@ class Option : public OptionBase<Option> {
     Validator *get_validator(int index);
 
     /// Sets required options
-    Option *needs(Option *opt) {
-        if(opt != this) {
-            needs_.insert(opt);
-        }
-        return this;
-    }
+    Option *needs(Option *opt);
 
     /// Can find a string if needed
     template <typename T = App> Option *needs(std::string opt_name) {
@@ -597,18 +585,7 @@ class Option : public OptionBase<Option> {
     /// Get the flag names with specified default values
     CLI11_NODISCARD const std::vector<std::string> &get_fnames() const { return fnames_; }
     /// Get a single name for the option, first of lname, sname, pname, envname
-    CLI11_NODISCARD const std::string &get_single_name() const {
-        if(!lnames_.empty()) {
-            return lnames_[0];
-        }
-        if(!snames_.empty()) {
-            return snames_[0];
-        }
-        if(!pname_.empty()) {
-            return pname_;
-        }
-        return envname_;
-    }
+    CLI11_NODISCARD const std::string &get_single_name() const;
     /// The number of times the option expects to be included
     CLI11_NODISCARD int get_expected() const { return expected_min_; }
 
@@ -782,10 +759,7 @@ class Option : public OptionBase<Option> {
     }
 
     /// Set a custom option typestring
-    Option *type_name(std::string typeval) {
-        type_name_fn([typeval]() { return typeval; });
-        return this;
-    }
+    Option *type_name(std::string typeval);
 
     /// Set a custom option size
     Option *type_size(int option_type_size);
@@ -803,12 +777,7 @@ class Option : public OptionBase<Option> {
     }
 
     /// Capture the default value from the original value (if it can be captured)
-    Option *capture_default_str() {
-        if(default_function_) {
-            default_str_ = default_function_();
-        }
-        return this;
-    }
+    Option *capture_default_str();
 
     /// Set the default value string representation (does not change the contained value)
     Option *default_str(std::string val) {

--- a/include/CLI/Validators.hpp
+++ b/include/CLI/Validators.hpp
@@ -68,17 +68,16 @@ class Validator {
     /// specify that a validator should not modify the input
     bool non_modifying_{false};
 
-    Validator(std::string validator_desc, std::function<std::string(std::string &)> func)
-        : desc_function_([validator_desc]() { return validator_desc; }), func_(std::move(func)) {}
+    Validator(std::string validator_desc, std::function<std::string(std::string &)> func);
 
   public:
     Validator() = default;
     /// Construct a Validator with just the description string
     explicit Validator(std::string validator_desc) : desc_function_([validator_desc]() { return validator_desc; }) {}
     /// Construct Validator from basic information
-    Validator(std::function<std::string(std::string &)> op, std::string validator_desc, std::string validator_name = "")
-        : desc_function_([validator_desc]() { return validator_desc; }), func_(std::move(op)),
-          name_(std::move(validator_name)) {}
+    Validator(std::function<std::string(std::string &)> op,
+              std::string validator_desc,
+              std::string validator_name = "");
     /// Set the Validator operation function
     Validator &operation(std::function<std::string(std::string &)> op) {
         func_ = std::move(op);
@@ -90,10 +89,7 @@ class Validator {
 
     /// This is the required operator for a Validator - provided to help
     /// users (CLI11 uses the member `func` directly)
-    std::string operator()(const std::string &str) const {
-        std::string value = str;
-        return (active_) ? func_(value) : std::string{};
-    }
+    std::string operator()(const std::string &str) const;
 
     /// Specify the type string
     Validator &description(std::string validator_desc) {
@@ -104,23 +100,14 @@ class Validator {
     CLI11_NODISCARD Validator description(std::string validator_desc) const;
 
     /// Generate type description information for the Validator
-    CLI11_NODISCARD std::string get_description() const {
-        if(active_) {
-            return desc_function_();
-        }
-        return std::string{};
-    }
+    CLI11_NODISCARD std::string get_description() const;
     /// Specify the type string
     Validator &name(std::string validator_name) {
         name_ = std::move(validator_name);
         return *this;
     }
     /// Specify the type string
-    CLI11_NODISCARD Validator name(std::string validator_name) const {
-        Validator newval(*this);
-        newval.name_ = std::move(validator_name);
-        return newval;
-    }
+    CLI11_NODISCARD Validator name(std::string validator_name) const;
     /// Get the name of the Validator
     CLI11_NODISCARD const std::string &get_name() const { return name_; }
     /// Specify whether the Validator is active or not
@@ -129,11 +116,7 @@ class Validator {
         return *this;
     }
     /// Specify whether the Validator is active or not
-    CLI11_NODISCARD Validator active(bool active_val = true) const {
-        Validator newval(*this);
-        newval.active_ = active_val;
-        return newval;
-    }
+    CLI11_NODISCARD Validator active(bool active_val = true) const;
 
     /// Specify whether the Validator can be modifying or not
     Validator &non_modifying(bool no_modify = true) {
@@ -146,11 +129,7 @@ class Validator {
         return *this;
     }
     /// Specify the application index of a validator
-    CLI11_NODISCARD Validator application_index(int app_index) const {
-        Validator newval(*this);
-        newval.application_index_ = app_index;
-        return newval;
-    }
+    CLI11_NODISCARD Validator application_index(int app_index) const;
     /// Get the current value of the application index
     CLI11_NODISCARD int get_application_index() const { return application_index_; }
     /// Get a boolean if the validator is active

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -62,6 +62,10 @@ CLI11_INLINE App::App(std::string app_description, std::string app_name, App *pa
     }
 }
 
+CLI11_INLINE App::App(std::string app_description, std::string app_name) : App(app_description, app_name, nullptr) {
+    set_help_flag("-h,--help", "Print this help message and exit");
+}
+
 CLI11_NODISCARD CLI11_INLINE char **App::ensure_utf8(char **argv) {
 #ifdef _WIN32
     (void)argv;
@@ -82,6 +86,15 @@ CLI11_NODISCARD CLI11_INLINE char **App::ensure_utf8(char **argv) {
 #else
     return argv;
 #endif
+}
+
+CLI11_INLINE App *App::callback(std::function<void()> app_callback) {
+    if(immediate_callback_) {
+        parse_complete_callback_ = std::move(app_callback);
+    } else {
+        final_callback_ = std::move(app_callback);
+    }
+    return this;
 }
 
 CLI11_INLINE App *App::name(std::string app_name) {
@@ -116,6 +129,34 @@ CLI11_INLINE App *App::alias(std::string app_name) {
         aliases_.push_back(app_name);
     }
 
+    return this;
+}
+
+CLI11_INLINE App *App::disabled_by_default(bool disable) {
+    if(disable) {
+        default_startup = startup_mode::disabled;
+    } else {
+        default_startup = (default_startup == startup_mode::enabled) ? startup_mode::enabled : startup_mode::stable;
+    }
+    return this;
+}
+
+CLI11_INLINE App *App::enabled_by_default(bool enable) {
+    if(enable) {
+        default_startup = startup_mode::enabled;
+    } else {
+        default_startup = (default_startup == startup_mode::disabled) ? startup_mode::disabled : startup_mode::stable;
+    }
+    return this;
+}
+
+CLI11_INLINE App *App::allow_config_extras(bool allow) {
+    if(allow) {
+        allow_config_extras_ = ConfigExtrasMode::Capture;
+        allow_extras_ = ExtrasMode::Capture;
+    } else {
+        allow_config_extras_ = ConfigExtrasMode::Error;
+    }
     return this;
 }
 
@@ -275,6 +316,10 @@ CLI11_INLINE Option *App::add_option(std::string option_name,
     return option.get();
 }
 
+CLI11_INLINE Option *App::add_option(std::string option_name) {
+    return add_option(option_name, CLI::callback_t{}, std::string{}, false);
+}
+
 CLI11_INLINE Option *App::set_help_flag(std::string flag_name, const std::string &help_description) {
     // take flag_description by const reference otherwise add_flag tries to assign to help_description
     if(help_ptr_ != nullptr) {
@@ -365,6 +410,10 @@ CLI11_INLINE Option *App::_add_flag_internal(std::string flag_name, CLI::callbac
     opt->expected(0);
     opt->required(false);
     return opt;
+}
+
+CLI11_INLINE Option *App::add_flag(std::string flag_name) {
+    return _add_flag_internal(flag_name, CLI::callback_t(), std::string{});
 }
 
 CLI11_INLINE Option *App::add_flag_callback(std::string flag_name,
@@ -759,6 +808,80 @@ CLI11_INLINE std::vector<App *> App::get_subcommands(const std::function<bool(Ap
     return subcomms;
 }
 
+CLI11_INLINE App *App::require_subcommand(int value) {
+    if(value < 0) {
+        require_subcommand_min_ = 0;
+        require_subcommand_max_ = static_cast<std::size_t>(-value);
+    } else {
+        require_subcommand_min_ = static_cast<std::size_t>(value);
+        require_subcommand_max_ = static_cast<std::size_t>(value);
+    }
+    return this;
+}
+
+CLI11_INLINE App *App::require_option(int value) {
+    if(value < 0) {
+        require_option_min_ = 0;
+        require_option_max_ = static_cast<std::size_t>(-value);
+    } else {
+        require_option_min_ = static_cast<std::size_t>(value);
+        require_option_max_ = static_cast<std::size_t>(value);
+    }
+    return this;
+}
+
+CLI11_INLINE bool App::got_subcommand(const App *subcom) const {
+    // get subcom needed to verify that this was a real subcommand
+    return get_subcommand(subcom)->parsed_ > 0;
+}
+
+CLI11_NODISCARD CLI11_INLINE bool App::got_subcommand(std::string subcommand_name) const noexcept {
+    App *sub = get_subcommand_no_throw(subcommand_name);
+    return (sub != nullptr) ? (sub->parsed_ > 0) : false;
+}
+
+CLI11_INLINE App *App::excludes(Option *opt) {
+    if(opt == nullptr) {
+        throw OptionNotFound("nullptr passed");
+    }
+    exclude_options_.insert(opt);
+    return this;
+}
+
+CLI11_INLINE App *App::excludes(App *app) {
+    if(app == nullptr) {
+        throw OptionNotFound("nullptr passed");
+    }
+    if(app == this) {
+        throw OptionNotFound("cannot self reference in excludes");
+    }
+    auto res = exclude_subcommands_.insert(app);
+    // subcommand exclusion should be symmetric
+    if(res.second) {
+        app->exclude_subcommands_.insert(this);
+    }
+    return this;
+}
+
+CLI11_INLINE App *App::needs(Option *opt) {
+    if(opt == nullptr) {
+        throw OptionNotFound("nullptr passed");
+    }
+    need_options_.insert(opt);
+    return this;
+}
+
+CLI11_INLINE App *App::needs(App *app) {
+    if(app == nullptr) {
+        throw OptionNotFound("nullptr passed");
+    }
+    if(app == this) {
+        throw OptionNotFound("cannot self reference in needs");
+    }
+    need_subcommands_.insert(app);
+    return this;
+}
+
 CLI11_INLINE bool App::remove_excludes(Option *opt) {
     auto iterator = std::find(std::begin(exclude_options_), std::end(exclude_options_), opt);
     if(iterator == std::end(exclude_options_)) {
@@ -795,6 +918,26 @@ CLI11_INLINE bool App::remove_needs(App *app) {
     }
     need_subcommands_.erase(iterator);
     return true;
+}
+
+CLI11_NODISCARD CLI11_INLINE std::string App::config_to_str() const {
+    return config_to_str(ConfigOutputMode::Active, false);
+}
+
+CLI11_NODISCARD CLI11_INLINE std::string App::config_to_str(ConfigOutputMode mode, bool write_description) const {
+    return config_formatter_->to_config(this, mode, write_description, "");
+}
+
+CLI11_NODISCARD CLI11_INLINE std::string App::config_to_str(bool default_also, bool write_description) const {
+    return config_to_str(default_also ? ConfigOutputMode::AllDefaults : ConfigOutputMode::Active, write_description);
+}
+
+CLI11_NODISCARD CLI11_INLINE std::string App::get_usage() const {
+    return (usage_callback_) ? usage_callback_() + '\n' + usage_ : usage_;
+}
+
+CLI11_NODISCARD CLI11_INLINE std::string App::get_footer() const {
+    return (footer_callback_) ? footer_callback_() + '\n' + footer_ : footer_;
 }
 
 CLI11_NODISCARD CLI11_INLINE std::string App::help(std::string prev, AppFormatMode mode) const {
@@ -2495,6 +2638,34 @@ CLI11_INLINE void App::_move_option(Option *opt, App *app) {
     }
 }
 
+CLI11_INLINE Option_group::Option_group(std::string group_description, std::string group_name, App *parent)
+    : App(std::move(group_description), "", parent) {
+    group(group_name);
+    // option groups should have automatic fallthrough
+    if(group_name.empty() || group_name.front() == '+') {
+        // help will not be used by default in these contexts
+        set_help_flag("");
+        set_help_all_flag("");
+    }
+}
+
+CLI11_INLINE Option *Option_group::add_option(Option *opt) {
+    if(get_parent() == nullptr) {
+        throw OptionNotFound("Unable to locate the specified option");
+    }
+    get_parent()->_move_option(opt, this);
+    return opt;
+}
+
+CLI11_INLINE void Option_group::add_options(Option *opt) { add_option(opt); }
+
+CLI11_INLINE App *Option_group::add_subcommand(App *subcom) {
+    App_p subc = subcom->get_parent()->get_subcommand_ptr(subcom);
+    subc->get_parent()->remove_subcommand(subcom);
+    add_subcommand(std::move(subc));
+    return subcom;
+}
+
 CLI11_INLINE void TriggerOn(App *trigger_app, App *app_to_enable) {
     app_to_enable->enabled_by_default(false);
     app_to_enable->disabled_by_default();
@@ -2545,6 +2716,16 @@ CLI11_INLINE void deprecate_option(Option *opt, const std::string &replacement) 
     if(!replacement.empty()) {
         opt->description(opt->get_description() + " DEPRECATED: please use '" + replacement + "' instead");
     }
+}
+
+CLI11_INLINE void deprecate_option(App *app, const std::string &option_name, const std::string &replacement) {
+    auto *opt = app->get_option(option_name);
+    deprecate_option(opt, replacement);
+}
+
+CLI11_INLINE void deprecate_option(App &app, const std::string &option_name, const std::string &replacement) {
+    auto *opt = app.get_option(option_name);
+    deprecate_option(opt, replacement);
 }
 
 CLI11_INLINE void retire_option(App *app, Option *opt) {

--- a/include/CLI/impl/ExtraValidators_inl.hpp
+++ b/include/CLI/impl/ExtraValidators_inl.hpp
@@ -9,7 +9,7 @@
 // IWYU pragma: private, include "CLI/CLI.hpp"
 #include "../ExtraValidators.hpp"
 
-#if (defined(CLI11_ENABLE_EXTRA_VALIDATORS) && CLI11_ENABLE_EXTRA_VALIDATORS == 1) ||                                  \
+#if (defined(CLI11_ENABLE_EXTRA_VALIDATORS) && CLI11_ENABLE_EXTRA_VALIDATORS != 0) ||                                  \
     (!defined(CLI11_DISABLE_EXTRA_VALIDATORS) || CLI11_DISABLE_EXTRA_VALIDATORS == 0)
 
 #include "../Encoding.hpp"

--- a/include/CLI/impl/Option_inl.hpp
+++ b/include/CLI/impl/Option_inl.hpp
@@ -16,6 +16,7 @@
 #include <cerrno>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 // [CLI11:public_includes:end]
@@ -34,6 +35,18 @@ template <typename CRTP> template <typename T> void OptionBase<CRTP>::copy_to(T 
     other->always_capture_default(always_capture_default_);
     other->multi_option_policy(multi_option_policy_);
     other->callback_priority(callback_priority_);
+}
+
+CLI11_INLINE Option::Option(
+    std::string option_name, std::string option_description, callback_t callback, App *parent, bool allow_non_standard)
+    : description_(std::move(option_description)), parent_(parent), callback_(std::move(callback)) {
+    std::tie(snames_, lnames_, pname_) = detail::get_names(detail::split_names(option_name), allow_non_standard);
+}
+
+CLI11_INLINE void Option::clear() {
+    results_.clear();
+    proc_results_.clear();
+    current_option_state_ = option_state::parsing;
 }
 
 CLI11_INLINE Option *Option::expected(int value) {
@@ -175,6 +188,13 @@ CLI11_INLINE Validator *Option::get_validator(int index) {
         return validators_[static_cast<decltype(validators_)::size_type>(index)].get();
     }
     throw OptionNotFound("Validator index is not valid");
+}
+
+CLI11_INLINE Option *Option::needs(Option *opt) {
+    if(opt != this) {
+        needs_.insert(opt);
+    }
+    return this;
 }
 
 CLI11_INLINE bool Option::remove_needs(Option *opt) {
@@ -543,6 +563,31 @@ CLI11_INLINE Option *Option::type_size(int option_type_size_min, int option_type
     }
     if(type_size_max_ >= detail::expected_max_vector_size) {
         inject_separator_ = true;
+    }
+    return this;
+}
+
+CLI11_NODISCARD CLI11_INLINE const std::string &Option::get_single_name() const {
+    if(!lnames_.empty()) {
+        return lnames_[0];
+    }
+    if(!snames_.empty()) {
+        return snames_[0];
+    }
+    if(!pname_.empty()) {
+        return pname_;
+    }
+    return envname_;
+}
+
+CLI11_INLINE Option *Option::type_name(std::string typeval) {
+    type_name_fn([typeval]() { return typeval; });
+    return this;
+}
+
+CLI11_INLINE Option *Option::capture_default_str() {
+    if(default_function_) {
+        default_str_ = default_function_();
     }
     return this;
 }

--- a/include/CLI/impl/Validators_inl.hpp
+++ b/include/CLI/impl/Validators_inl.hpp
@@ -15,6 +15,7 @@
 #include "../TypeTools.hpp"
 
 // [CLI11:public_includes:set]
+#include <functional>
 #include <map>
 #include <string>
 #include <utility>
@@ -22,6 +23,15 @@
 
 namespace CLI {
 // [CLI11:validators_inl_hpp:verbatim]
+
+CLI11_INLINE Validator::Validator(std::string validator_desc, std::function<std::string(std::string &)> func)
+    : desc_function_([validator_desc]() { return validator_desc; }), func_(std::move(func)) {}
+
+CLI11_INLINE Validator::Validator(std::function<std::string(std::string &)> op,
+                                  std::string validator_desc,
+                                  std::string validator_name)
+    : desc_function_([validator_desc]() { return validator_desc; }), func_(std::move(op)),
+      name_(std::move(validator_name)) {}
 
 CLI11_INLINE std::string Validator::operator()(std::string &str) const {
     std::string retstring;
@@ -36,9 +46,39 @@ CLI11_INLINE std::string Validator::operator()(std::string &str) const {
     return retstring;
 }
 
+CLI11_INLINE std::string Validator::operator()(const std::string &str) const {
+    std::string value = str;
+    return (active_) ? func_(value) : std::string{};
+}
+
 CLI11_NODISCARD CLI11_INLINE Validator Validator::description(std::string validator_desc) const {
     Validator newval(*this);
     newval.desc_function_ = [validator_desc]() { return validator_desc; };
+    return newval;
+}
+
+CLI11_NODISCARD CLI11_INLINE std::string Validator::get_description() const {
+    if(active_) {
+        return desc_function_();
+    }
+    return std::string{};
+}
+
+CLI11_NODISCARD CLI11_INLINE Validator Validator::name(std::string validator_name) const {
+    Validator newval(*this);
+    newval.name_ = std::move(validator_name);
+    return newval;
+}
+
+CLI11_NODISCARD CLI11_INLINE Validator Validator::active(bool active_val) const {
+    Validator newval(*this);
+    newval.active_ = active_val;
+    return newval;
+}
+
+CLI11_NODISCARD CLI11_INLINE Validator Validator::application_index(int app_index) const {
+    Validator newval(*this);
+    newval.application_index_ = app_index;
     return newval;
 }
 


### PR DESCRIPTION
See #1414.

:robot: _AI text below_ :robot:

Move the remaining substantive non-template function bodies out of `App.hpp`, `Option.hpp`, and `Validators.hpp` into their existing `impl/*_inl.hpp` files, so they compile into the static library in precompiled mode. Trivial one-line accessors intentionally stay in the headers, as do the hot-path helpers (`Option::check_?name`, `get_items_expected_max`).

Small related fixes found during the review:

- The two `deprecate_option(App...)` helpers used plain `inline` with in-header bodies; they now use `CLI11_INLINE` with out-of-line bodies like their `retire_option` siblings.
- `ExtraValidators_inl.hpp` gated on `CLI11_ENABLE_EXTRA_VALIDATORS == 1` while the header uses `!= 0`; the expressions now match.
- `ReadPermissions`/`WritePermissions`/`ExecPermissions`/`NonEmptyFile` now carry `CLI11_MODULE_INLINE` like every other global validator.

Verified beyond CI-equivalent runs: both `dev` (precompiled) and `default` (header-only) workflows pass locally, and the generated single header compiles standalone in C++11 mode.