### PR TITLE
refactor: move the two non-template functions out of TypeTools.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ set(CLI11_impl_headers
     ${CLI11_headerLoc}/impl/Option_inl.hpp
     ${CLI11_headerLoc}/impl/Split_inl.hpp
     ${CLI11_headerLoc}/impl/StringTools_inl.hpp
+    ${CLI11_headerLoc}/impl/TypeTools_inl.hpp
     ${CLI11_headerLoc}/impl/Validators_inl.hpp
     ${CLI11_headerLoc}/impl/ExtraValidators_inl.hpp
     ${CLI11_headerLoc}/impl/Encoding_inl.hpp

--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -26,6 +26,7 @@
 // [CLI11:public_includes:end]
 
 #include "Encoding.hpp"
+#include "Macros.hpp"
 #include "StringTools.hpp"
 
 namespace CLI {
@@ -1078,52 +1079,7 @@ bool integral_conversion(const std::string &input, T &output) noexcept {
 }
 
 /// Convert a flag into an integer value  typically binary flags sets errno to nonzero if conversion failed
-inline std::int64_t to_flag_value(std::string val) noexcept {
-    static const std::string trueString("true");
-    static const std::string falseString("false");
-    if(val == trueString) {
-        return 1;
-    }
-    if(val == falseString) {
-        return -1;
-    }
-    val = detail::to_lower(std::move(val));
-    std::int64_t ret = 0;
-    if(val.size() == 1) {
-        if(val[0] >= '1' && val[0] <= '9') {
-            return (static_cast<std::int64_t>(val[0]) - '0');
-        }
-        switch(val[0]) {
-        case '0':
-        case 'f':
-        case 'n':
-        case '-':
-            ret = -1;
-            break;
-        case 't':
-        case 'y':
-        case '+':
-            ret = 1;
-            break;
-        default:
-            errno = EINVAL;
-            return -1;
-        }
-        return ret;
-    }
-    if(val == trueString || val == "on" || val == "yes" || val == "enable") {
-        ret = 1;
-    } else if(val == falseString || val == "off" || val == "no" || val == "disable") {
-        ret = -1;
-    } else {
-        char *loc_ptr{nullptr};
-        ret = std::strtoll(val.c_str(), &loc_ptr, 0);
-        if(loc_ptr != (val.c_str() + val.size()) && errno == 0) {
-            errno = EINVAL;
-        }
-    }
-    return ret;
-}
+CLI11_INLINE std::int64_t to_flag_value(std::string val) noexcept;
 
 /// Integer conversion
 template <typename T,
@@ -1875,59 +1831,12 @@ bool lexical_conversion(const std::vector<std::string> &strings, AssignTo &outpu
 }
 
 /// Sum a vector of strings
-inline std::string sum_string_vector(const std::vector<std::string> &values) {
-    // First try a pure integer sum so that large integral totals (>= 1e16, or beyond the 2^53 mantissa of
-    // double) are preserved exactly and rendered as a plain integer rather than scientific notation
-    std::int64_t ival{0};
-    bool int_sum{true};
-    for(const auto &arg : values) {
-        std::int64_t tv{0};
-        if(!integral_conversion(arg, tv)) {
-            int_sum = false;
-            break;
-        }
-        // detect signed overflow before performing the addition since signed overflow is undefined behavior
-        if((tv > 0 && ival > (std::numeric_limits<std::int64_t>::max)() - tv) ||
-           (tv < 0 && ival < (std::numeric_limits<std::int64_t>::min)() - tv)) {
-            int_sum = false;
-            break;
-        }
-        ival += tv;
-    }
-    if(int_sum) {
-        return std::to_string(ival);
-    }
-
-    double val{0.0};
-    bool fail{false};
-    std::string output;
-    for(const auto &arg : values) {
-        double tv{0.0};
-        auto comp = lexical_cast(arg, tv);
-        if(!comp) {
-            errno = 0;
-            auto fv = detail::to_flag_value(arg);
-            fail = (errno != 0);
-            if(fail) {
-                break;
-            }
-            tv = static_cast<double>(fv);
-        }
-        val += tv;
-    }
-    if(fail) {
-        for(const auto &arg : values) {
-            output.append(arg);
-        }
-    } else {
-        std::ostringstream out;
-        out.precision(16);
-        out << val;
-        output = out.str();
-    }
-    return output;
-}
+CLI11_INLINE std::string sum_string_vector(const std::vector<std::string> &values);
 
 }  // namespace detail
 // [CLI11:type_tools_hpp:end]
 }  // namespace CLI
+
+#ifndef CLI11_COMPILE
+#include "impl/TypeTools_inl.hpp"  // IWYU pragma: export
+#endif

--- a/include/CLI/impl/TypeTools_inl.hpp
+++ b/include/CLI/impl/TypeTools_inl.hpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2017-2026, University of Cincinnati, developed by Henry Schreiner
+// under NSF AWARD 1414736 and by the respective contributors.
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+// IWYU pragma: private, include "CLI/CLI.hpp"
+
+// This include is only needed for IDEs to discover symbols
+#include "../TypeTools.hpp"
+
+#include "../StringTools.hpp"
+
+// [CLI11:public_includes:set]
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+// [CLI11:public_includes:end]
+
+namespace CLI {
+// [CLI11:type_tools_inl_hpp:verbatim]
+
+namespace detail {
+
+CLI11_INLINE std::int64_t to_flag_value(std::string val) noexcept {
+    static const std::string trueString("true");
+    static const std::string falseString("false");
+    if(val == trueString) {
+        return 1;
+    }
+    if(val == falseString) {
+        return -1;
+    }
+    val = detail::to_lower(std::move(val));
+    std::int64_t ret = 0;
+    if(val.size() == 1) {
+        if(val[0] >= '1' && val[0] <= '9') {
+            return (static_cast<std::int64_t>(val[0]) - '0');
+        }
+        switch(val[0]) {
+        case '0':
+        case 'f':
+        case 'n':
+        case '-':
+            ret = -1;
+            break;
+        case 't':
+        case 'y':
+        case '+':
+            ret = 1;
+            break;
+        default:
+            errno = EINVAL;
+            return -1;
+        }
+        return ret;
+    }
+    if(val == trueString || val == "on" || val == "yes" || val == "enable") {
+        ret = 1;
+    } else if(val == falseString || val == "off" || val == "no" || val == "disable") {
+        ret = -1;
+    } else {
+        char *loc_ptr{nullptr};
+        ret = std::strtoll(val.c_str(), &loc_ptr, 0);
+        if(loc_ptr != (val.c_str() + val.size()) && errno == 0) {
+            errno = EINVAL;
+        }
+    }
+    return ret;
+}
+
+CLI11_INLINE std::string sum_string_vector(const std::vector<std::string> &values) {
+    // First try a pure integer sum so that large integral totals (>= 1e16, or beyond the 2^53 mantissa of
+    // double) are preserved exactly and rendered as a plain integer rather than scientific notation
+    std::int64_t ival{0};
+    bool int_sum{true};
+    for(const auto &arg : values) {
+        std::int64_t tv{0};
+        if(!integral_conversion(arg, tv)) {
+            int_sum = false;
+            break;
+        }
+        // detect signed overflow before performing the addition since signed overflow is undefined behavior
+        if((tv > 0 && ival > (std::numeric_limits<std::int64_t>::max)() - tv) ||
+           (tv < 0 && ival < (std::numeric_limits<std::int64_t>::min)() - tv)) {
+            int_sum = false;
+            break;
+        }
+        ival += tv;
+    }
+    if(int_sum) {
+        return std::to_string(ival);
+    }
+
+    double val{0.0};
+    bool fail{false};
+    std::string output;
+    for(const auto &arg : values) {
+        double tv{0.0};
+        auto comp = lexical_cast(arg, tv);
+        if(!comp) {
+            errno = 0;
+            auto fv = detail::to_flag_value(arg);
+            fail = (errno != 0);
+            if(fail) {
+                break;
+            }
+            tv = static_cast<double>(fv);
+        }
+        val += tv;
+    }
+    if(fail) {
+        for(const auto &arg : values) {
+            output.append(arg);
+        }
+    } else {
+        std::ostringstream out;
+        out.precision(16);
+        out << val;
+        output = out.str();
+    }
+    return output;
+}
+
+}  // namespace detail
+// [CLI11:type_tools_inl_hpp:end]
+}  // namespace CLI

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,7 @@ cli11_impl_headers = files(
   'include/CLI/impl/Option_inl.hpp',
   'include/CLI/impl/Split_inl.hpp',
   'include/CLI/impl/StringTools_inl.hpp',
+  'include/CLI/impl/TypeTools_inl.hpp',
   'include/CLI/impl/Validators_inl.hpp',
   'include/CLI/impl/ExtraValidators_inl.hpp',
 )

--- a/single-include/CLI11.hpp.in
+++ b/single-include/CLI11.hpp.in
@@ -66,6 +66,8 @@ namespace {namespace} {{
 
 {type_tools_hpp}
 
+{type_tools_inl_hpp}
+
 {split_hpp}
 
 {split_inl_hpp}

--- a/src/Precompile.cpp
+++ b/src/Precompile.cpp
@@ -22,6 +22,7 @@
 #include <CLI/impl/Option_inl.hpp>
 #include <CLI/impl/Split_inl.hpp>
 #include <CLI/impl/StringTools_inl.hpp>
+#include <CLI/impl/TypeTools_inl.hpp>
 #include <CLI/impl/Validators_inl.hpp>
 
 // IWYU pragma: end_keep


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #1415. TypeTools.hpp is all templates except two functions: `detail::to_flag_value` and `detail::sum_string_vector` (~100 lines). This moves them into a new `impl/TypeTools_inl.hpp` so they compile into the library in precompiled mode. `sum_string_vector` was already only called from `Option_inl.hpp`, and `to_flag_value`'s two function-local `static const std::string`s no longer emit per-TU thread-safe-static guards.

Plumbing for the new file: `src/Precompile.cpp`, `CLI11_impl_headers` in CMakeLists.txt, `meson.build`, a `{type_tools_inl_hpp}` slot in `single-include/CLI11.hpp.in`, and the standard `#ifndef CLI11_COMPILE` include at the bottom of TypeTools.hpp (which previously had none). TypeTools.hpp now includes `Macros.hpp` directly for `CLI11_INLINE`.

Verified beyond CI-equivalent runs: `dev` (precompiled) and `default` (header-only) workflows pass, the generated single header compiles standalone at C++11, and the C++20 module (`CLI11_MODULES=ON`, Homebrew clang 22) builds — its only warning is the pre-existing `wstring_convert` deprecation in Encoding_inl.hpp. Client compile time is unchanged (within noise), as expected for ~100 lines.