### PR TITLE
refactor: move ConfigFwd/FormatterFwd bodies to the _inl files

### DIFF
--- a/include/CLI/ConfigFwd.hpp
+++ b/include/CLI/ConfigFwd.hpp
@@ -40,12 +40,7 @@ struct ConfigItem {
     /// @brief indicator if a multiline vector separator was inserted
     bool multiline{false};
     /// The list of parents and name joined by "."
-    CLI11_NODISCARD std::string fullname() const {
-        std::vector<std::string> tmp = parents;
-        tmp.emplace_back(name);
-        return detail::join(tmp, ".");
-        (void)multiline;  // suppression for cppcheck false positive
-    }
+    CLI11_NODISCARD std::string fullname() const;
 };
 
 /// This class provides a converter for configuration files.
@@ -59,23 +54,13 @@ class Config {
 
     /// Convert an app into a configuration
     virtual std::string
-    to_config(const App *app, ConfigOutputMode mode, bool write_description, std::string prefix) const {
-        return to_config(app, mode != ConfigOutputMode::Active, write_description, std::move(prefix));
-    }
+    to_config(const App *app, ConfigOutputMode mode, bool write_description, std::string prefix) const;
 
     /// Convert a configuration into an app
     virtual std::vector<ConfigItem> from_config(std::istream &) const = 0;
 
     /// Get a flag value
-    CLI11_NODISCARD virtual std::string to_flag(const ConfigItem &item) const {
-        if(item.inputs.size() == 1) {
-            return item.inputs.at(0);
-        }
-        if(item.inputs.empty()) {
-            return "{}";
-        }
-        throw ConversionError::TooManyInputsFlag(item.fullname());  // LCOV_EXCL_LINE
-    }
+    CLI11_NODISCARD virtual std::string to_flag(const ConfigItem &item) const;
 
     /// Parse a config file, throw an error (ParseError:ConfigParseError or FileError) on failure
     CLI11_NODISCARD std::vector<ConfigItem> from_file(const std::string &name) const;
@@ -197,13 +182,7 @@ using ConfigTOML = ConfigBase;
 class ConfigINI : public ConfigTOML {
 
   public:
-    ConfigINI() {
-        commentChar = ';';
-        arrayStart = '\0';
-        arrayEnd = '\0';
-        arraySeparator = ' ';
-        valueDelimiter = '=';
-    }
+    ConfigINI();
 };
 // [CLI11:config_fwd_hpp:end]
 }  // namespace CLI

--- a/include/CLI/FormatterFwd.hpp
+++ b/include/CLI/FormatterFwd.hpp
@@ -104,10 +104,7 @@ class FormatterBase {
 
     /// Set the alignment ratio for long options within the left column
     /// The ratio is in [0;1] range (e.g. 0.2 = 20% of column width, 6.f/column_width = 6th character)
-    void long_option_alignment_ratio(float ratio) {
-        long_option_alignment_ratio_ =
-            (ratio >= 0.0f) ? ((ratio <= 1.0f) ? ratio : 1.0f / ratio) : ((ratio < -1.0f) ? 1.0f / (-ratio) : -ratio);
-    }
+    void long_option_alignment_ratio(float ratio);
 
     /// Set the right column width (description of options/flags/subcommands)
     void right_column_width(std::size_t val) { right_column_width_ = val; }
@@ -133,10 +130,7 @@ class FormatterBase {
     ///@{
 
     /// Get the current value of a name (REQUIRED, etc.)
-    CLI11_NODISCARD std::string get_label(std::string key) const {
-        auto it = labels_.find(key);
-        return it != labels_.end() ? it->second : default_label(key);
-    }
+    CLI11_NODISCARD std::string get_label(std::string key) const;
 
     /// Get the current left column width (options/flags/subcommands)
     CLI11_NODISCARD std::size_t get_column_width() const { return column_width_; }
@@ -181,15 +175,13 @@ class FormatterLambda final : public FormatterBase {
 
   public:
     /// Create a FormatterLambda with a lambda function
-    explicit FormatterLambda(funct_t funct) : lambda_(std::move(funct)) {}
+    explicit FormatterLambda(funct_t funct);
 
     /// Adding a destructor (mostly to make GCC 4.7 happy)
     ~FormatterLambda() noexcept override {}  // NOLINT(modernize-use-equals-default)
 
     /// This will simply call the lambda function
-    std::string make_help(const App *app, std::string name, AppFormatMode mode) const override {
-        return lambda_(app, name, mode);
-    }
+    std::string make_help(const App *app, std::string name, AppFormatMode mode) const override;
 };
 
 /// This is the default Formatter for CLI11. It pretty prints help output, and is broken into quite a few

--- a/include/CLI/impl/Config_inl.hpp
+++ b/include/CLI/impl/Config_inl.hpp
@@ -27,6 +27,28 @@
 namespace CLI {
 // [CLI11:config_inl_hpp:verbatim]
 
+CLI11_NODISCARD CLI11_INLINE std::string ConfigItem::fullname() const {
+    std::vector<std::string> tmp = parents;
+    tmp.emplace_back(name);
+    return detail::join(tmp, ".");
+    (void)multiline;  // suppression for cppcheck false positive
+}
+
+CLI11_INLINE std::string
+Config::to_config(const App *app, ConfigOutputMode mode, bool write_description, std::string prefix) const {
+    return to_config(app, mode != ConfigOutputMode::Active, write_description, std::move(prefix));
+}
+
+CLI11_NODISCARD CLI11_INLINE std::string Config::to_flag(const ConfigItem &item) const {
+    if(item.inputs.size() == 1) {
+        return item.inputs.at(0);
+    }
+    if(item.inputs.empty()) {
+        return "{}";
+    }
+    throw ConversionError::TooManyInputsFlag(item.fullname());  // LCOV_EXCL_LINE
+}
+
 CLI11_INLINE std::vector<ConfigItem> Config::from_file(const std::string &name) const {
 #if defined CLI11_HAS_FILESYSTEM && CLI11_HAS_FILESYSTEM > 0
     std::ifstream input{to_path(name)};
@@ -773,6 +795,14 @@ ConfigBase::to_config(const App *app, ConfigOutputMode mode, bool write_descript
         return outString + out.str();
     }
     return out.str();
+}
+
+CLI11_INLINE ConfigINI::ConfigINI() {
+    commentChar = ';';
+    arrayStart = '\0';
+    arrayEnd = '\0';
+    arraySeparator = ' ';
+    valueDelimiter = '=';
 }
 // [CLI11:config_inl_hpp:end]
 }  // namespace CLI

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -40,6 +40,22 @@ CLI11_INLINE std::string indent_block(const std::string &input, const std::strin
 }
 }  // namespace detail
 
+CLI11_INLINE void FormatterBase::long_option_alignment_ratio(float ratio) {
+    long_option_alignment_ratio_ =
+        (ratio >= 0.0f) ? ((ratio <= 1.0f) ? ratio : 1.0f / ratio) : ((ratio < -1.0f) ? 1.0f / (-ratio) : -ratio);
+}
+
+CLI11_NODISCARD CLI11_INLINE std::string FormatterBase::get_label(std::string key) const {
+    auto it = labels_.find(key);
+    return it != labels_.end() ? it->second : default_label(key);
+}
+
+CLI11_INLINE FormatterLambda::FormatterLambda(funct_t funct) : lambda_(std::move(funct)) {}
+
+CLI11_INLINE std::string FormatterLambda::make_help(const App *app, std::string name, AppFormatMode mode) const {
+    return lambda_(app, name, mode);
+}
+
 CLI11_INLINE std::string
 Formatter::make_group(std::string group, bool is_positional, std::vector<const Option *> opts) const {
     std::stringstream out;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Continues #1415/#1416. Move the remaining non-trivial bodies out of the two forward headers into the existing `_inl` files (no new files or build plumbing needed):

- `ConfigFwd.hpp` → `Config_inl.hpp`: `ConfigItem::fullname`, the non-pure `Config::to_config` overload, `Config::to_flag`, and the `ConfigINI` constructor.
- `FormatterFwd.hpp` → `Formatter_inl.hpp`: `FormatterBase::long_option_alignment_ratio`, `FormatterBase::get_label`, and the `FormatterLambda` constructor and `make_help` override.

The trivial chaining setters and accessors stay in the headers. Moving the virtual functions out of line anchors the `Config` and `FormatterLambda` vtables in the precompiled library; header-only mode is unchanged (`CLI11_INLINE` = `inline`).

Verified beyond CI: single-file generation with a C++11 syntax check, and the `CLI11_MODULES=ON` C++20 build with Homebrew clang 22.