### PR TITLE
fix(bazel): propagate CLI11_COMPILE to consumers with defines

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,3 +7,11 @@ cc_library(
     strip_include_prefix = "/include",
     visibility = ["//visibility:public"],
 )
+
+# Header-only mode, like the CMake target without CLI11_PRECOMPILED
+cc_library(
+    name = "cli11_header_only",
+    hdrs = glob(["include/**/*.hpp"]),
+    strip_include_prefix = "/include",
+    visibility = ["//visibility:public"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,9 +1,19 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# CLI::argv() needs CommandLineToArgvW from shell32 on Windows
+WINDOWS_LINKOPTS = select({
+    "@rules_cc//cc/compiler:msvc-cl": ["-DEFAULTLIB:shell32.lib"],
+    "@rules_cc//cc/compiler:clang-cl": ["-DEFAULTLIB:shell32.lib"],
+    "@rules_cc//cc/compiler:mingw-gcc": ["-lshell32"],
+    "//conditions:default": [],
+})
+
 cc_library(
     name = "cli11",
     srcs = glob(["src/**/*.cpp"]),
     hdrs = glob(["include/**/*.hpp"]),
     defines = ["CLI11_COMPILE", "CLI11_ENABLE_EXTRA_VALIDATORS=1"],
+    linkopts = WINDOWS_LINKOPTS,
     strip_include_prefix = "/include",
     visibility = ["//visibility:public"],
 )
@@ -12,6 +22,7 @@ cc_library(
 cc_library(
     name = "cli11_header_only",
     hdrs = glob(["include/**/*.hpp"]),
+    linkopts = WINDOWS_LINKOPTS,
     strip_include_prefix = "/include",
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,7 @@ cc_library(
     name = "cli11",
     srcs = glob(["src/**/*.cpp"]),
     hdrs = glob(["include/**/*.hpp"]),
-    local_defines = ["CLI11_COMPILE", "CLI11_ENABLE_EXTRA_VALIDATORS=1"],
+    defines = ["CLI11_COMPILE", "CLI11_ENABLE_EXTRA_VALIDATORS=1"],
     strip_include_prefix = "/include",
     visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,5 +3,5 @@ module(
     bazel_compatibility = [">=7.4.0"],
 )
 
-bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "catch2", version = "3.12.0", dev_dependency = True)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -46,6 +46,46 @@ cc_test(
 )
 
 cc_test(
+    name = "TimerTest",
+    srcs = ["TimerTest.cpp"],
+    deps = [
+        "catch_main",
+        "//:cli11",
+        "@catch2",
+    ],
+    linkopts = select({
+        "@rules_cc//cc/compiler:msvc-cl": [],
+        "@rules_cc//cc/compiler:clang-cl": [],
+        "//conditions:default": ["-pthread"],
+    }),
+)
+
+# Verifies there are no unguarded inlines (duplicate symbols across TUs)
+[
+    (
+        cc_library(
+            name = "link_test_1" + suffix,
+            srcs = ["link_test_1.cpp"],
+            deps = [lib],
+        ),
+        cc_test(
+            name = "link_test_2" + suffix,
+            srcs = ["link_test_2.cpp"],
+            deps = [
+                "catch_main",
+                "link_test_1" + suffix,
+                lib,
+                "@catch2",
+            ],
+        ),
+    )
+    for suffix, lib in [
+        ("", "//:cli11"),
+        ("_header_only", "//:cli11_header_only"),
+    ]
+]
+
+cc_test(
     name = "SimpleTestHeaderOnly",
     srcs = [
         "SimpleTest.cpp",
@@ -90,6 +130,8 @@ cc_test(
         "ComplexTypeTest",
         "TrueFalseTest",
         "OptionGroupTest",
+        "ExtraValidatorsTest",
+        "localeTest",
         "EncodingTest",
     ]
 ]

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -45,6 +45,19 @@ cc_test(
     }),
 )
 
+cc_test(
+    name = "SimpleTestHeaderOnly",
+    srcs = [
+        "SimpleTest.cpp",
+        "app_helper.hpp",
+    ],
+    deps = [
+        "catch_main",
+        "//:cli11_header_only",
+        "@catch2",
+    ],
+)
+
 [
     cc_test(
         name = test,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #1419.

The Bazel target set `CLI11_COMPILE` and `CLI11_ENABLE_EXTRA_VALIDATORS=1` with `local_defines`, which applies only to CLI11's own sources. Consumers did not get the defines, so their translation units generated the inline header implementations while also linking the precompiled objects. The duplicate symbols can cause a segfault through ELF symbol interposition when a shared `libcli11.so` is retained (the `cc_test` link path on Linux).

Change `local_defines` to `defines`, the Bazel equivalent of the `PUBLIC` compile definitions used in the CMake precompiled mode. Consumers now get their implementations only from the compiled library, and the in-repo Bazel tests now exercise the true precompiled configuration.

Additional changes to better match the CMake build:

- Add a `cli11_header_only` target, equivalent to the CMake target without `CLI11_PRECOMPILED`, and compile `SimpleTest` against it. Extra validators are on by default in the headers, so that target needs no defines.
- Link `shell32` on Windows (both targets), matching the `PUBLIC` link in CMake; `CLI::argv()` needs `CommandLineToArgvW`.
- Add the two-TU link test (`link_test_1`/`link_test_2`) against both targets — this is the regression test for the class of bug in #1419.
- Add `TimerTest`, `ExtraValidatorsTest`, and `localeTest`, which were in the CMake test list but not the Bazel one.

All 26 Bazel tests pass locally on macOS.