### PR TITLE
feat: show the option delimiter in the help text

### DIFF
--- a/book/chapters/formatting.md
+++ b/book/chapters/formatting.md
@@ -82,6 +82,11 @@ be turned off in the help output through `enable_option_defaults(false)`. The
 `enable_option_type_names(false)`. and the `{false}` or flag default values can
 be turned off using `enable_default_flag_values(false)`.
 
+An option with a delimiter shows it on the type name, so `--opt TEXT,...` takes
+values such as `a,b,c`. A trailing `...` is separate, it means the option also
+takes values separated by spaces. The delimiter is part of the type name, so
+`enable_option_type_names(false)` hides it as well.
+
 ## Subclassing
 
 You can further configure pieces of the code while still keeping most of the

--- a/include/CLI/impl/Formatter_inl.hpp
+++ b/include/CLI/impl/Formatter_inl.hpp
@@ -443,8 +443,12 @@ CLI11_INLINE std::string Formatter::make_option_opts(const Option *opt) const {
     } else {
         if(opt->get_type_size() != 0) {
             if(enable_option_type_names_) {
-                if(!opt->get_type_name().empty())
+                if(!opt->get_type_name().empty()) {
                     out << " " << get_label(opt->get_type_name());
+                    // Show the delimiter on the type, a trailing "..." only means space separated values
+                    if(opt->get_delimiter() != '\0')
+                        out << opt->get_delimiter() << "...";
+                }
             }
             if(enable_option_defaults_) {
                 if(!opt->get_default_str().empty())

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -1680,3 +1680,35 @@ TEST_CASE("TVersion: exit_with_required", "[help]") {
         CHECK(0 == ret);
     }
 }
+
+TEST_CASE("THelp: Delimiter", "[help]") {
+    CLI::App app{"My prog"};
+
+    std::vector<std::string> greedy;
+    app.add_option("--greedy", greedy, "Greedy")->delimiter(',');
+
+    std::vector<std::string> single;
+    app.add_option("--single", single, "Single")->delimiter(',')->allow_extra_args(false);
+
+    std::vector<std::string> plain;
+    app.add_option("--plain", plain, "Plain");
+
+    std::string help = app.help();
+
+    // A greedy option keeps the trailing ellipsis for the extra arguments it takes
+    CHECK_THAT(help, Contains("--greedy TEXT,... ..."));
+    CHECK_THAT(help, Contains("--single TEXT,..."));
+    CHECK_THAT(help, Contains("--plain TEXT ..."));
+}
+
+TEST_CASE("THelp: DelimiterNoTypeNames", "[help]") {
+    CLI::App app{"My prog"};
+
+    std::vector<std::string> val;
+    app.add_option("--opt", val, "Option")->delimiter(',');
+    app.get_formatter()->enable_option_type_names(false);
+
+    std::string help = app.help();
+
+    CHECK_THAT(help, !Contains(",..."));
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Second item of #1423: a `delimiter()` was invisible in the help, so `--opt a,b` looked no different from any other value.

The delimiter now prints on the type name:

```text
  --greedy TEXT,... ...       Greedy
  --single TEXT,...           Single
  --plain TEXT ...            Plain
```

A trailing ` ...` keeps its current meaning, the option also takes values separated by spaces. So `--greedy` shows both markers, while `--single` (`allow_extra_args(false)`) shows only the delimited form. `enable_option_type_names(false)` hides the marker with the type name.

Docs updated in `book/chapters/formatting.md`. Depends on nothing, but pairs with #1424.