### PR TITLE
ci: only let codecov comment when coverage changes

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,6 +3,11 @@ codecov:
   notify:
     after_n_builds: 8
 
+# Only comment when the coverage numbers actually move
+comment:
+  after_n_builds: 8
+  require_changes: true
+
 ignore:
   - "tests"
   - "examples"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Codecov posts a comment on every PR, including ones that do not move coverage. This adds a `comment:` block to `.github/codecov.yml` with `require_changes: true`, so a comment appears only when the coverage numbers change, and `after_n_builds: 8` so it waits for all coverage uploads like the existing notify setting.

Config validated with `codecov.io/validate`.