### PR TITLE
fix: preserve precision in floating-point default values

### DIFF
--- a/include/CLI/TypeTools.hpp
+++ b/include/CLI/TypeTools.hpp
@@ -15,6 +15,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <iomanip>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -468,11 +470,20 @@ template <typename T1,
 std::string checked_to_string(T &&) {
     return std::string{};
 }
-/// get a string as a convertible value for arithmetic types
-template <typename T, enable_if_t<std::is_arithmetic<T>::value, detail::enabler> = detail::dummy>
+/// get a string as a convertible value for integral types
+template <typename T, enable_if_t<std::is_integral<T>::value, detail::enabler> = detail::dummy>
 std::string value_string(const T &value) {
     return std::to_string(value);
 }
+
+/// get a string as a convertible value for floating-point types
+template <typename T, enable_if_t<std::is_floating_point<T>::value, detail::enabler> = detail::dummy>
+std::string value_string(const T &value) {
+    std::ostringstream stream;
+    stream << std::setprecision(std::numeric_limits<T>::max_digits10) << value;
+    return stream.str();
+}
+
 /// get a string as a convertible value for enumerations
 template <typename T, enable_if_t<std::is_enum<T>::value, detail::enabler> = detail::dummy>
 std::string value_string(const T &value) {

--- a/tests/AppTest.cpp
+++ b/tests/AppTest.cpp
@@ -487,6 +487,18 @@ TEST_CASE_METHOD(TApp, "OneStringFlagLike", "[app]") {
     CHECK(str.empty());
 }
 
+TEST_CASE_METHOD(TApp, "SmallFloatingPointDefaultVal", "[app]") {
+    double value = 0.0;
+
+    auto *opt = app.add_option("--value", value);
+
+    opt->default_val(1e-8);
+
+    run();
+
+    CHECK(value == Approx(1e-8));
+}
+
 TEST_CASE_METHOD(TApp, "OneIntFlagLike", "[app]") {
     int val{0};
     auto *opt = app.add_option("-i", val)->expected(0, 1);


### PR DESCRIPTION
Closes #1429 

`default_val()` uses `detail::value_string()` to convert values to strings before parsing them back. For floating-point values, this relied on `std::to_string`, which can lose precision for small values such as `1e-8`, producing `"0.000000"`.

This change separates integral and floating-point handling in `value_string()`:

- Integral types continue to use `std::to_string`.
- Floating-point types use a precision-preserving stream conversion with `std::numeric_limits<T>::max_digits10`.

A regression test was added to verify that small floating-point default values such as `1e-8` are preserved correctly.

Validation performed locally:
- Full test suite passes.
- Formatting checks pass with `prek`.
- Additional round-trip checks were performed for `float`, `double`, and `long double`.