### PR TITLE
fix(windows): link shell32 via pragma for header-only MSVC (#1053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog {#changelog}
 
-## Version 2.7.3: Explicit shell32 for MSVC headers
-
-### Fixed
-
-- Link `shell32` for MSVC/clang-cl even when CLI11 is used as headers without
-  the CMake or Bazel target, via `#pragma comment(lib, "shell32.lib")` next to
-  `CommandLineToArgvW`. CMake/`shell32` and Bazel `DEFAULTLIB:shell32.lib`
-  remain for MinGW and target-based builds. Fixes [#1053][].
-
-[#1053]: https://github.com/CLIUtils/CLI11/issues/1053
-
 ## Version 2.7.2: Faster compiles
 
 This patch release makes the precompiled and experimental module modes cheaper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog {#changelog}
 
+## Version 2.7.3: Explicit shell32 for MSVC headers
+
+### Fixed
+
+- Link `shell32` for MSVC/clang-cl even when CLI11 is used as headers without the
+  CMake or Bazel target, via `#pragma comment(lib, "shell32.lib")` next to
+  `CommandLineToArgvW`. CMake/`shell32` and Bazel `DEFAULTLIB:shell32.lib` remain
+  for MinGW and target-based builds. Fixes [#1053][].
+
+[#1053]: https://github.com/CLIUtils/CLI11/issues/1053
+
 ## Version 2.7.2: Faster compiles
 
 This patch release makes the precompiled and experimental module modes cheaper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Fixed
 
-- Link `shell32` for MSVC/clang-cl even when CLI11 is used as headers without the
-  CMake or Bazel target, via `#pragma comment(lib, "shell32.lib")` next to
-  `CommandLineToArgvW`. CMake/`shell32` and Bazel `DEFAULTLIB:shell32.lib` remain
-  for MinGW and target-based builds. Fixes [#1053][].
+- Link `shell32` for MSVC/clang-cl even when CLI11 is used as headers without
+  the CMake or Bazel target, via `#pragma comment(lib, "shell32.lib")` next to
+  `CommandLineToArgvW`. CMake/`shell32` and Bazel `DEFAULTLIB:shell32.lib`
+  remain for MinGW and target-based builds. Fixes [#1053][].
 
 [#1053]: https://github.com/CLIUtils/CLI11/issues/1053
 

--- a/include/CLI/impl/Argv_inl.hpp
+++ b/include/CLI/impl/Argv_inl.hpp
@@ -54,7 +54,8 @@
 #include <shellapi.h>
 // CommandLineToArgvW lives in shell32. CMake/Bazel already link it when using the
 // CLI11 targets; this pragma covers MSVC/clang-cl consumers that only include the
-// headers (or clear CMAKE_CXX_STANDARD_LIBRARIES). See #1053.
+// headers (or clear CMAKE_CXX_STANDARD_LIBRARIES). See #1053 and
+// https://learn.microsoft.com/en-us/cpp/preprocessor/comment-c-cpp#lib
 #if defined(_MSC_VER)
 #pragma comment(lib, "shell32.lib")
 #endif

--- a/include/CLI/impl/Argv_inl.hpp
+++ b/include/CLI/impl/Argv_inl.hpp
@@ -52,6 +52,12 @@
 // third
 #include <processthreadsapi.h>
 #include <shellapi.h>
+// CommandLineToArgvW lives in shell32. CMake/Bazel already link it when using the
+// CLI11 targets; this pragma covers MSVC/clang-cl consumers that only include the
+// headers (or clear CMAKE_CXX_STANDARD_LIBRARIES). See #1053.
+#if defined(_MSC_VER)
+#pragma comment(lib, "shell32.lib")
+#endif
 #endif
 // [CLI11:argv_inl_includes:end]
 


### PR DESCRIPTION
## Summary

Fixes #1053.

CMake and Bazel already link `shell32` when consumers use the `CLI11` / `cli11_header_only` targets. That does not help MSVC (or clang-cl) projects that only include the headers, or that clear `CMAKE_CXX_STANDARD_LIBRARIES` so the usual implicit `shell32.lib` is gone — they still hit `LNK2019` on `CommandLineToArgvW`.

This PR adds `#pragma comment(lib, "shell32.lib")` next to the Windows argv helper so header-only MSVC builds pull in `shell32` explicitly. Existing CMake/`shell32` and Bazel `DEFAULTLIB:shell32.lib` links stay for MinGW and target-based builds.

## Test plan

- [ ] MSVC: build a tiny TU that only `#include <CLI/CLI.hpp>` / calls `CLI::detail::compute_win32_argv` (or `ensure_utf8`) with `CMAKE_CXX_STANDARD_LIBRARIES` cleared and without linking `CLI11::CLI11`; confirm link succeeds
- [ ] Existing Windows CI (MSVC / clang-cl) stays green
- [ ] Non-Windows builds unchanged
