### PR TITLE
feat(help): multiline CheckedTransformer enum maps (#554)

### DIFF
--- a/include/CLI/ExtraValidators.hpp
+++ b/include/CLI/ExtraValidators.hpp
@@ -129,22 +129,26 @@ template <typename T> std::string generate_set(const T &set) {
 }
 
 /// Generate a string representation of a map
-template <typename T> std::string generate_map(const T &map, bool key_only = false) {
+template <typename T> std::string generate_map(const T &map, bool key_only = false, bool multiline = false) {
     using element_t = typename detail::element_type<T>::type;
     using iteration_type_t = typename detail::pair_adaptor<element_t>::value_type;  // the type of the object pair
-    std::string out(1, '{');
-    out.append(detail::join(
-        detail::smart_deref(map),
-        [key_only](const iteration_type_t &v) {
-            std::string res{detail::to_string(detail::pair_adaptor<element_t>::first(v))};
+    auto entry_to_string = [key_only](const iteration_type_t &v) {
+        std::string res{detail::to_string(detail::pair_adaptor<element_t>::first(v))};
 
-            if(!key_only) {
-                res.append("->");
-                res += detail::to_string(detail::pair_adaptor<element_t>::second(v));
-            }
-            return res;
-        },
-        ","));
+        if(!key_only) {
+            res.append("->");
+            res += detail::to_string(detail::pair_adaptor<element_t>::second(v));
+        }
+        return res;
+    };
+    if(multiline) {
+        std::string out("{\n  ");
+        out.append(detail::join(detail::smart_deref(map), entry_to_string, ",\n  "));
+        out.append("\n}");
+        return out;
+    }
+    std::string out(1, '{');
+    out.append(detail::join(detail::smart_deref(map), entry_to_string, ","));
     out.push_back('}');
     return out;
 }
@@ -368,7 +372,7 @@ class CheckedTransformer : public Validator {
 
         auto tfunc = [shared_mapping]() {
             std::string out("value in ");
-            out += detail::generate_map(detail::smart_deref(*shared_mapping)) + " OR {";
+            out += detail::generate_map(detail::smart_deref(*shared_mapping), false, true) + " OR {";
             out += detail::join(
                 detail::smart_deref(*shared_mapping),
                 [](const iteration_type_t &v) {

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -120,6 +120,25 @@ TEST_CASE_METHOD(TApp, "EnumCheckedTransform", "[transform]") {
     CHECK_THROWS_AS(run(), CLI::ValidationError);
 }
 
+// from GitHub issue: https://github.com/CLIUtils/CLI11/issues/554
+// CheckedTransformer help should list enum map entries on separate lines
+TEST_CASE_METHOD(TApp, "CheckedTransformerMultilineHelp", "[transform]") {
+    enum class test_cli : std::int16_t { val1 = 3, val2 = 4, val3 = 17, val4 = 21 };
+    test_cli value{test_cli::val1};
+    app.add_option("-s", value)
+        ->transform(CLI::CheckedTransformer(CLI::TransformPairs<test_cli>{
+            {"val1", test_cli::val1},
+            {"val2", test_cli::val2},
+            {"val3", test_cli::val3},
+            {"val4", test_cli::val4}}));
+
+    auto help = app.help();
+    CHECK(help.find("value in {\n  ") != std::string::npos);
+    CHECK(help.find(",\n  ") != std::string::npos);
+    CHECK(help.find("val1->3") != std::string::npos);
+    CHECK(help.find("val4->21") != std::string::npos);
+}
+
 // from to-mas-kral Issue #1086
 TEST_CASE_METHOD(TApp, "EnumCheckedTransformUint8", "[transform]") {
     enum class FooType : std::uint8_t { A, B };

--- a/tests/TransformTest.cpp
+++ b/tests/TransformTest.cpp
@@ -127,10 +127,7 @@ TEST_CASE_METHOD(TApp, "CheckedTransformerMultilineHelp", "[transform]") {
     test_cli value{test_cli::val1};
     app.add_option("-s", value)
         ->transform(CLI::CheckedTransformer(CLI::TransformPairs<test_cli>{
-            {"val1", test_cli::val1},
-            {"val2", test_cli::val2},
-            {"val3", test_cli::val3},
-            {"val4", test_cli::val4}}));
+            {"val1", test_cli::val1}, {"val2", test_cli::val2}, {"val3", test_cli::val3}, {"val4", test_cli::val4}}));
 
     auto help = app.help();
     CHECK(help.find("value in {\n  ") != std::string::npos);


### PR DESCRIPTION
## Summary
Formats `CheckedTransformer` / enum map help text across multiple lines (#554) so long ENUM option lists stay readable in `--help`.

`detail::generate_map` gains an optional `multiline` flag; `CheckedTransformer` enables it. Other validators keep the compact single-line default.

## Test plan
- [ ] Help for a multi-entry `CheckedTransformer` contains newlines between map entries
- [ ] Existing transform/parse behavior unchanged

Closes #554
