### PR TITLE
fix: support wide strings for app description and usage

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -345,6 +345,9 @@ class App {
     /// Create a new program. Pass in the same arguments as main(), along with a help string.
     explicit App(std::string app_description = "", std::string app_name = "");
 
+    /// Create a new program with a wide-string description.
+    explicit App(std::wstring app_description);
+
     App(const App &) = delete;
     App &operator=(const App &) = delete;
 
@@ -975,6 +978,8 @@ class App {
         usage_ = std::move(usage_string);
         return this;
     }
+    /// Set usage from a wide string.
+    App *usage(std::wstring usage_string);
     /// Set usage.
     App *usage(std::function<std::string()> usage_function) {
         usage_callback_ = std::move(usage_function);

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -73,6 +73,8 @@ CLI11_INLINE App::App(std::string app_description, std::string app_name) : App(a
     set_help_flag("-h,--help", "Print this help message and exit");
 }
 
+CLI11_INLINE App::App(std::wstring app_description) : App(narrow(app_description)) {}
+
 CLI11_NODISCARD CLI11_INLINE char **App::ensure_utf8(char **argv) {
 #ifdef _WIN32
     (void)argv;
@@ -103,6 +105,8 @@ CLI11_INLINE App *App::callback(std::function<void()> app_callback) {
     }
     return this;
 }
+
+CLI11_INLINE App *App::usage(std::wstring usage_string) { return usage(narrow(usage_string)); }
 
 CLI11_INLINE App *App::name(std::string app_name) {
 

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -552,6 +552,17 @@ TEST_CASE_METHOD(TApp, "SubcommandDefaults", "[creation]") {
     CHECK(3u == app2->get_require_subcommand_max());
 }
 
+TEST_CASE("WideStringDescriptionAndUsage", "[creation][unicode]") {
+    const std::wstring wide_text = L"Hello \u4F60\u597D";
+    const std::string expected = CLI::narrow(wide_text);
+
+    CLI::App app{L"Hello \u4F60\u597D"};
+    CHECK(app.get_description() == expected);
+
+    app.usage(L"Hello \u4F60\u597D");
+    CHECK(app.get_usage() == expected);
+}
+
 TEST_CASE_METHOD(TApp, "SubcommandMinMax", "[creation]") {
 
     CHECK(0u == app.get_require_subcommand_min());


### PR DESCRIPTION
Closes #1130.

## Summary

Adds support for wide strings in the `CLI::App` description constructor and `usage()` setter.

## Changes

* Add a `std::wstring` overload for the `CLI::App` description constructor.
* Add a `std::wstring` overload for `App::usage()`.
* Convert wide strings through CLI11's existing `narrow()` helper and delegate to the existing `std::string` implementations.
* Add a regression test covering wide string literals with non-ASCII Unicode characters.

## Testing

* Added a regression test reproducing the previously unsupported wide-string calls.
* Verified the regression test fails to compile without the new overloads.
* Built successfully with C++11.
* Ran the full test suite: 83/83 tests passed.
* Ran `prek` successfully.
* Ran `git diff --check` successfully.