### PR TITLE
docs: explain configurable effect on config output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,7 +1046,9 @@ option_groups. These are:
   default is true.
 - `.configurable()`: Allow the subcommand to be triggered from a configuration
   file. By default subcommand options in a configuration file do not trigger a
-  subcommand but will just update default values.
+  subcommand but will just update default values. This flag also controls how
+  the subcommand is written out by `config_to_str`; see
+  [the config chapter](https://cliutils.github.io/CLI11/book/chapters/config.html).
 - `.disable()`: Specify that the subcommand is disabled, if given with a bool
   value it will enable or disable the subcommand or option group.
 - `.disabled_by_default()`: Specify that at the start of parsing the

--- a/book/chapters/config.md
+++ b/book/chapters/config.md
@@ -329,6 +329,28 @@ following overloads:
 The `write_description` argument will include option descriptions and the App
 description.
 
+Subcommands are written in one of two forms. A subcommand set to
+`configurable()` gets its own section, such as `[sub]`, if the subcommand was
+passed on the command line or the mode is `CLI::ConfigOutputMode::AllDefaults`.
+In all other conditions, the options of the subcommand are written with dotted
+names, such as `sub.value=1`. Nested subcommands use the parent names as a
+prefix, such as `[sub.subsub]` or `sub.subsub.value=1`.
+
+```cpp
+ CLI::App app;
+ int a{1}, b{1};
+ app.add_subcommand("plain")->add_option("--value", a)->capture_default_str();
+ app.add_subcommand("configurable")->configurable()
+    ->add_option("--value", b)->capture_default_str();
+ std::cout<<app.config_to_str(CLI::ConfigOutputMode::AllDefaults);
+```
+
+```toml
+plain.value=1
+[configurable]
+value=1
+```
+
 ```cpp
  CLI::App app;
  app.add_option(...);

--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -1076,10 +1076,11 @@ class App {
     /// Check the status of the allow windows style options
     CLI11_NODISCARD bool get_allow_windows_style_options() const { return allow_windows_style_options_; }
 
-    /// Check the status of the allow windows style options
+    /// Check the status of positionals at end
     CLI11_NODISCARD bool get_positionals_at_end() const { return positionals_at_end_; }
 
-    /// Check the status of the allow windows style options
+    /// Check the status of configurable; a configurable subcommand can be triggered from a configuration file, and is
+    /// written out as its own section instead of dotted names
     CLI11_NODISCARD bool get_configurable() const { return configurable_; }
 
     /// Get the group of this subcommand


### PR DESCRIPTION
:robot: _AI text below_ :robot:

From [discussion #1440](https://github.com/CLIUtils/CLI11/discussions/1440).

Two problems, both reported there:

- `get_configurable()` and `get_positionals_at_end()` had doc comments copied from `get_allow_windows_style_options()`.
- The effect of `configurable()` on the `config_to_str` output format was undocumented. A configurable subcommand is written as a `[section]`; other subcommands get dotted names. This is why TOML table notation does not appear unless `configurable()` is set.

The new documentation example was compiled and run to confirm the output shown.