### PR TITLE
refactor: defer config file errors by value instead of exception_ptr

### DIFF
--- a/book/chapters/internals.md
+++ b/book/chapters/internals.md
@@ -50,7 +50,7 @@ CLI11_INLINE void App::_process() {
     _process_help_flags(CallbackPriority::First);
     _process_callbacks(CallbackPriority::First);
 
-    std::exception_ptr config_exception;
+    std::unique_ptr<CLI::FileError> config_error;
     try {
         // the config file might generate a FileError but that should not be processed until later in the process
         // to allow for help, version and other errors to generate first.
@@ -58,8 +58,8 @@ CLI11_INLINE void App::_process() {
 
         // process env shouldn't throw but no reason to process it if config generated an error
         _process_env();
-    } catch(const CLI::FileError &) {
-        config_exception = std::current_exception();
+    } catch(const CLI::FileError &e) {
+        config_error.reset(new CLI::FileError(e));
     }
     // callbacks and requirements processing can generate exceptions which should take priority
     // over the config file error if one exists.
@@ -73,8 +73,8 @@ CLI11_INLINE void App::_process() {
     _process_help_flags(CallbackPriority::Normal);
     _process_callbacks(CallbackPriority::Normal);
 
-    if(config_exception) {
-        std::rethrow_exception(config_exception);
+    if(config_error) {
+        throw *config_error;
     }
 
     _process_callbacks(CallbackPriority::LastPreHelp);
@@ -94,4 +94,6 @@ processing requirements. The default for help and version flags is to execute
 The library immediately returns a C++ exception when it detects a problem, such
 as an incorrect construction or a malformed command line. Errors from config
 processing are delayed until after other processing, to give priority to any
-help or version flags, or other types of callback errors.
+help or version flags, or other types of callback errors. The delay is done by
+storing a copy of the `FileError` and throwing it later, so that any error from
+the intermediate steps can propagate first.

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -1661,7 +1661,7 @@ CLI11_INLINE void App::_process() {
     _process_callbacks(CallbackPriority::Normal);
 
     if(config_error) {
-        throw *config_error;
+        throw CLI::FileError(*config_error);
     }
 
     _process_callbacks(CallbackPriority::LastPreHelp);

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -19,7 +19,6 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
-#include <exception>
 #include <functional>
 #include <iostream>
 #include <iterator>
@@ -1638,7 +1637,7 @@ CLI11_INLINE void App::_process() {
     _process_help_flags(CallbackPriority::First);
     _process_callbacks(CallbackPriority::First);
 
-    std::exception_ptr config_exception;
+    std::unique_ptr<CLI::FileError> config_error;
     try {
         // the config file might generate a FileError but that should not be processed until later in the process
         // to allow for help, version and other errors to generate first.
@@ -1646,8 +1645,8 @@ CLI11_INLINE void App::_process() {
 
         // process env shouldn't throw but no reason to process it if config generated an error
         _process_env();
-    } catch(const CLI::FileError &) {
-        config_exception = std::current_exception();
+    } catch(const CLI::FileError &e) {
+        config_error.reset(new CLI::FileError(e));
     }
     // callbacks and requirements processing can generate exceptions which should take priority
     // over the config file error if one exists.
@@ -1661,8 +1660,8 @@ CLI11_INLINE void App::_process() {
     _process_help_flags(CallbackPriority::Normal);
     _process_callbacks(CallbackPriority::Normal);
 
-    if(config_exception) {
-        std::rethrow_exception(config_exception);
+    if(config_error) {
+        throw *config_error;
     }
 
     _process_callbacks(CallbackPriority::LastPreHelp);

--- a/tests/ConfigFileTest.cpp
+++ b/tests/ConfigFileTest.cpp
@@ -1164,6 +1164,10 @@ TEST_CASE_METHOD(TApp, "IniRequiredNotFound", "[config]") {
     app.set_config("--config", noini, "", true);
 
     CHECK_THROWS_AS(run(), CLI::FileError);
+
+    // the FileError is deferred, so help takes priority over it
+    args = {"--help"};
+    CHECK_THROWS_AS(run(), CLI::CallForHelp);
 }
 
 TEST_CASE_METHOD(TApp, "IniDefaultNotExist", "[config]") {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1443.

Replace the `std::exception_ptr` in `App::_process()` with a stored copy of the `CLI::FileError` (`std::unique_ptr<CLI::FileError>`), thrown at the same point the exception was rethrown before. This removes the only `std::exception_ptr` use in the library as preparation for `-fno-exceptions` support. The observable behavior (error type, message, exit code, and priority of help/version/requirement errors over config errors) is unchanged.

Also updates the internals chapter of the book and adds a test that `--help` takes priority over a missing required config file, which was not covered before.