### PR TITLE
refactor: handle version flag without exception control flow

### DIFF
--- a/include/CLI/App.hpp
+++ b/include/CLI/App.hpp
@@ -198,6 +198,9 @@ class App {
     /// A pointer to a version flag if there is one
     Option *version_ptr_{nullptr};
 
+    /// This is a function that generates the version string
+    std::function<std::string()> version_producer_{};
+
     /// This is the formatter for help printing. Default provided. INHERITABLE (same pointer)
     std::shared_ptr<FormatterBase> formatter_{new Formatter()};
 

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -365,12 +365,13 @@ App::set_version_flag(std::string flag_name, const std::string &versionString, c
     if(version_ptr_ != nullptr) {
         remove_option(version_ptr_);
         version_ptr_ = nullptr;
+        version_producer_ = nullptr;
     }
 
     // Empty name will simply remove the version flag
     if(!flag_name.empty()) {
-        version_ptr_ = add_flag_callback(
-            flag_name, [versionString]() { throw(CLI::CallForVersion(versionString, 0)); }, version_help);
+        version_producer_ = [versionString]() { return versionString; };
+        version_ptr_ = add_flag_callback(flag_name, []() {}, version_help);
         version_ptr_->configurable(false)->callback_priority(CallbackPriority::First);
     }
 
@@ -382,12 +383,13 @@ App::set_version_flag(std::string flag_name, std::function<std::string()> vfunc,
     if(version_ptr_ != nullptr) {
         remove_option(version_ptr_);
         version_ptr_ = nullptr;
+        version_producer_ = nullptr;
     }
 
     // Empty name will simply remove the version flag
     if(!flag_name.empty()) {
-        version_ptr_ =
-            add_flag_callback(flag_name, [vfunc]() { throw(CLI::CallForVersion(vfunc(), 0)); }, version_help);
+        version_producer_ = std::move(vfunc);
+        version_ptr_ = add_flag_callback(flag_name, []() {}, version_help);
         version_ptr_->configurable(false)->callback_priority(CallbackPriority::First);
     }
 
@@ -963,18 +965,8 @@ CLI11_NODISCARD CLI11_INLINE std::string App::help(std::string prev, AppFormatMo
 
 CLI11_NODISCARD CLI11_INLINE std::string App::version() const {
     std::string val;
-    if(version_ptr_ != nullptr) {
-        // copy the results for reuse later
-        results_t rv = version_ptr_->results();
-        version_ptr_->clear();
-        version_ptr_->add_result("true");
-        try {
-            version_ptr_->run_callback();
-        } catch(const CLI::CallForVersion &cfv) {
-            val = cfv.what();
-        }
-        version_ptr_->clear();
-        version_ptr_->add_result(rv);
+    if(version_ptr_ != nullptr && version_producer_) {
+        val = version_producer_();
     }
     return val;
 }
@@ -1461,6 +1453,15 @@ CLI11_INLINE void App::_process_callbacks(CallbackPriority priority) {
                     sub->run_callback();
                 }
             }
+        }
+    }
+
+    // the version flag triggers here rather than from an option callback
+    if(version_ptr_ != nullptr && version_ptr_->get_callback_priority() == priority && version_ptr_->count() > 0 &&
+       !version_ptr_->get_callback_run()) {
+        bool trigger{false};
+        if(detail::lexical_cast(version_ptr_->results()[0], trigger) && trigger) {
+            throw CLI::CallForVersion(version_producer_(), 0);
         }
     }
 

--- a/tests/HelpTest.cpp
+++ b/tests/HelpTest.cpp
@@ -1681,6 +1681,41 @@ TEST_CASE("TVersion: exit_with_required", "[help]") {
     }
 }
 
+TEST_CASE("TVersion: help_precedence", "[help]") {
+    // help wins over version regardless of the order on the command line
+    CLI::App app;
+
+    app.set_version_flag("--version", CLI11_VERSION);
+
+    CHECK_THROWS_AS(app.parse("--version --help"), CLI::CallForHelp);
+    CHECK_THROWS_AS(app.parse("--help --version"), CLI::CallForHelp);
+}
+
+TEST_CASE("TVersion: no_parse_in_flight", "[help]") {
+    // version() works with no parse in flight and does not disturb parse results
+    CLI::App app;
+
+    app.set_version_flag("--version", CLI11_VERSION);
+    CHECK_THAT(app.version(), Equals(CLI11_VERSION));
+
+    try {
+        app.parse("--version");
+    } catch(const CLI::CallForVersion &v) {
+        CHECK_THAT(CLI11_VERSION, Equals(v.what()));
+    }
+    CHECK(1U == app.get_version_ptr()->count());
+    CHECK_THAT(app.version(), Equals(CLI11_VERSION));
+}
+
+TEST_CASE("TVersion: false_value", "[help]") {
+    // an explicit false value does not trigger the version output
+    CLI::App app;
+
+    app.set_version_flag("--version", CLI11_VERSION);
+
+    CHECK_NOTHROW(app.parse("--version=false"));
+}
+
 TEST_CASE("THelp: Delimiter", "[help]") {
     CLI::App app{"My prog"};
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1443.

The version flag callbacks no longer throw `CallForVersion`. The version string producer is stored on the `App`, the parse path throws when the flag is counted, and `App::version()` calls the stored producer directly instead of catching its own exception. This removes throw-based control flow from the version flag as preparation for `-fno-exceptions` support.

Behavior is unchanged: the same exception and message reach users, and help keeps precedence over version. New tests pin help/version ordering, `--version=false`, and `App::version()` outside a parse. Verified locally with the header-only build in addition to the precompiled dev preset.
