### PR TITLE
refactor: return status from string/encoding detail utilities

### DIFF
--- a/include/CLI/Argv.hpp
+++ b/include/CLI/Argv.hpp
@@ -19,8 +19,9 @@ namespace CLI {
 // [CLI11:argv_hpp:verbatim]
 namespace detail {
 #ifdef _WIN32
-/// Decode and return UTF-8 argv from GetCommandLineW.
-CLI11_INLINE std::vector<std::string> compute_win32_argv();
+/// Decode UTF-8 argv from GetCommandLineW into result.
+/// Returns true on success; on failure error_msg is filled with a description
+CLI11_INLINE bool compute_win32_argv(std::vector<std::string> &result, std::string &error_msg);
 #endif
 }  // namespace detail
 // [CLI11:argv_hpp:end]

--- a/include/CLI/StringTools.hpp
+++ b/include/CLI/StringTools.hpp
@@ -132,7 +132,8 @@ CLI11_INLINE std::string &remove_outer(std::string &str, char key);
 CLI11_INLINE std::string &remove_quotes(std::string &str);
 
 /// remove quotes from all elements of a string vector and process escaped components
-CLI11_INLINE void remove_quotes(std::vector<std::string> &args);
+/// @return true on success; on failure false is returned and error_msg is filled with a description
+CLI11_INLINE bool remove_quotes(std::vector<std::string> &args, std::string &error_msg);
 
 /// Add a leader to the beginning of all new lines (nothing is added
 /// at the start of the first line). `"; "` would be for ini files
@@ -246,8 +247,9 @@ CLI11_INLINE bool has_escapable_character(const std::string &str);
 /// @return a string with the escapable characters escaped with '\'
 CLI11_INLINE std::string add_escaped_characters(const std::string &str);
 
-/// @brief replace the escaped characters with their equivalent
-CLI11_INLINE std::string remove_escaped_characters(const std::string &str);
+/// @brief replace the escaped characters with their equivalent in place
+/// @return true on success; on failure str is unmodified and error_msg is filled with a description
+CLI11_INLINE bool remove_escaped_characters(std::string &str, std::string &error_msg);
 
 /// generate a string with all non printable characters escaped to hex codes
 CLI11_INLINE std::string binary_escape_string(const std::string &string_to_escape, bool force = false);
@@ -261,6 +263,16 @@ CLI11_INLINE std::string extract_binary_string(const std::string &escaped_string
 CLI11_INLINE void handle_secondary_array(std::string &str);
 
 /// process a quoted string, remove the quotes and if appropriate handle escaped characters
+/// @return true if str was modified; if escape processing fails, false is returned and error_msg is
+/// filled with a description
+CLI11_INLINE bool process_quoted_string(std::string &str,
+                                        std::string &error_msg,
+                                        char string_char = '\"',
+                                        char literal_char = '\'',
+                                        bool disable_secondary_array_processing = false);
+
+/// process a quoted string, remove the quotes and if appropriate handle escaped characters, ignoring any
+/// escape processing errors
 CLI11_INLINE bool process_quoted_string(std::string &str,
                                         char string_char = '\"',
                                         char literal_char = '\'',

--- a/include/CLI/impl/App_inl.hpp
+++ b/include/CLI/impl/App_inl.hpp
@@ -77,7 +77,10 @@ CLI11_NODISCARD CLI11_INLINE char **App::ensure_utf8(char **argv) {
 #ifdef _WIN32
     (void)argv;
 
-    normalized_argv_ = detail::compute_win32_argv();
+    std::string win32_argv_error;
+    if(!detail::compute_win32_argv(normalized_argv_, win32_argv_error)) {
+        throw std::runtime_error(win32_argv_error);
+    }
 
     if(!normalized_argv_view_.empty()) {
         normalized_argv_view_.clear();
@@ -701,10 +704,9 @@ CLI11_INLINE void App::parse(std::string commandline, bool program_name_included
     auto args = detail::split_up(std::move(commandline));
     // remove all empty strings
     args.erase(std::remove(args.begin(), args.end(), std::string{}), args.end());
-    try {
-        detail::remove_quotes(args);
-    } catch(const std::invalid_argument &arg) {
-        throw CLI::ParseError(arg.what(), CLI::ExitCodes::InvalidError);
+    std::string error_msg;
+    if(!detail::remove_quotes(args, error_msg)) {
+        throw CLI::ParseError(error_msg, CLI::ExitCodes::InvalidError);
     }
     std::reverse(args.begin(), args.end());
     parse(std::move(args));

--- a/include/CLI/impl/Argv_inl.hpp
+++ b/include/CLI/impl/Argv_inl.hpp
@@ -15,7 +15,6 @@
 
 // [CLI11:public_includes:set]
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <vector>
 // [CLI11:public_includes:end]
@@ -61,8 +60,8 @@ namespace CLI {
 namespace detail {
 
 #ifdef _WIN32
-CLI11_INLINE std::vector<std::string> compute_win32_argv() {
-    std::vector<std::string> result;
+CLI11_INLINE bool compute_win32_argv(std::vector<std::string> &result, std::string &error_msg) {
+    result.clear();
     int argc = 0;
 
     auto deleter = [](wchar_t **ptr) { LocalFree(ptr); };
@@ -71,7 +70,8 @@ CLI11_INLINE std::vector<std::string> compute_win32_argv() {
     // NOLINTEND(*-avoid-c-arrays)
 
     if(wargv == nullptr) {
-        throw std::runtime_error("CommandLineToArgvW failed with code " + std::to_string(GetLastError()));
+        error_msg = "CommandLineToArgvW failed with code " + std::to_string(GetLastError());
+        return false;
     }
 
     result.reserve(static_cast<size_t>(argc));
@@ -79,7 +79,7 @@ CLI11_INLINE std::vector<std::string> compute_win32_argv() {
         result.push_back(narrow(wargv[i]));
     }
 
-    return result;
+    return true;
 }
 #endif
 

--- a/include/CLI/impl/Config_inl.hpp
+++ b/include/CLI/impl/Config_inl.hpp
@@ -21,7 +21,6 @@
 #include <functional>
 #include <locale>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -194,10 +193,9 @@ generate_parents(const std::string &section, std::string &name, char parentSepar
         parents.insert(parents.end(), plist.begin(), plist.end());
     }
     // clean up quotes on the parents
-    try {
-        detail::remove_quotes(parents);
-    } catch(const std::invalid_argument &iarg) {
-        throw CLI::ParseError(iarg.what(), CLI::ExitCodes::InvalidError);
+    std::string error_msg;
+    if(!detail::remove_quotes(parents, error_msg)) {
+        throw CLI::ParseError(error_msg, CLI::ExitCodes::InvalidError);
     }
     return parents;
 }
@@ -451,10 +449,9 @@ CLI11_INLINE std::vector<ConfigItem> ConfigBase::from_config(std::istream &input
                     item.pop_back();
                     item.pop_back();
                     if(keyChar == '\"') {
-                        try {
-                            item = detail::remove_escaped_characters(item);
-                        } catch(const std::invalid_argument &iarg) {
-                            throw CLI::ParseError(iarg.what(), CLI::ExitCodes::InvalidError);
+                        std::string error_msg;
+                        if(!detail::remove_escaped_characters(item, error_msg)) {
+                            throw CLI::ParseError(error_msg, CLI::ExitCodes::InvalidError);
                         }
                     }
                     inMLineValue = false;
@@ -482,10 +479,9 @@ CLI11_INLINE std::vector<ConfigItem> ConfigBase::from_config(std::istream &input
                             item.pop_back();
                         }
                         if(keyChar == '\"') {
-                            try {
-                                item = detail::remove_escaped_characters(item);
-                            } catch(const std::invalid_argument &iarg) {
-                                throw CLI::ParseError(iarg.what(), CLI::ExitCodes::InvalidError);
+                            std::string error_msg;
+                            if(!detail::remove_escaped_characters(item, error_msg)) {
+                                throw CLI::ParseError(error_msg, CLI::ExitCodes::InvalidError);
                             }
                         }
                     } else {
@@ -525,16 +521,20 @@ CLI11_INLINE std::vector<ConfigItem> ConfigBase::from_config(std::istream &input
             name = detail::trim_copy(line.substr(0, comment_pos));
             items_buffer = {"true"};
         }
-        std::vector<std::string> parents;
-        try {
-            parents = detail::generate_parents(currentSection, name, parentSeparatorChar);
-            detail::process_quoted_string(name, '"', '\'', true);
+        std::vector<std::string> parents = detail::generate_parents(currentSection, name, parentSeparatorChar);
+        std::string error_msg;
+        detail::process_quoted_string(name, error_msg, '"', '\'', true);
+        if(error_msg.empty()) {
             // clean up quotes on the items and check for escaped strings
             for(auto &it : items_buffer) {
-                detail::process_quoted_string(it, stringQuote, literalQuote);
+                detail::process_quoted_string(it, error_msg, stringQuote, literalQuote);
+                if(!error_msg.empty()) {
+                    break;
+                }
             }
-        } catch(const std::invalid_argument &ia) {
-            throw CLI::ParseError(ia.what(), CLI::ExitCodes::InvalidError);
+        }
+        if(!error_msg.empty()) {
+            throw CLI::ParseError(error_msg, CLI::ExitCodes::InvalidError);
         }
 
         if(parents.size() > maximumLayers) {

--- a/include/CLI/impl/Encoding_inl.hpp
+++ b/include/CLI/impl/Encoding_inl.hpp
@@ -113,6 +113,7 @@ CLI11_INLINE bool narrow_impl(const wchar_t *str, std::size_t str_size, std::str
 CLI11_INLINE std::string narrow_impl(const wchar_t *str, std::size_t str_size) {
     std::string result;
     std::string error_msg;
+    // cppcheck-suppress knownConditionTrueFalse ; the codecvt branch cannot fail
     if(!narrow_impl(str, str_size, result, error_msg)) {
         throw std::runtime_error(error_msg);
     }
@@ -165,6 +166,7 @@ CLI11_INLINE bool widen_impl(const char *str, std::size_t str_size, std::wstring
 CLI11_INLINE std::wstring widen_impl(const char *str, std::size_t str_size) {
     std::wstring result;
     std::string error_msg;
+    // cppcheck-suppress knownConditionTrueFalse ; the codecvt branch cannot fail
     if(!widen_impl(str, str_size, result, error_msg)) {
         throw std::runtime_error(error_msg);
     }

--- a/include/CLI/impl/Encoding_inl.hpp
+++ b/include/CLI/impl/Encoding_inl.hpp
@@ -38,15 +38,17 @@ namespace detail {
 
 #if !CLI11_HAS_CODECVT
 /// Attempt to set one of the acceptable unicode locales for conversion
-CLI11_INLINE void set_unicode_locale() {
+/// Returns true on success; on failure error_msg is filled with a description
+CLI11_INLINE bool set_unicode_locale(std::string &error_msg) {
     static const std::array<const char *, 2> unicode_locales{{"C.UTF-8", ".UTF-8"}};
 
     for(const auto &locale_name : unicode_locales) {
         if(std::setlocale(LC_ALL, locale_name) != nullptr) {
-            return;
+            return true;
         }
     }
-    throw std::runtime_error("CLI::narrow: could not set locale to C.UTF-8");
+    error_msg = "CLI::narrow: could not set locale to C.UTF-8";
+    return false;
 }
 
 template <typename F> struct scope_guard_t {
@@ -65,16 +67,20 @@ template <typename F> CLI11_NODISCARD CLI11_INLINE scope_guard_t<F> scope_guard(
 CLI11_DIAGNOSTIC_PUSH
 CLI11_DIAGNOSTIC_IGNORE_DEPRECATED
 
-CLI11_INLINE std::string narrow_impl(const wchar_t *str, std::size_t str_size) {
+/// Convert a wide string to a narrow string
+/// Returns true on success; on failure error_msg is filled with a description and result is unspecified
+CLI11_INLINE bool narrow_impl(const wchar_t *str, std::size_t str_size, std::string &result, std::string &error_msg) {
 #if CLI11_HAS_CODECVT
+    (void)error_msg;
 #ifdef _WIN32
-    return std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>().to_bytes(str, str + str_size);
+    result = std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>().to_bytes(str, str + str_size);
 
 #else
-    return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(str, str + str_size);
+    result = std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(str, str + str_size);
 
 #endif  // _WIN32
-#else   // CLI11_HAS_CODECVT
+    return true;
+#else  // CLI11_HAS_CODECVT
     // Copy into a local, NUL-terminated buffer so the conversion is bounded by str_size: a view into the
     // middle of a larger buffer or a non-NUL-terminated buffer must not be read past str_size. Note that an
     // embedded NUL inside the first str_size characters will still terminate std::wcsrtombs early; this matches
@@ -87,31 +93,46 @@ CLI11_INLINE std::string narrow_impl(const wchar_t *str, std::size_t str_size) {
 
     std::string old_locale = std::setlocale(LC_ALL, nullptr);
     auto sg = scope_guard([&] { std::setlocale(LC_ALL, old_locale.c_str()); });
-    set_unicode_locale();
+    if(!set_unicode_locale(error_msg)) {
+        return false;
+    }
 
     std::size_t new_size = std::wcsrtombs(nullptr, &it, 0, &state);
     if(new_size == static_cast<std::size_t>(-1)) {
-        throw std::runtime_error("CLI::narrow: conversion error in std::wcsrtombs at offset " +
-                                 std::to_string(it - src));
+        error_msg = "CLI::narrow: conversion error in std::wcsrtombs at offset " + std::to_string(it - src);
+        return false;
     }
-    std::string result(new_size, '\0');
+    result.assign(new_size, '\0');
     std::wcsrtombs(const_cast<char *>(result.data()), &src, new_size, &state);
 
-    return result;
+    return true;
 
 #endif  // CLI11_HAS_CODECVT
 }
 
-CLI11_INLINE std::wstring widen_impl(const char *str, std::size_t str_size) {
+CLI11_INLINE std::string narrow_impl(const wchar_t *str, std::size_t str_size) {
+    std::string result;
+    std::string error_msg;
+    if(!narrow_impl(str, str_size, result, error_msg)) {
+        throw std::runtime_error(error_msg);
+    }
+    return result;
+}
+
+/// Convert a narrow string to a wide string
+/// Returns true on success; on failure error_msg is filled with a description and result is unspecified
+CLI11_INLINE bool widen_impl(const char *str, std::size_t str_size, std::wstring &result, std::string &error_msg) {
 #if CLI11_HAS_CODECVT
+    (void)error_msg;
 #ifdef _WIN32
-    return std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>().from_bytes(str, str + str_size);
+    result = std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>().from_bytes(str, str + str_size);
 
 #else
-    return std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(str, str + str_size);
+    result = std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(str, str + str_size);
 
 #endif  // _WIN32
-#else   // CLI11_HAS_CODECVT
+    return true;
+#else  // CLI11_HAS_CODECVT
     // Copy into a local, NUL-terminated buffer so the conversion is bounded by str_size: a view into the
     // middle of a larger buffer or a non-NUL-terminated buffer must not be read past str_size. Note that an
     // embedded NUL inside the first str_size characters will still terminate std::mbsrtowcs early; this matches
@@ -124,19 +145,30 @@ CLI11_INLINE std::wstring widen_impl(const char *str, std::size_t str_size) {
 
     std::string old_locale = std::setlocale(LC_ALL, nullptr);
     auto sg = scope_guard([&] { std::setlocale(LC_ALL, old_locale.c_str()); });
-    set_unicode_locale();
+    if(!set_unicode_locale(error_msg)) {
+        return false;
+    }
 
     std::size_t new_size = std::mbsrtowcs(nullptr, &it, 0, &state);
     if(new_size == static_cast<std::size_t>(-1)) {
-        throw std::runtime_error("CLI::widen: conversion error in std::mbsrtowcs at offset " +
-                                 std::to_string(it - src));
+        error_msg = "CLI::widen: conversion error in std::mbsrtowcs at offset " + std::to_string(it - src);
+        return false;
     }
-    std::wstring result(new_size, L'\0');
+    result.assign(new_size, L'\0');
     std::mbsrtowcs(const_cast<wchar_t *>(result.data()), &src, new_size, &state);
 
-    return result;
+    return true;
 
 #endif  // CLI11_HAS_CODECVT
+}
+
+CLI11_INLINE std::wstring widen_impl(const char *str, std::size_t str_size) {
+    std::wstring result;
+    std::string error_msg;
+    if(!widen_impl(str, str_size, result, error_msg)) {
+        throw std::runtime_error(error_msg);
+    }
+    return result;
 }
 
 CLI11_DIAGNOSTIC_POP

--- a/include/CLI/impl/StringTools_inl.hpp
+++ b/include/CLI/impl/StringTools_inl.hpp
@@ -21,7 +21,6 @@
 #include <iterator>
 #include <locale>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -257,7 +256,7 @@ CLI11_INLINE std::uint32_t hexConvert(char hc) {
 
 CLI11_INLINE char make_char(std::uint32_t code) { return static_cast<char>(static_cast<unsigned char>(code)); }
 
-CLI11_INLINE void append_codepoint(std::string &str, std::uint32_t code) {
+CLI11_INLINE bool append_codepoint(std::string &str, std::uint32_t code, std::string &error_msg) {
     if(code < 0x80) {  // ascii code equivalent
         str.push_back(static_cast<char>(code));
     } else if(code < 0x800) {  // \u0080 to \u07FF
@@ -266,7 +265,8 @@ CLI11_INLINE void append_codepoint(std::string &str, std::uint32_t code) {
         str.push_back(make_char(0x80 | (code & 0x3F)));
     } else if(code < 0x10000) {  // U+0800...U+FFFF
         if(0xD800 <= code && code <= 0xDFFF) {
-            throw std::invalid_argument("[0xD800, 0xDFFF] are not valid code points.");
+            error_msg = "[0xD800, 0xDFFF] are not valid code points.";
+            return false;
         }
         // 1110yyyy 10yxxxxx 10xxxxxx
         str.push_back(make_char(0xE0 | code >> 12));
@@ -279,18 +279,21 @@ CLI11_INLINE void append_codepoint(std::string &str, std::uint32_t code) {
         str.push_back(make_char(0x80 | (code >> 6 & 0x3F)));
         str.push_back(make_char(0x80 | (code & 0x3F)));
     } else {  // code points above U+10FFFF are not valid
-        throw std::invalid_argument("values above 0x10FFFF are not valid code points.");
+        error_msg = "values above 0x10FFFF are not valid code points.";
+        return false;
     }
+    return true;
 }
 
-CLI11_INLINE std::string remove_escaped_characters(const std::string &str) {
+CLI11_INLINE bool remove_escaped_characters(std::string &str, std::string &error_msg) {
 
     std::string out;
     out.reserve(str.size());
     for(auto loc = str.begin(); loc < str.end(); ++loc) {
         if(*loc == '\\') {
             if(str.end() - loc < 2) {
-                throw std::invalid_argument("invalid escape sequence " + str);
+                error_msg = "invalid escape sequence " + str;
+                return false;
             }
             auto ecloc = escapedCharsCode().find_first_of(*(loc + 1));
             if(ecloc != std::string::npos) {
@@ -299,48 +302,58 @@ CLI11_INLINE std::string remove_escaped_characters(const std::string &str) {
             } else if(*(loc + 1) == 'u') {
                 // must have 4 hex characters
                 if(str.end() - loc < 6) {
-                    throw std::invalid_argument("unicode sequence must have 4 hex codes " + str);
+                    error_msg = "unicode sequence must have 4 hex codes " + str;
+                    return false;
                 }
                 std::uint32_t code{0};
                 std::uint32_t mplier{16 * 16 * 16};
                 for(int ii = 2; ii < 6; ++ii) {
                     std::uint32_t res = hexConvert(*(loc + ii));
                     if(res > 0x0F) {
-                        throw std::invalid_argument("unicode sequence must have 4 hex codes " + str);
+                        error_msg = "unicode sequence must have 4 hex codes " + str;
+                        return false;
                     }
                     code += res * mplier;
                     mplier = mplier / 16;
                 }
-                append_codepoint(out, code);
+                if(!append_codepoint(out, code, error_msg)) {
+                    return false;
+                }
                 loc += 5;
             } else if(*(loc + 1) == 'U') {
                 // must have 8 hex characters
                 if(str.end() - loc < 10) {
-                    throw std::invalid_argument("unicode sequence must have 8 hex codes " + str);
+                    error_msg = "unicode sequence must have 8 hex codes " + str;
+                    return false;
                 }
                 std::uint32_t code{0};
                 std::uint32_t mplier{16 * 16 * 16 * 16 * 16 * 16 * 16};
                 for(int ii = 2; ii < 10; ++ii) {
                     std::uint32_t res = hexConvert(*(loc + ii));
                     if(res > 0x0F) {
-                        throw std::invalid_argument("unicode sequence must have 8 hex codes " + str);
+                        error_msg = "unicode sequence must have 8 hex codes " + str;
+                        return false;
                     }
                     code += res * mplier;
                     mplier = mplier / 16;
                 }
-                append_codepoint(out, code);
+                if(!append_codepoint(out, code, error_msg)) {
+                    return false;
+                }
                 loc += 9;
             } else if(*(loc + 1) == '0') {
                 out.push_back('\0');
                 ++loc;
             } else {
-                throw std::invalid_argument(std::string("unrecognized escape sequence \\") + *(loc + 1) + " in " + str);
+                error_msg = std::string("unrecognized escape sequence \\") + *(loc + 1) + " in " + str;
+                return false;
             }
         } else {
             out.push_back(*loc);
         }
     }
-    return out;
+    str = std::move(out);
+    return true;
 }
 
 CLI11_INLINE std::size_t close_string_quote(const std::string &str, std::size_t start, char closure_char) {
@@ -567,7 +580,7 @@ CLI11_INLINE std::string extract_binary_string(const std::string &escaped_string
     return outstring;
 }
 
-CLI11_INLINE void remove_quotes(std::vector<std::string> &args) {
+CLI11_INLINE bool remove_quotes(std::vector<std::string> &args, std::string &error_msg) {
     for(auto &arg : args) {
         if(arg.empty()) {
             continue;
@@ -575,11 +588,14 @@ CLI11_INLINE void remove_quotes(std::vector<std::string> &args) {
         if(arg.front() == '\"' && arg.back() == '\"') {
             remove_quotes(arg);
             // only remove escaped for string arguments not literal strings
-            arg = remove_escaped_characters(arg);
+            if(!remove_escaped_characters(arg, error_msg)) {
+                return false;
+            }
         } else {
             remove_quotes(arg);
         }
     }
+    return true;
 }
 
 CLI11_INLINE void handle_secondary_array(std::string &str) {
@@ -594,8 +610,11 @@ CLI11_INLINE void handle_secondary_array(std::string &str) {
     }
 }
 
-CLI11_INLINE bool
-process_quoted_string(std::string &str, char string_char, char literal_char, bool disable_secondary_array_processing) {
+CLI11_INLINE bool process_quoted_string(std::string &str,
+                                        std::string &error_msg,
+                                        char string_char,
+                                        char literal_char,
+                                        bool disable_secondary_array_processing) {
     if(str.size() <= 1) {
         return false;
     }
@@ -608,7 +627,9 @@ process_quoted_string(std::string &str, char string_char, char literal_char, boo
     if(str.front() == string_char && str.back() == string_char) {
         detail::remove_outer(str, string_char);
         if(str.find_first_of('\\') != std::string::npos) {
-            str = detail::remove_escaped_characters(str);
+            if(!detail::remove_escaped_characters(str, error_msg)) {
+                return false;
+            }
         }
         if(!disable_secondary_array_processing)
             handle_secondary_array(str);
@@ -621,6 +642,12 @@ process_quoted_string(std::string &str, char string_char, char literal_char, boo
         return true;
     }
     return false;
+}
+
+CLI11_INLINE bool
+process_quoted_string(std::string &str, char string_char, char literal_char, bool disable_secondary_array_processing) {
+    std::string error_msg;
+    return process_quoted_string(str, error_msg, string_char, literal_char, disable_secondary_array_processing);
 }
 
 CLI11_INLINE std::string get_environment_value(const std::string &env_name) {

--- a/include/CLI/impl/Validators_inl.hpp
+++ b/include/CLI/impl/Validators_inl.hpp
@@ -16,7 +16,6 @@
 
 // [CLI11:public_includes:set]
 #include <functional>
-#include <stdexcept>
 #include <string>
 #include <system_error>
 #include <utility>
@@ -259,21 +258,18 @@ CLI11_INLINE NonexistentPathValidator::NonexistentPathValidator() : Validator("P
 
 CLI11_INLINE EscapedStringTransformer::EscapedStringTransformer() {
     func_ = [](std::string &str) {
-        try {
-            if(str.size() > 1 && (str.front() == '\"' || str.front() == '\'' || str.front() == '`') &&
-               str.front() == str.back()) {
-                process_quoted_string(str);
-            } else if(str.find_first_of('\\') != std::string::npos) {
-                if(detail::is_binary_escaped_string(str)) {
-                    str = detail::extract_binary_string(str);
-                } else {
-                    str = remove_escaped_characters(str);
-                }
+        std::string error_msg;
+        if(str.size() > 1 && (str.front() == '\"' || str.front() == '\'' || str.front() == '`') &&
+           str.front() == str.back()) {
+            process_quoted_string(str, error_msg);
+        } else if(str.find_first_of('\\') != std::string::npos) {
+            if(detail::is_binary_escaped_string(str)) {
+                str = detail::extract_binary_string(str);
+            } else {
+                remove_escaped_characters(str, error_msg);
             }
-            return std::string{};
-        } catch(const std::invalid_argument &ia) {
-            return std::string(ia.what());
         }
+        return error_msg;
     };
 }
 }  // namespace detail

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -420,21 +420,44 @@ TEST_CASE("StringTools: binaryStrings", "[helpers]") {
     CHECK(result == "\\XEM\\X7K");
 }
 
+/// run the escape processing on a copy and verify it succeeds, returning the processed string
+static std::string remove_escapes(std::string str) {
+    std::string error_msg;
+    CHECK(CLI::detail::remove_escaped_characters(str, error_msg));
+    CHECK(error_msg.empty());
+    return str;
+}
+
+/// run the escape processing on a copy and return the error message; verify it fails and leaves the
+/// string unmodified
+static std::string remove_escapes_error(std::string str) {
+    std::string error_msg;
+    CHECK_FALSE(CLI::detail::remove_escaped_characters(str, error_msg));
+    CHECK_FALSE(error_msg.empty());
+    return error_msg;
+}
+
 TEST_CASE("StringTools: escapeConversion", "[helpers]") {
-    CHECK(CLI::detail::remove_escaped_characters("test\\\"") == "test\"");
-    CHECK(CLI::detail::remove_escaped_characters("test\\\\") == "test\\");
-    CHECK(CLI::detail::remove_escaped_characters("test\\b") == "test\b");
-    CHECK(CLI::detail::remove_escaped_characters("test\\t") == "test\t");
-    CHECK(CLI::detail::remove_escaped_characters("test\\n\\r\\t\\f") == "test\n\r\t\f");
-    CHECK(CLI::detail::remove_escaped_characters("test\\r") == "test\r");
-    CHECK(CLI::detail::remove_escaped_characters("test\\f") == "test\f");
+    CHECK(remove_escapes("test\\\"") == "test\"");
+    CHECK(remove_escapes("test\\\\") == "test\\");
+    CHECK(remove_escapes("test\\b") == "test\b");
+    CHECK(remove_escapes("test\\t") == "test\t");
+    CHECK(remove_escapes("test\\n\\r\\t\\f") == "test\n\r\t\f");
+    CHECK(remove_escapes("test\\r") == "test\r");
+    CHECK(remove_escapes("test\\f") == "test\f");
     std::string zstring = "test";
     zstring.push_back('\0');
     zstring.append("test\n");
-    CHECK(CLI::detail::remove_escaped_characters("test\\0test\\n") == zstring);
+    CHECK(remove_escapes("test\\0test\\n") == zstring);
 
-    CHECK_THROWS_AS(CLI::detail::remove_escaped_characters("test\\m_bad"), std::invalid_argument);
-    CHECK_THROWS_AS(CLI::detail::remove_escaped_characters("test\\"), std::invalid_argument);
+    CHECK(remove_escapes_error("test\\m_bad") == "unrecognized escape sequence \\m in test\\m_bad");
+    CHECK(remove_escapes_error("test\\") == "invalid escape sequence test\\");
+
+    // a failure must leave the input string unmodified
+    std::string bad = "test\\m_bad";
+    std::string error_msg;
+    CHECK_FALSE(CLI::detail::remove_escaped_characters(bad, error_msg));
+    CHECK(bad == "test\\m_bad");
 }
 
 TEST_CASE("StringTools: quotedString", "[helpers]") {
@@ -507,26 +530,54 @@ TEST_CASE("StringTools: quotedString", "[helpers]") {
     // test that '`' still works regardless of the other specified characters
     CHECK(CLI::detail::process_quoted_string(q3));
     CHECK(q3 == qliteral);
+
+    // an escape processing failure returns false and fills the error message
+    std::string qbad = "\"bad\\m_escape\"";
+    std::string error_msg;
+    CHECK_FALSE(CLI::detail::process_quoted_string(qbad, error_msg));
+    CHECK(error_msg == "unrecognized escape sequence \\m in bad\\m_escape");
+
+    // the overload without an error message ignores the failure
+    qbad = "\"bad\\m_escape\"";
+    CHECK_FALSE(CLI::detail::process_quoted_string(qbad));
+}
+
+TEST_CASE("StringTools: removeQuotesVector", "[helpers]") {
+    std::vector<std::string> args{"\"quoted\\tstring\"", "'literal\\n'", "plain"};
+    std::string error_msg;
+    CHECK(CLI::detail::remove_quotes(args, error_msg));
+    CHECK(error_msg.empty());
+    CHECK(args[0] == "quoted\tstring");
+    // escape processing is not done on literal strings
+    CHECK(args[1] == "literal\\n");
+    CHECK(args[2] == "plain");
+
+    args = {"\"bad\\m_escape\""};
+    CHECK_FALSE(CLI::detail::remove_quotes(args, error_msg));
+    CHECK(error_msg == "unrecognized escape sequence \\m in bad\\m_escape");
 }
 
 TEST_CASE("StringTools: unicode_literals", "[helpers]") {
 
-    CHECK(CLI::detail::remove_escaped_characters("test\\u03C0\\u00e9") == from_u8string(u8"test\u03C0\u00E9"));
-    CHECK(CLI::detail::remove_escaped_characters("test\\u73C0\\u0057") == from_u8string(u8"test\u73C0\u0057"));
+    CHECK(remove_escapes("test\\u03C0\\u00e9") == from_u8string(u8"test\u03C0\u00E9"));
+    CHECK(remove_escapes("test\\u73C0\\u0057") == from_u8string(u8"test\u73C0\u0057"));
 
-    CHECK(CLI::detail::remove_escaped_characters("test\\U0001F600\\u00E9") == from_u8string(u8"test\U0001F600\u00E9"));
+    CHECK(remove_escapes("test\\U0001F600\\u00E9") == from_u8string(u8"test\U0001F600\u00E9"));
 
-    CHECK_THROWS_AS(CLI::detail::remove_escaped_characters("test\\U0001M600\\u00E9"), std::invalid_argument);
-    CHECK_THROWS_AS(CLI::detail::remove_escaped_characters("test\\U0001E600\\u00M9"), std::invalid_argument);
-    CHECK_THROWS_AS(CLI::detail::remove_escaped_characters("test\\U0001E600\\uD8E9"), std::invalid_argument);
+    CHECK(remove_escapes_error("test\\U0001M600\\u00E9") ==
+          "unicode sequence must have 8 hex codes test\\U0001M600\\u00E9");
+    CHECK(remove_escapes_error("test\\U0001E600\\u00M9") ==
+          "unicode sequence must have 4 hex codes test\\U0001E600\\u00M9");
+    CHECK(remove_escapes_error("test\\U0001E600\\uD8E9") == "[0xD800, 0xDFFF] are not valid code points.");
 
-    CHECK_THROWS_AS(CLI::detail::remove_escaped_characters("test\\U0001E600\\uD8"), std::invalid_argument);
-    CHECK_THROWS_AS(CLI::detail::remove_escaped_characters("test\\U0001E60"), std::invalid_argument);
-    // code points above U+10FFFF are not valid and must throw rather than silently vanish
-    CHECK_THROWS_AS(CLI::detail::remove_escaped_characters("test\\U00110000"), std::invalid_argument);
-    CHECK_THROWS_AS(CLI::detail::remove_escaped_characters("test\\UFFFFFFFF"), std::invalid_argument);
+    CHECK(remove_escapes_error("test\\U0001E600\\uD8") ==
+          "unicode sequence must have 4 hex codes test\\U0001E600\\uD8");
+    CHECK(remove_escapes_error("test\\U0001E60") == "unicode sequence must have 8 hex codes test\\U0001E60");
+    // code points above U+10FFFF are not valid and must fail rather than silently vanish
+    CHECK(remove_escapes_error("test\\U00110000") == "values above 0x10FFFF are not valid code points.");
+    CHECK(remove_escapes_error("test\\UFFFFFFFF") == "values above 0x10FFFF are not valid code points.");
     // the largest valid code point still works
-    CHECK(CLI::detail::remove_escaped_characters("test\\U0010FFFF") == from_u8string(u8"test\U0010FFFF"));
+    CHECK(remove_escapes("test\\U0010FFFF") == from_u8string(u8"test\U0010FFFF"));
 }
 
 TEST_CASE("StringTools: handleSecondaryArray", "[helpers]") {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1443.

Converts the throwing leaf utilities in `detail::` to status-returning functions with an `error_msg` out-parameter, and replaces the try/catch translation blocks at their call sites with direct branches:

- `append_codepoint`, `remove_escaped_characters`, `remove_quotes(vector)`, and `process_quoted_string` return a success flag; a convenience `process_quoted_string` overload without `error_msg` remains for callers that ignore escape errors.
- `narrow_impl`/`widen_impl` gain status-returning overloads; the public `narrow`/`widen` wrappers keep their throwing contract.
- `compute_win32_argv` reports failure through the out-parameter; the throw moves to `App::ensure_utf8`.

Error messages that reach users are byte-identical. New unit tests cover the success and failure paths of the status-returning functions, including the exact error messages. The Windows-only `Argv` change is compile-checked only by CI.