### PR TITLE
refactor: add non-throwing name parsing and flag-value paths

### DIFF
--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -684,6 +684,11 @@ class Option : public OptionBase<Option> {
     /// disabled
     CLI11_NODISCARD std::string get_flag_value(const std::string &name, std::string input_value) const;
 
+    /// Non-throwing form of get_flag_value: sets output and returns true on success, returns false where
+    /// get_flag_value would throw an ArgumentMismatch
+    CLI11_NODISCARD bool
+    try_get_flag_value(const std::string &name, std::string input_value, std::string &output) const;
+
     /// Puts a result at the end
     Option *add_result(std::string s);
 
@@ -791,32 +796,32 @@ class Option : public OptionBase<Option> {
     /// bound value only available for types that can be converted to a string
     template <typename X> Option *default_val(const X &val) {
         std::string val_str = detail::value_string(val);
-        auto old_option_state = current_option_state_;
-        results_t old_results{std::move(results_)};
-        results_.clear();
+        // validate on scratch results first; members are only modified on success, so a failure needs no rollback
+        results_t scratch_results;
+        _add_result(std::string(val_str), scratch_results);
         try {
-            add_result(val_str);
             // if trigger_on_result_ is set the callback already ran
             if(run_callback_for_default_ && !trigger_on_result_) {
-                run_callback();  // run callback sets the state, we need to reset it again
+                if(force_callback_ && scratch_results.empty()) {
+                    _add_result(std::string(default_str_), scratch_results);
+                }
+                _validate_results(scratch_results);
+                results_t reduced_results;
+                _reduce_results(reduced_results, scratch_results);
+                if(callback_) {
+                    const results_t &send_results = reduced_results.empty() ? scratch_results : reduced_results;
+                    if(!send_results.empty() && !callback_(send_results)) {
+                        throw ConversionError(get_name(), scratch_results);
+                    }
+                }
                 current_option_state_ = option_state::parsing;
             } else {
-                _validate_results(results_);
-                current_option_state_ = old_option_state;
+                _validate_results(scratch_results);
             }
         } catch(const ConversionError &err) {
-            // this should be done
-            results_ = std::move(old_results);
-            current_option_state_ = old_option_state;
-
             throw ConversionError(
                 get_name(), std::string("given default value(\"") + val_str + "\") produces an error : " + err.what());
-        } catch(const CLI::Error &) {
-            results_ = std::move(old_results);
-            current_option_state_ = old_option_state;
-            throw;
         }
-        results_ = std::move(old_results);
         default_str_ = std::move(val_str);
         return this;
     }

--- a/include/CLI/Option.hpp
+++ b/include/CLI/Option.hpp
@@ -806,10 +806,10 @@ class Option : public OptionBase<Option> {
                     _add_result(std::string(default_str_), scratch_results);
                 }
                 _validate_results(scratch_results);
-                results_t reduced_results;
-                _reduce_results(reduced_results, scratch_results);
+                results_t scratch_reduced;
+                _reduce_results(scratch_reduced, scratch_results);
                 if(callback_) {
-                    const results_t &send_results = reduced_results.empty() ? scratch_results : reduced_results;
+                    const results_t &send_results = scratch_reduced.empty() ? scratch_results : scratch_reduced;
                     if(!send_results.empty() && !callback_(send_results)) {
                         throw ConversionError(get_name(), scratch_results);
                     }

--- a/include/CLI/Split.hpp
+++ b/include/CLI/Split.hpp
@@ -38,9 +38,22 @@ CLI11_INLINE std::vector<std::string> split_names(std::string current);
 /// extract default flag values either {def} or starting with a !
 CLI11_INLINE std::vector<std::pair<std::string, std::string>> get_default_flag_values(const std::string &str);
 
-/// Get a vector of short names, one of long names, and a single name
+/// The failure conditions from get_names, matching the BadNameString variants
+enum class name_error : char {
+    success = 0,
+    one_char,            ///< BadNameString::OneCharName
+    missing_dash,        ///< BadNameString::MissingDash
+    bad_long_name,       ///< BadNameString::BadLongName
+    bad_positional,      ///< BadNameString::BadPositionalName
+    reserved,            ///< BadNameString::ReservedName
+    multiple_positional  ///< BadNameString::MultiPositionalNames
+};
+
+/// Get a vector of short names, one of long names, and a single name.
+/// Does not throw: on a bad name it stops and reports the failure through err and err_name,
+/// which identify the BadNameString variant and its argument.
 CLI11_INLINE std::tuple<std::vector<std::string>, std::vector<std::string>, std::string>
-get_names(const std::vector<std::string> &input, bool allow_non_standard = false);
+get_names(const std::vector<std::string> &input, bool allow_non_standard, name_error &err, std::string &err_name);
 
 }  // namespace detail
 // [CLI11:split_hpp:end]

--- a/include/CLI/impl/Config_inl.hpp
+++ b/include/CLI/impl/Config_inl.hpp
@@ -697,17 +697,16 @@ ConfigBase::to_config(const App *app, ConfigOutputMode mode, bool write_descript
 
                 if(!value.empty()) {
                     if(!opt->get_fnames().empty()) {
-                        try {
-                            value = opt->get_flag_value(single_name, value);
-                        } catch(const CLI::ArgumentMismatch &) {
+                        std::string flag_value;
+                        if(opt->try_get_flag_value(single_name, value, flag_value)) {
+                            value = std::move(flag_value);
+                        } else {
                             bool valid{false};
                             for(const auto &test_name : opt->get_fnames()) {
-                                try {
-                                    value = opt->get_flag_value(test_name, value);
+                                if(opt->try_get_flag_value(test_name, value, flag_value)) {
+                                    value = std::move(flag_value);
                                     single_name = test_name;
                                     valid = true;
-                                } catch(const CLI::ArgumentMismatch &) {
-                                    continue;
                                 }
                             }
                             if(!valid) {

--- a/include/CLI/impl/Option_inl.hpp
+++ b/include/CLI/impl/Option_inl.hpp
@@ -44,7 +44,26 @@ template <typename CRTP> template <typename T> void OptionBase<CRTP>::copy_to(T 
 CLI11_INLINE Option::Option(
     std::string option_name, std::string option_description, callback_t callback, App *parent, bool allow_non_standard)
     : description_(std::move(option_description)), parent_(parent), callback_(std::move(callback)) {
-    std::tie(snames_, lnames_, pname_) = detail::get_names(detail::split_names(option_name), allow_non_standard);
+    detail::name_error name_err = detail::name_error::success;
+    std::string bad_name;
+    std::tie(snames_, lnames_, pname_) =
+        detail::get_names(detail::split_names(option_name), allow_non_standard, name_err, bad_name);
+    switch(name_err) {
+    case detail::name_error::success:
+        break;
+    case detail::name_error::one_char:
+        throw BadNameString::OneCharName(bad_name);
+    case detail::name_error::missing_dash:
+        throw BadNameString::MissingDash(bad_name);
+    case detail::name_error::bad_long_name:
+        throw BadNameString::BadLongName(bad_name);
+    case detail::name_error::bad_positional:
+        throw BadNameString::BadPositionalName(bad_name);
+    case detail::name_error::reserved:
+        throw BadNameString::ReservedName(bad_name);
+    case detail::name_error::multiple_positional:
+        throw BadNameString::MultiPositionalNames(bad_name);
+    }
 }
 
 CLI11_INLINE void Option::clear() {
@@ -446,6 +465,15 @@ CLI11_NODISCARD CLI11_INLINE bool Option::check_name(const std::string &name) co
 
 CLI11_NODISCARD CLI11_INLINE std::string Option::get_flag_value(const std::string &name,
                                                                 std::string input_value) const {
+    std::string output;
+    if(!try_get_flag_value(name, std::move(input_value), output)) {
+        throw(ArgumentMismatch::FlagOverride(name));
+    }
+    return output;
+}
+
+CLI11_NODISCARD CLI11_INLINE bool
+Option::try_get_flag_value(const std::string &name, std::string input_value, std::string &output) const {
     static const std::string trueString{"true"};
     static const std::string falseString{"false"};
     static const std::string emptyString{"{}"};
@@ -457,13 +485,14 @@ CLI11_NODISCARD CLI11_INLINE std::string Option::get_flag_value(const std::strin
                 // We can static cast this to std::size_t because it is more than 0 in this block
                 if(default_flag_values_[static_cast<std::size_t>(default_ind)].second != input_value) {
                     if(input_value == default_str_ && force_callback_) {
-                        return input_value;
+                        output = std::move(input_value);
+                        return true;
                     }
-                    throw(ArgumentMismatch::FlagOverride(name));
+                    return false;
                 }
             } else {
                 if(input_value != trueString) {
-                    throw(ArgumentMismatch::FlagOverride(name));
+                    return false;
                 }
             }
         }
@@ -471,23 +500,29 @@ CLI11_NODISCARD CLI11_INLINE std::string Option::get_flag_value(const std::strin
     auto ind = detail::find_member(name, fnames_, ignore_case_, ignore_underscore_);
     if((input_value.empty()) || (input_value == emptyString)) {
         if(flag_like_) {
-            return (ind < 0) ? trueString : default_flag_values_[static_cast<std::size_t>(ind)].second;
+            output = (ind < 0) ? trueString : default_flag_values_[static_cast<std::size_t>(ind)].second;
+        } else {
+            output = (ind < 0) ? default_str_ : default_flag_values_[static_cast<std::size_t>(ind)].second;
         }
-        return (ind < 0) ? default_str_ : default_flag_values_[static_cast<std::size_t>(ind)].second;
+        return true;
     }
     if(ind < 0) {
-        return input_value;
+        output = std::move(input_value);
+        return true;
     }
     if(default_flag_values_[static_cast<std::size_t>(ind)].second == falseString) {
         errno = 0;
         auto val = detail::to_flag_value(input_value);
         if(errno != 0) {
             errno = 0;
-            return input_value;
+            output = std::move(input_value);
+            return true;
         }
-        return (val == 1) ? falseString : (val == (-1) ? trueString : std::to_string(-val));
+        output = (val == 1) ? falseString : (val == (-1) ? trueString : std::to_string(-val));
+        return true;
     }
-    return input_value;
+    output = std::move(input_value);
+    return true;
 }
 
 CLI11_INLINE Option *Option::add_result(std::string s) {

--- a/include/CLI/impl/Split_inl.hpp
+++ b/include/CLI/impl/Split_inl.hpp
@@ -21,7 +21,6 @@
 #include <vector>
 // [CLI11:public_includes:end]
 
-#include "../Error.hpp"
 #include "../StringTools.hpp"
 
 namespace CLI {
@@ -106,11 +105,13 @@ CLI11_INLINE std::vector<std::pair<std::string, std::string>> get_default_flag_v
 }
 
 CLI11_INLINE std::tuple<std::vector<std::string>, std::vector<std::string>, std::string>
-get_names(const std::vector<std::string> &input, bool allow_non_standard) {
+get_names(const std::vector<std::string> &input, bool allow_non_standard, name_error &err, std::string &err_name) {
 
     std::vector<std::string> short_names;
     std::vector<std::string> long_names;
     std::string pos_name;
+    err = name_error::success;
+    err_name.clear();
     for(std::string name : input) {
         if(name.empty()) {
             continue;
@@ -124,32 +125,35 @@ get_names(const std::vector<std::string> &input, bool allow_non_standard) {
                     if(valid_name_string(name)) {
                         short_names.push_back(name);
                     } else {
-                        throw BadNameString::BadLongName(name);
+                        err = name_error::bad_long_name;
                     }
                 } else {
-                    throw BadNameString::MissingDash(name);
+                    err = name_error::missing_dash;
                 }
             } else {
-                throw BadNameString::OneCharName(name);
+                err = name_error::one_char;
             }
         } else if(name.length() > 2 && name.substr(0, 2) == "--") {
             name = name.substr(2);
             if(valid_name_string(name)) {
                 long_names.push_back(name);
             } else {
-                throw BadNameString::BadLongName(name);
+                err = name_error::bad_long_name;
             }
         } else if(name == "-" || name == "--" || name == "++") {
-            throw BadNameString::ReservedName(name);
+            err = name_error::reserved;
         } else {
             if(!pos_name.empty()) {
-                throw BadNameString::MultiPositionalNames(name);
-            }
-            if(valid_name_string(name)) {
+                err = name_error::multiple_positional;
+            } else if(valid_name_string(name)) {
                 pos_name = name;
             } else {
-                throw BadNameString::BadPositionalName(name);
+                err = name_error::bad_positional;
             }
+        }
+        if(err != name_error::success) {
+            err_name = name;
+            break;
         }
     }
     return std::make_tuple(short_names, long_names, pos_name);

--- a/tests/CreationTest.cpp
+++ b/tests/CreationTest.cpp
@@ -874,3 +874,20 @@ TEST_CASE_METHOD(TApp, "MakeUnstreamableOptions", "[creation]") {
     CHECK(3u == values.size());
     CHECK(34 == values[2].get_x());
 }
+
+TEST_CASE_METHOD(TApp, "TryGetFlagValue", "[creation]") {
+    auto *flg = app.add_flag("--flag,!--no-flag");
+    std::string output;
+
+    CHECK(flg->try_get_flag_value("flag", "{}", output));
+    CHECK(output == "true");
+    CHECK(flg->try_get_flag_value("no-flag", "{}", output));
+    CHECK(output == "false");
+
+    flg->disable_flag_override();
+    CHECK(flg->try_get_flag_value("flag", "true", output));
+    CHECK(output == "true");
+    // an override on a flag with overrides disabled is the failure case
+    CHECK_FALSE(flg->try_get_flag_value("flag", "false", output));
+    CHECK_THROWS_AS(static_cast<void>(flg->get_flag_value("flag", "false")), CLI::ArgumentMismatch);
+}

--- a/tests/HelpersTest.cpp
+++ b/tests/HelpersTest.cpp
@@ -1163,23 +1163,47 @@ TEST_CASE("RegEx: SplittingNew", "[helpers]") {
     std::vector<std::string> shorts;
     std::vector<std::string> longs;
     std::string pname;
+    CLI::detail::name_error err = CLI::detail::name_error::success;
+    std::string err_name;
 
-    CHECK_NOTHROW(std::tie(shorts, longs, pname) = CLI::detail::get_names({"--long", "-s", "-q", "--also-long"}));
+    std::tie(shorts, longs, pname) =
+        CLI::detail::get_names({"--long", "-s", "-q", "--also-long"}, false, err, err_name);
+    CHECK(err == CLI::detail::name_error::success);
+    CHECK(err_name.empty());
     CHECK(longs == std::vector<std::string>({"long", "also-long"}));
     CHECK(shorts == std::vector<std::string>({"s", "q"}));
     CHECK(pname.empty());
 
-    std::tie(shorts, longs, pname) = CLI::detail::get_names({"--long", "", "-s", "-q", "", "--also-long"});
+    std::tie(shorts, longs, pname) =
+        CLI::detail::get_names({"--long", "", "-s", "-q", "", "--also-long"}, false, err, err_name);
+    CHECK(err == CLI::detail::name_error::success);
     CHECK(longs == std::vector<std::string>({"long", "also-long"}));
     CHECK(shorts == std::vector<std::string>({"s", "q"}));
 
-    CHECK_THROWS_AS([&]() { std::tie(shorts, longs, pname) = CLI::detail::get_names({"-"}); }(), CLI::BadNameString);
-    CHECK_THROWS_AS([&]() { std::tie(shorts, longs, pname) = CLI::detail::get_names({"--"}); }(), CLI::BadNameString);
-    CHECK_THROWS_AS([&]() { std::tie(shorts, longs, pname) = CLI::detail::get_names({"-hi"}); }(), CLI::BadNameString);
-    CHECK_THROWS_AS([&]() { std::tie(shorts, longs, pname) = CLI::detail::get_names({"---hi"}); }(),
-                    CLI::BadNameString);
-    CHECK_THROWS_AS([&]() { std::tie(shorts, longs, pname) = CLI::detail::get_names({"one", "two"}); }(),
-                    CLI::BadNameString);
+    std::tie(shorts, longs, pname) = CLI::detail::get_names({"-"}, false, err, err_name);
+    CHECK(err == CLI::detail::name_error::reserved);
+    CHECK(err_name == "-");
+    std::tie(shorts, longs, pname) = CLI::detail::get_names({"--"}, false, err, err_name);
+    CHECK(err == CLI::detail::name_error::reserved);
+    CHECK(err_name == "--");
+    std::tie(shorts, longs, pname) = CLI::detail::get_names({"-hi"}, false, err, err_name);
+    CHECK(err == CLI::detail::name_error::missing_dash);
+    CHECK(err_name == "-hi");
+    std::tie(shorts, longs, pname) = CLI::detail::get_names({"-hi"}, true, err, err_name);
+    CHECK(err == CLI::detail::name_error::success);
+    CHECK(shorts == std::vector<std::string>({"hi"}));
+    std::tie(shorts, longs, pname) = CLI::detail::get_names({"---hi"}, false, err, err_name);
+    CHECK(err == CLI::detail::name_error::bad_long_name);
+    CHECK(err_name == "-hi");
+    std::tie(shorts, longs, pname) = CLI::detail::get_names({"one", "two"}, false, err, err_name);
+    CHECK(err == CLI::detail::name_error::multiple_positional);
+    CHECK(err_name == "two");
+    std::tie(shorts, longs, pname) = CLI::detail::get_names({"-!"}, false, err, err_name);
+    CHECK(err == CLI::detail::name_error::one_char);
+    CHECK(err_name == "-!");
+    std::tie(shorts, longs, pname) = CLI::detail::get_names({"one two"}, false, err, err_name);
+    CHECK(err == CLI::detail::name_error::bad_positional);
+    CHECK(err_name == "one two");
 }
 
 TEST_CASE("String: ToLower", "[helpers]") { CHECK("one and two" == CLI::detail::to_lower("one And TWO")); }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1443. This removes internal try/catch control flow in three places, in preparation for `-fno-exceptions` support. Thrown types and messages are unchanged.

- `detail::get_names` no longer throws: it reports the applicable `BadNameString` variant through a `name_error` out-parameter, and the `Option` constructor throws the same error. `Split_inl.hpp` no longer needs `Error.hpp`.
- New `Option::try_get_flag_value`, a non-throwing form of `get_flag_value` (which is now a thin throwing wrapper around it). Config output uses it instead of the catch-`ArgumentMismatch` trial-and-error loop.
- `Option::default_val` validates on scratch results and only commits members on success, so it no longer needs catch-based rollback; only the `ConversionError` re-wrap catch remains.

Unit tests cover the new non-throwing paths (success and failure). Verified locally with both the `dev` (precompiled) and `default` (header-only) workflows.
